### PR TITLE
feat: implement DC sweep analysis (.dc command)

### DIFF
--- a/docs/superpowers/plans/2026-04-10-dc-sweep.md
+++ b/docs/superpowers/plans/2026-04-10-dc-sweep.md
@@ -1,0 +1,561 @@
+# DC Sweep Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `.dc` sweep analysis that sweeps a voltage or current source over a range and records node voltages and branch currents at each operating point.
+
+**Architecture:** A new `solveDCSweep()` function in `analysis/dc-sweep.ts` loops over sweep values, mutates the source waveform, calls Newton-Raphson with warm-starting via a persistent `MNAAssembler`, and collects results into a `DCSweepResult` class. The dispatcher in `simulate.ts` wires it up.
+
+**Tech Stack:** TypeScript, vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-10-dc-sweep-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `packages/core/src/analysis/dc-sweep.ts` | Sweep loop + source lookup |
+| Create | `packages/core/src/analysis/dc-sweep.test.ts` | All DC sweep tests |
+| Modify | `packages/core/src/results.ts:70-74` | Replace `DCSweepResult` interface with class |
+| Modify | `packages/core/src/index.ts:6` | Export `DCSweepResult` as value (class), not just type |
+| Modify | `packages/core/src/simulate.ts:37-40` | Wire up `'dc'` case to `solveDCSweep()` |
+| Modify | `packages/core/src/devices/current-source.ts:11` | Change `readonly waveform` to `public waveform` |
+
+---
+
+### Task 1: Convert `DCSweepResult` from interface to class
+
+**Files:**
+- Modify: `packages/core/src/results.ts:70-74`
+- Modify: `packages/core/src/index.ts:6`
+- Modify: `packages/core/src/analysis/dc.ts:6` (remove unused import)
+
+- [ ] **Step 1: Replace the `DCSweepResult` interface with a class in `results.ts`**
+
+In `packages/core/src/results.ts`, replace lines 70-74:
+
+```typescript
+export interface DCSweepResult {
+  sweepValues: number[];
+  voltages: Map<string, number[]>;
+  currents: Map<string, number[]>;
+}
+```
+
+With:
+
+```typescript
+export class DCSweepResult {
+  constructor(
+    public readonly sweepValues: Float64Array,
+    private readonly voltageArrays: Map<string, Float64Array>,
+    private readonly currentArrays: Map<string, Float64Array>,
+  ) {}
+
+  voltage(node: string): Float64Array {
+    const v = this.voltageArrays.get(node);
+    if (v === undefined) throw new Error(`Unknown node: ${node}`);
+    return v;
+  }
+
+  current(source: string): Float64Array {
+    const i = this.currentArrays.get(source);
+    if (i === undefined) throw new Error(`Unknown branch: ${source}`);
+    return i;
+  }
+}
+```
+
+- [ ] **Step 2: Update `index.ts` to export `DCSweepResult` as a value export**
+
+In `packages/core/src/index.ts`, change line 5 from:
+
+```typescript
+export { DCResult, TransientResult, ACResult } from './results.js';
+```
+
+To:
+
+```typescript
+export { DCResult, TransientResult, ACResult, DCSweepResult } from './results.js';
+```
+
+And change line 6 from:
+
+```typescript
+export type { SimulationResult, DCSweepResult } from './results.js';
+```
+
+To:
+
+```typescript
+export type { SimulationResult } from './results.js';
+```
+
+- [ ] **Step 3: Remove unused `DCSweepResult` type import from `dc.ts`**
+
+In `packages/core/src/analysis/dc.ts`, change line 6 from:
+
+```typescript
+import type { DCSweepResult } from '../results.js';
+```
+
+To remove it entirely (delete the line). It is unused.
+
+- [ ] **Step 4: Verify the project compiles**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm tsc --noEmit -p packages/core/tsconfig.json`
+Expected: no errors
+
+- [ ] **Step 5: Run existing tests to confirm no regressions**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm test --run`
+Expected: all existing tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/results.ts packages/core/src/index.ts packages/core/src/analysis/dc.ts
+git commit -m "refactor: convert DCSweepResult from interface to class with accessor methods"
+```
+
+---
+
+### Task 2: Make `CurrentSource.waveform` mutable
+
+**Files:**
+- Modify: `packages/core/src/devices/current-source.ts:11`
+
+- [ ] **Step 1: Change `readonly waveform` to `public waveform`**
+
+In `packages/core/src/devices/current-source.ts`, change line 11 from:
+
+```typescript
+    readonly waveform: SourceWaveform,
+```
+
+To:
+
+```typescript
+    public waveform: SourceWaveform,
+```
+
+This makes the waveform mutable, matching `VoltageSource` (which already has `public waveform` at line 12 of `voltage-source.ts`).
+
+- [ ] **Step 2: Verify the project compiles**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm tsc --noEmit -p packages/core/tsconfig.json`
+Expected: no errors
+
+- [ ] **Step 3: Run existing tests to confirm no regressions**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm test --run`
+Expected: all existing tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/devices/current-source.ts
+git commit -m "refactor: make CurrentSource.waveform mutable for DC sweep support"
+```
+
+---
+
+### Task 3: Implement `solveDCSweep()` with voltage divider test (TDD)
+
+**Files:**
+- Create: `packages/core/src/analysis/dc-sweep.test.ts`
+- Create: `packages/core/src/analysis/dc-sweep.ts`
+
+- [ ] **Step 1: Write the voltage divider sweep test**
+
+Create `packages/core/src/analysis/dc-sweep.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { Circuit } from '../circuit.js';
+import { solveDCSweep } from './dc-sweep.js';
+import { resolveOptions } from '../types.js';
+import type { DCSweepAnalysis } from '../types.js';
+
+describe('DC Sweep', () => {
+  it('sweeps a voltage divider', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 0 });
+    ckt.addResistor('R1', '1', '2', 1000);
+    ckt.addResistor('R2', '2', '0', 2000);
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'V1', start: 0, stop: 5, step: 1,
+    };
+
+    const result = solveDCSweep(compiled, analysis, options);
+
+    // 6 points: 0, 1, 2, 3, 4, 5
+    expect(result.sweepValues.length).toBe(6);
+    expect(result.sweepValues[0]).toBeCloseTo(0, 10);
+    expect(result.sweepValues[5]).toBeCloseTo(5, 10);
+
+    const v2 = result.voltage('2');
+    expect(v2.length).toBe(6);
+    for (let i = 0; i < 6; i++) {
+      const vsrc = i * 1; // start + i * step
+      const expected = vsrc * 2000 / (1000 + 2000);
+      expect(v2[i]).toBeCloseTo(expected, 6);
+    }
+
+    // Current through V1: I = -V1 / (R1 + R2)
+    const iV1 = result.current('V1');
+    expect(iV1.length).toBe(6);
+    for (let i = 0; i < 6; i++) {
+      const vsrc = i * 1;
+      expect(iV1[i]).toBeCloseTo(-vsrc / 3000, 9);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm vitest run packages/core/src/analysis/dc-sweep.test.ts`
+Expected: FAIL — module `./dc-sweep.js` not found
+
+- [ ] **Step 3: Implement `solveDCSweep()`**
+
+Create `packages/core/src/analysis/dc-sweep.ts`:
+
+```typescript
+import type { ResolvedOptions, DCSweepAnalysis, SourceWaveform } from '../types.js';
+import type { CompiledCircuit } from '../circuit.js';
+import { MNAAssembler } from '../mna/assembler.js';
+import { newtonRaphson } from './newton-raphson.js';
+import { DCSweepResult } from '../results.js';
+import { VoltageSource } from '../devices/voltage-source.js';
+import { CurrentSource } from '../devices/current-source.js';
+import { InvalidCircuitError } from '../errors.js';
+
+export function solveDCSweep(
+  compiled: CompiledCircuit,
+  analysis: DCSweepAnalysis,
+  options: ResolvedOptions,
+): DCSweepResult {
+  const { devices, nodeCount, branchCount, nodeNames, branchNames } = compiled;
+
+  // Find the sweep source
+  const source = devices.find(
+    (d): d is VoltageSource | CurrentSource =>
+      (d instanceof VoltageSource || d instanceof CurrentSource) && d.name === analysis.source,
+  );
+  if (!source) {
+    throw new InvalidCircuitError(`DC sweep source '${analysis.source}' not found`);
+  }
+
+  const originalWaveform = source.waveform;
+  const numPoints = Math.round((analysis.stop - analysis.start) / analysis.step) + 1;
+
+  // Pre-allocate result arrays
+  const sweepValues = new Float64Array(numPoints);
+  const voltageArrays = new Map<string, Float64Array>();
+  const currentArrays = new Map<string, Float64Array>();
+  for (const name of nodeNames) voltageArrays.set(name, new Float64Array(numPoints));
+  for (const name of branchNames) currentArrays.set(name, new Float64Array(numPoints));
+
+  const assembler = new MNAAssembler(nodeCount, branchCount);
+
+  try {
+    for (let i = 0; i < numPoints; i++) {
+      const sweepValue = analysis.start + i * analysis.step;
+      sweepValues[i] = sweepValue;
+
+      source.waveform = { type: 'dc', value: sweepValue };
+
+      newtonRaphson(assembler, devices, options, options.maxIterations, nodeNames);
+
+      // Record solution
+      for (let n = 0; n < nodeNames.length; n++) {
+        voltageArrays.get(nodeNames[n])![i] = assembler.solution[n];
+      }
+      for (let b = 0; b < branchNames.length; b++) {
+        currentArrays.get(branchNames[b])![i] = assembler.solution[nodeCount + b];
+      }
+    }
+  } finally {
+    source.waveform = originalWaveform;
+  }
+
+  return new DCSweepResult(sweepValues, voltageArrays, currentArrays);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm vitest run packages/core/src/analysis/dc-sweep.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/analysis/dc-sweep.ts packages/core/src/analysis/dc-sweep.test.ts
+git commit -m "feat: implement DC sweep analysis with voltage divider test"
+```
+
+---
+
+### Task 4: Add diode I-V curve test
+
+**Files:**
+- Modify: `packages/core/src/analysis/dc-sweep.test.ts`
+
+- [ ] **Step 1: Add the diode I-V sweep test**
+
+Append to the `describe('DC Sweep', ...)` block in `packages/core/src/analysis/dc-sweep.test.ts`:
+
+```typescript
+  it('sweeps diode I-V curve', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 0 });
+    ckt.addResistor('R1', '1', '2', 1000);
+    ckt.addDiode('D1', '2', '0');
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'V1', start: -1, stop: 1, step: 0.1,
+    };
+
+    const result = solveDCSweep(compiled, analysis, options);
+
+    // 21 points: -1.0, -0.9, ..., 0.9, 1.0
+    expect(result.sweepValues.length).toBe(21);
+
+    // At V1 = -1V, diode is reverse biased: current magnitude near zero
+    const iV1 = result.current('V1');
+    expect(Math.abs(iV1[0])).toBeLessThan(1e-6);
+
+    // At V1 = 1V, diode is forward biased: significant current flows
+    expect(Math.abs(iV1[20])).toBeGreaterThan(1e-4);
+
+    // Current should monotonically increase across sweep
+    for (let i = 1; i < 21; i++) {
+      expect(-iV1[i]).toBeGreaterThanOrEqual(-iV1[i - 1] - 1e-12);
+    }
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm vitest run packages/core/src/analysis/dc-sweep.test.ts`
+Expected: PASS (all tests including the new one)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/analysis/dc-sweep.test.ts
+git commit -m "test: add diode I-V curve DC sweep test"
+```
+
+---
+
+### Task 5: Add current source sweep test
+
+**Files:**
+- Modify: `packages/core/src/analysis/dc-sweep.test.ts`
+
+- [ ] **Step 1: Add the current source sweep test**
+
+Append to the `describe('DC Sweep', ...)` block in `packages/core/src/analysis/dc-sweep.test.ts`:
+
+```typescript
+  it('sweeps a current source', () => {
+    const ckt = new Circuit();
+    ckt.addCurrentSource('I1', '1', '0', { dc: 0 });
+    ckt.addResistor('R1', '1', '0', 1000);
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'I1', start: 0, stop: 0.001, step: 0.0001,
+    };
+
+    const result = solveDCSweep(compiled, analysis, options);
+
+    // 11 points: 0, 0.1m, 0.2m, ..., 1.0m
+    expect(result.sweepValues.length).toBe(11);
+
+    const v1 = result.voltage('1');
+    expect(v1.length).toBe(11);
+    for (let i = 0; i < 11; i++) {
+      const current = analysis.start + i * analysis.step;
+      // V = I * R (current injected into node 1, flows through R1 to ground)
+      expect(v1[i]).toBeCloseTo(current * 1000, 6);
+    }
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm vitest run packages/core/src/analysis/dc-sweep.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/analysis/dc-sweep.test.ts
+git commit -m "test: add current source DC sweep test"
+```
+
+---
+
+### Task 6: Add unknown source error test
+
+**Files:**
+- Modify: `packages/core/src/analysis/dc-sweep.test.ts`
+
+- [ ] **Step 1: Add the error test**
+
+Append to the `describe('DC Sweep', ...)` block in `packages/core/src/analysis/dc-sweep.test.ts`:
+
+```typescript
+  it('throws on unknown sweep source', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 5 });
+    ckt.addResistor('R1', '1', '0', 1000);
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'V99', start: 0, stop: 5, step: 1,
+    };
+
+    expect(() => solveDCSweep(compiled, analysis, options)).toThrow(
+      "DC sweep source 'V99' not found",
+    );
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm vitest run packages/core/src/analysis/dc-sweep.test.ts`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/analysis/dc-sweep.test.ts
+git commit -m "test: add unknown source error test for DC sweep"
+```
+
+---
+
+### Task 7: Wire up `simulate.ts` dispatcher
+
+**Files:**
+- Modify: `packages/core/src/simulate.ts:1-11,37-40`
+
+- [ ] **Step 1: Add import for `solveDCSweep`**
+
+In `packages/core/src/simulate.ts`, after line 9 (`import { solveAC } from './analysis/ac.js';`), add:
+
+```typescript
+import { solveDCSweep } from './analysis/dc-sweep.js';
+```
+
+- [ ] **Step 2: Replace the `'dc'` case stub**
+
+In `packages/core/src/simulate.ts`, replace lines 37-39:
+
+```typescript
+      case 'dc': {
+        // DC sweep — will be implemented later
+        break;
+      }
+```
+
+With:
+
+```typescript
+      case 'dc': {
+        const opts = resolveOptions(options);
+        result.dcSweep = solveDCSweep(compiled, analysis, opts);
+        break;
+      }
+```
+
+- [ ] **Step 3: Verify the project compiles**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm tsc --noEmit -p packages/core/tsconfig.json`
+Expected: no errors
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm test --run`
+Expected: all tests pass (existing + new DC sweep tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/simulate.ts
+git commit -m "feat: wire up DC sweep analysis in simulate() dispatcher"
+```
+
+---
+
+### Task 8: Add end-to-end test via `simulate()`
+
+**Files:**
+- Modify: `packages/core/src/analysis/dc-sweep.test.ts`
+
+- [ ] **Step 1: Add an end-to-end test using `simulate()`**
+
+Add this import at the top of `packages/core/src/analysis/dc-sweep.test.ts`:
+
+```typescript
+import { simulate } from '../simulate.js';
+```
+
+Then append a new `describe` block after the existing one:
+
+```typescript
+describe('DC Sweep via simulate()', () => {
+  it('runs DC sweep from netlist string', async () => {
+    const result = await simulate(`
+      V1 1 0 DC 0
+      R1 1 2 1k
+      R2 2 0 2k
+      .dc V1 0 5 1
+      .end
+    `);
+
+    expect(result.dcSweep).toBeDefined();
+    const sweep = result.dcSweep!;
+    expect(sweep.sweepValues.length).toBe(6);
+
+    const v2 = sweep.voltage('2');
+    for (let i = 0; i < 6; i++) {
+      const vsrc = i;
+      expect(v2[i]).toBeCloseTo(vsrc * 2000 / 3000, 6);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm vitest run packages/core/src/analysis/dc-sweep.test.ts`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 3: Run the full test suite one final time**
+
+Run: `cd /home/mattia/repos/spice-ts && pnpm test --run`
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/analysis/dc-sweep.test.ts
+git commit -m "test: add end-to-end DC sweep test via simulate()"
+```

--- a/docs/superpowers/specs/2026-04-10-dc-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-10-dc-sweep-design.md
@@ -1,0 +1,110 @@
+# DC Sweep Analysis (.dc command)
+
+**Issue:** mfiumara/spice-ts#9
+**Date:** 2026-04-10
+
+## Summary
+
+Implement `.dc` sweep analysis to compute DC transfer characteristics by sweeping a voltage or current source over a range and recording node voltages and branch currents at each operating point.
+
+## SPICE Syntax
+
+```
+.dc Vsrc start stop step
+.dc Isrc start stop step
+```
+
+## What Already Exists
+
+- **Parser** (`src/parser/index.ts:37-43`): Extracts `source`, `start`, `stop`, `step` into a `DCSweepAnalysis` command.
+- **Type** (`src/types.ts:15-22`): `DCSweepAnalysis` interface with `type: 'dc'`, `source`, `start`, `stop`, `step`.
+- **Result field** (`src/results.ts`): `SimulationResult.dcSweep` field exists, typed as `DCSweepResult`.
+- **Simulator stub** (`src/simulate.ts:37-40`): The `'dc'` case in the analysis switch is a no-op placeholder.
+- **DC solver** (`src/analysis/dc.ts`): `solveDCOperatingPoint()` solves a single DC operating point using Newton-Raphson.
+
+## Architecture
+
+### New file: `packages/core/src/analysis/dc-sweep.ts`
+
+A `solveDCSweep()` function that:
+
+1. Receives `CompiledCircuit`, `DCSweepAnalysis`, and `ResolvedOptions`.
+2. Finds the sweep source by name in `compiled.devices` (supports both `VoltageSource` and `CurrentSource`).
+3. Saves the original waveform, replaces it with a DC waveform at each sweep point.
+4. Creates one `MNAAssembler` that persists across the loop. The `solution` vector carries forward as a warm-start initial guess for Newton-Raphson at each point.
+5. Collects results into a `DCSweepResult` instance.
+6. Restores the original waveform in a `finally` block.
+
+### Dispatch: `simulate.ts`
+
+The `'dc'` case calls `solveDCSweep()` and assigns the return value to `result.dcSweep`.
+
+### No other files changed
+
+The `index.ts` barrel already re-exports from `results.ts`. The `SimulationResult.dcSweep` field already exists.
+
+## Source Lookup and Mutation
+
+Scan `compiled.devices` for a `VoltageSource` or `CurrentSource` whose `.name` matches `analysis.source` (case-sensitive). If not found, throw `SimulationError` with message like `"DC sweep source 'V1' not found"`.
+
+Before the loop, save `source.waveform` to a local variable. At each step, set `source.waveform = { type: 'dc', value: sweepValue }`. In a `finally` block, restore the original waveform so the compiled circuit is not left in a dirty state.
+
+## Sweep Loop
+
+Compute `N = Math.round((stop - start) / step) + 1` points. For `i = 0..N-1`:
+
+1. `sweepValue = start + i * step` (avoids floating-point drift from repeated addition).
+2. Set the source waveform to `{ type: 'dc', value: sweepValue }`.
+3. `assembler.clear()` — zeros G matrix and b vector but keeps `solution` as-is for warm start.
+4. `newtonRaphson(assembler, devices, options, ...)` — converges from previous solution.
+5. Read `assembler.solution` into pre-allocated `Float64Array`s for each node and branch.
+
+If `newtonRaphson` throws `ConvergenceError`, it propagates up and aborts the entire sweep (after restoring the source waveform via `finally`).
+
+## Result Class
+
+Replace the existing `DCSweepResult` plain interface in `results.ts` with a class:
+
+```typescript
+export class DCSweepResult {
+  constructor(
+    public readonly sweepValues: Float64Array,
+    private readonly voltageArrays: Map<string, Float64Array>,
+    private readonly currentArrays: Map<string, Float64Array>,
+  ) {}
+
+  voltage(node: string): Float64Array {
+    const arr = this.voltageArrays.get(node);
+    if (!arr) throw new Error(`Node '${node}' not found in DC sweep results`);
+    return arr;
+  }
+
+  current(source: string): Float64Array {
+    const arr = this.currentArrays.get(source);
+    if (!arr) throw new Error(`Source '${source}' not found in DC sweep results`);
+    return arr;
+  }
+}
+```
+
+- `sweepValues`: `Float64Array` of length N.
+- `voltage(node)`: returns `Float64Array` of length N, aligned with `sweepValues`.
+- `current(source)`: returns `Float64Array` of length N, aligned with `sweepValues`.
+
+## Error Handling
+
+- **Source not found:** `SimulationError` at the start of `solveDCSweep()`.
+- **Convergence failure:** `ConvergenceError` propagates from `newtonRaphson()`, aborts sweep. Source waveform restored via `finally`.
+
+## Tests
+
+New file: `packages/core/src/analysis/dc-sweep.test.ts`
+
+1. **Voltage divider sweep** — Sweep V1 0 to 5V, step 1V. Assert output voltage = `V1 * R2/(R1+R2)` at each point. Validates basic sweep mechanics and result shape.
+2. **Diode I-V curve** — Sweep V1 -1V to 1V through resistor + diode. Assert exponential current growth in forward region. Validates nonlinear convergence and warm-starting.
+3. **Current source sweep** — Sweep I1 0 to 1mA through a resistor. Assert `V = I * R`. Validates current source sweeping.
+4. **Unknown source error** — Sweep a non-existent source name. Expect `SimulationError`.
+
+## Public API Surface
+
+No new exports beyond the `DCSweepResult` class (replacing the existing interface). The `simulate()` function remains the only entry point. Consumers access sweep results via `result.dcSweep.voltage(node)` / `result.dcSweep.current(source)`.

--- a/packages/core/src/analysis/dc-sweep.test.ts
+++ b/packages/core/src/analysis/dc-sweep.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { Circuit } from '../circuit.js';
+import { solveDCSweep } from './dc-sweep.js';
+import { resolveOptions } from '../types.js';
+import type { DCSweepAnalysis } from '../types.js';
+
+describe('DC Sweep', () => {
+  it('sweeps a voltage divider', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 0 });
+    ckt.addResistor('R1', '1', '2', 1000);
+    ckt.addResistor('R2', '2', '0', 2000);
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'V1', start: 0, stop: 5, step: 1,
+    };
+
+    const result = solveDCSweep(compiled, analysis, options);
+
+    // 6 points: 0, 1, 2, 3, 4, 5
+    expect(result.sweepValues.length).toBe(6);
+    expect(result.sweepValues[0]).toBeCloseTo(0, 10);
+    expect(result.sweepValues[5]).toBeCloseTo(5, 10);
+
+    const v2 = result.voltage('2');
+    expect(v2.length).toBe(6);
+    for (let i = 0; i < 6; i++) {
+      const vsrc = i * 1; // start + i * step
+      const expected = vsrc * 2000 / (1000 + 2000);
+      expect(v2[i]).toBeCloseTo(expected, 6);
+    }
+
+    // Current through V1: I = -V1 / (R1 + R2)
+    const iV1 = result.current('V1');
+    expect(iV1.length).toBe(6);
+    for (let i = 0; i < 6; i++) {
+      const vsrc = i * 1;
+      expect(iV1[i]).toBeCloseTo(-vsrc / 3000, 9);
+    }
+  });
+});

--- a/packages/core/src/analysis/dc-sweep.test.ts
+++ b/packages/core/src/analysis/dc-sweep.test.ts
@@ -95,4 +95,20 @@ describe('DC Sweep', () => {
       expect(v1[i]).toBeCloseTo(current * 1000, 6);
     }
   });
+
+  it('throws on unknown sweep source', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 5 });
+    ckt.addResistor('R1', '1', '0', 1000);
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'V99', start: 0, stop: 5, step: 1,
+    };
+
+    expect(() => solveDCSweep(compiled, analysis, options)).toThrow(
+      "DC sweep source 'V99' not found",
+    );
+  });
 });

--- a/packages/core/src/analysis/dc-sweep.test.ts
+++ b/packages/core/src/analysis/dc-sweep.test.ts
@@ -3,6 +3,7 @@ import { Circuit } from '../circuit.js';
 import { solveDCSweep } from './dc-sweep.js';
 import { resolveOptions } from '../types.js';
 import type { DCSweepAnalysis } from '../types.js';
+import { simulate } from '../simulate.js';
 
 describe('DC Sweep', () => {
   it('sweeps a voltage divider', () => {
@@ -110,5 +111,27 @@ describe('DC Sweep', () => {
     expect(() => solveDCSweep(compiled, analysis, options)).toThrow(
       "DC sweep source 'V99' not found",
     );
+  });
+});
+
+describe('DC Sweep via simulate()', () => {
+  it('runs DC sweep from netlist string', async () => {
+    const result = await simulate(`
+      V1 1 0 DC 0
+      R1 1 2 1k
+      R2 2 0 2k
+      .dc V1 0 5 1
+      .end
+    `);
+
+    expect(result.dcSweep).toBeDefined();
+    const sweep = result.dcSweep!;
+    expect(sweep.sweepValues.length).toBe(6);
+
+    const v2 = sweep.voltage('2');
+    for (let i = 0; i < 6; i++) {
+      const vsrc = i;
+      expect(v2[i]).toBeCloseTo(vsrc * 2000 / 3000, 6);
+    }
   });
 });

--- a/packages/core/src/analysis/dc-sweep.test.ts
+++ b/packages/core/src/analysis/dc-sweep.test.ts
@@ -70,4 +70,29 @@ describe('DC Sweep', () => {
       expect(-iV1[i]).toBeGreaterThanOrEqual(-iV1[i - 1] - 1e-12);
     }
   });
+
+  it('sweeps a current source', () => {
+    const ckt = new Circuit();
+    ckt.addCurrentSource('I1', '1', '0', { dc: 0 });
+    ckt.addResistor('R1', '1', '0', 1000);
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'I1', start: 0, stop: 0.001, step: 0.0001,
+    };
+
+    const result = solveDCSweep(compiled, analysis, options);
+
+    // 11 points: 0, 0.1m, 0.2m, ..., 1.0m
+    expect(result.sweepValues.length).toBe(11);
+
+    const v1 = result.voltage('1');
+    expect(v1.length).toBe(11);
+    for (let i = 0; i < 11; i++) {
+      const current = analysis.start + i * analysis.step;
+      // V = I * R (current injected into node 1, flows through R1 to ground)
+      expect(v1[i]).toBeCloseTo(current * 1000, 6);
+    }
+  });
 });

--- a/packages/core/src/analysis/dc-sweep.test.ts
+++ b/packages/core/src/analysis/dc-sweep.test.ts
@@ -40,4 +40,34 @@ describe('DC Sweep', () => {
       expect(iV1[i]).toBeCloseTo(-vsrc / 3000, 9);
     }
   });
+
+  it('sweeps diode I-V curve', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 0 });
+    ckt.addResistor('R1', '1', '2', 1000);
+    ckt.addDiode('D1', '2', '0');
+
+    const compiled = ckt.compile();
+    const options = resolveOptions();
+    const analysis: DCSweepAnalysis = {
+      type: 'dc', source: 'V1', start: -1, stop: 1, step: 0.1,
+    };
+
+    const result = solveDCSweep(compiled, analysis, options);
+
+    // 21 points: -1.0, -0.9, ..., 0.9, 1.0
+    expect(result.sweepValues.length).toBe(21);
+
+    // At V1 = -1V, diode is reverse biased: current magnitude near zero
+    const iV1 = result.current('V1');
+    expect(Math.abs(iV1[0])).toBeLessThan(1e-6);
+
+    // At V1 = 1V, diode is forward biased: significant current flows
+    expect(Math.abs(iV1[20])).toBeGreaterThan(1e-4);
+
+    // Current should monotonically increase across sweep
+    for (let i = 1; i < 21; i++) {
+      expect(-iV1[i]).toBeGreaterThanOrEqual(-iV1[i - 1] - 1e-12);
+    }
+  });
 });

--- a/packages/core/src/analysis/dc-sweep.ts
+++ b/packages/core/src/analysis/dc-sweep.ts
@@ -1,0 +1,60 @@
+import type { ResolvedOptions, DCSweepAnalysis } from '../types.js';
+import type { CompiledCircuit } from '../circuit.js';
+import { MNAAssembler } from '../mna/assembler.js';
+import { newtonRaphson } from './newton-raphson.js';
+import { DCSweepResult } from '../results.js';
+import { VoltageSource } from '../devices/voltage-source.js';
+import { CurrentSource } from '../devices/current-source.js';
+import { InvalidCircuitError } from '../errors.js';
+
+export function solveDCSweep(
+  compiled: CompiledCircuit,
+  analysis: DCSweepAnalysis,
+  options: ResolvedOptions,
+): DCSweepResult {
+  const { devices, nodeCount, branchCount, nodeNames, branchNames } = compiled;
+
+  // Find the sweep source
+  const source = devices.find(
+    (d): d is VoltageSource | CurrentSource =>
+      (d instanceof VoltageSource || d instanceof CurrentSource) && d.name === analysis.source,
+  );
+  if (!source) {
+    throw new InvalidCircuitError(`DC sweep source '${analysis.source}' not found`);
+  }
+
+  const originalWaveform = source.waveform;
+  const numPoints = Math.round((analysis.stop - analysis.start) / analysis.step) + 1;
+
+  // Pre-allocate result arrays
+  const sweepValues = new Float64Array(numPoints);
+  const voltageArrays = new Map<string, Float64Array>();
+  const currentArrays = new Map<string, Float64Array>();
+  for (const name of nodeNames) voltageArrays.set(name, new Float64Array(numPoints));
+  for (const name of branchNames) currentArrays.set(name, new Float64Array(numPoints));
+
+  const assembler = new MNAAssembler(nodeCount, branchCount);
+
+  try {
+    for (let i = 0; i < numPoints; i++) {
+      const sweepValue = analysis.start + i * analysis.step;
+      sweepValues[i] = sweepValue;
+
+      source.waveform = { type: 'dc', value: sweepValue };
+
+      newtonRaphson(assembler, devices, options, options.maxIterations, nodeNames);
+
+      // Record solution
+      for (let n = 0; n < nodeNames.length; n++) {
+        voltageArrays.get(nodeNames[n])![i] = assembler.solution[n];
+      }
+      for (let b = 0; b < branchNames.length; b++) {
+        currentArrays.get(branchNames[b])![i] = assembler.solution[nodeCount + b];
+      }
+    }
+  } finally {
+    source.waveform = originalWaveform;
+  }
+
+  return new DCSweepResult(sweepValues, voltageArrays, currentArrays);
+}

--- a/packages/core/src/analysis/dc.ts
+++ b/packages/core/src/analysis/dc.ts
@@ -3,7 +3,6 @@ import type { CompiledCircuit } from '../circuit.js';
 import { MNAAssembler } from '../mna/assembler.js';
 import { newtonRaphson } from './newton-raphson.js';
 import { DCResult } from '../results.js';
-import type { DCSweepResult } from '../results.js';
 import { InvalidCircuitError } from '../errors.js';
 
 export function solveDCOperatingPoint(

--- a/packages/core/src/devices/current-source.ts
+++ b/packages/core/src/devices/current-source.ts
@@ -8,7 +8,7 @@ export class CurrentSource implements DeviceModel {
   constructor(
     readonly name: string,
     readonly nodes: number[],
-    readonly waveform: SourceWaveform,
+    public waveform: SourceWaveform,
   ) {}
 
   stamp(ctx: StampContext): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,8 @@ export { simulate, simulateStream } from './simulate.js';
 export { parse } from './parser/index.js';
 export { Circuit } from './circuit.js';
 export type { CompiledCircuit } from './circuit.js';
-export { DCResult, TransientResult, ACResult } from './results.js';
-export type { SimulationResult, DCSweepResult } from './results.js';
+export { DCResult, TransientResult, ACResult, DCSweepResult } from './results.js';
+export type { SimulationResult } from './results.js';
 export type {
   SimulationOptions,
   TransientStep,

--- a/packages/core/src/results.ts
+++ b/packages/core/src/results.ts
@@ -67,10 +67,24 @@ export class ACResult {
   }
 }
 
-export interface DCSweepResult {
-  sweepValues: number[];
-  voltages: Map<string, number[]>;
-  currents: Map<string, number[]>;
+export class DCSweepResult {
+  constructor(
+    public readonly sweepValues: Float64Array,
+    private readonly voltageArrays: Map<string, Float64Array>,
+    private readonly currentArrays: Map<string, Float64Array>,
+  ) {}
+
+  voltage(node: string): Float64Array {
+    const v = this.voltageArrays.get(node);
+    if (v === undefined) throw new Error(`Unknown node: ${node}`);
+    return v;
+  }
+
+  current(source: string): Float64Array {
+    const i = this.currentArrays.get(source);
+    if (i === undefined) throw new Error(`Unknown branch: ${source}`);
+    return i;
+  }
 }
 
 export interface SimulationResult {

--- a/packages/core/src/simulate.ts
+++ b/packages/core/src/simulate.ts
@@ -7,6 +7,7 @@ import { resolveOptions } from './types.js';
 import { solveDCOperatingPoint } from './analysis/dc.js';
 import { solveTransient } from './analysis/transient.js';
 import { solveAC } from './analysis/ac.js';
+import { solveDCSweep } from './analysis/dc-sweep.js';
 import type { SimulationResult } from './results.js';
 import { InvalidCircuitError, TimestepTooSmallError } from './errors.js';
 import { MNAAssembler } from './mna/assembler.js';
@@ -35,7 +36,8 @@ export async function simulate(
         break;
       }
       case 'dc': {
-        // DC sweep — will be implemented later
+        const opts = resolveOptions(options);
+        result.dcSweep = solveDCSweep(compiled, analysis, opts);
         break;
       }
       case 'tran': {


### PR DESCRIPTION
## Summary

- Implement `.dc` sweep analysis that sweeps a voltage or current source over a range, recording node voltages and branch currents at each operating point
- Convert `DCSweepResult` from a plain interface to a class with `.voltage(node)` and `.current(source)` accessor methods returning `Float64Array`
- Wire up the `'dc'` case in `simulate()` dispatcher — `.dc` commands now execute end-to-end

Closes #9

## Changes

| File | Change |
|------|--------|
| `analysis/dc-sweep.ts` | New — `solveDCSweep()` with source lookup, warm-started Newton-Raphson loop, waveform restore via `finally` |
| `analysis/dc-sweep.test.ts` | New — 5 tests: voltage divider, diode I-V, current source sweep, unknown source error, e2e via `simulate()` |
| `results.ts` | `DCSweepResult` interface → class with `Float64Array` accessors |
| `simulate.ts` | Wire `'dc'` case to `solveDCSweep()` |
| `devices/current-source.ts` | `readonly waveform` → `public waveform` (matches `VoltageSource`) |
| `index.ts` | Export `DCSweepResult` as value, not just type |

## Test plan

- [x] Voltage divider sweep — verifies `V_out = V_src * R2/(R1+R2)` at each point
- [x] Diode I-V curve — validates nonlinear convergence and warm-starting across sweep
- [x] Current source sweep — verifies `V = I * R` for current source sweeping
- [x] Unknown source error — expects `InvalidCircuitError`
- [x] End-to-end via `simulate()` with netlist string
- [x] Full test suite: 89/89 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)