### PR TITLE
feat: controlled sources (E/G/H/F) — integration tests and public API

### DIFF
--- a/docs/superpowers/plans/2026-04-11-controlled-sources.md
+++ b/docs/superpowers/plans/2026-04-11-controlled-sources.md
@@ -1,0 +1,1293 @@
+# Controlled Sources (E/G/H/F) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add VCVS (E), VCCS (G), CCVS (H), and CCCS (F) controlled sources to spice-ts with full DC, transient, and AC support.
+
+**Architecture:** Four new device classes implement `DeviceModel`, each with `stamp()` and `stampAC()`. VCCS and CCCS inject current (no branch variable). VCVS and CCVS force voltage (need a branch variable, like `VoltageSource`). `Circuit.compile()` gains E/H branch counting and a device map for resolving CCVS/CCCS controlling-source references by name. Parser adds four new element-type cases.
+
+**Tech Stack:** TypeScript, Vitest, MNA stamp pattern from existing device classes.
+
+---
+
+### Task 1: VCCS device (G element) — test + implementation
+
+The simplest controlled source: a current injection with no branch variable. Pattern follows `Resistor` — no branches, stamps only into G matrix.
+
+**Files:**
+- Create: `src/devices/vccs.ts`
+- Create: `src/devices/controlled-sources.test.ts`
+
+- [ ] **Step 1: Write the failing unit test for VCCS stamp**
+
+Create `src/devices/controlled-sources.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { MNAAssembler } from '../mna/assembler.js';
+import { VCCS } from './vccs.js';
+
+describe('VCCS (G element)', () => {
+  it('stamps transconductance gm between output and control nodes', () => {
+    // 4 nodes: 0=out+, 1=out-, 2=ctrl+, 3=ctrl-
+    const asm = new MNAAssembler(4, 0);
+    const g = new VCCS('G1', [0, 1, 2, 3], 0.01);
+    g.stamp(asm.getStampContext());
+
+    // G(out+, ctrl+) += gm
+    expect(asm.G.get(0, 2)).toBeCloseTo(0.01);
+    // G(out+, ctrl-) -= gm
+    expect(asm.G.get(0, 3)).toBeCloseTo(-0.01);
+    // G(out-, ctrl+) -= gm
+    expect(asm.G.get(1, 2)).toBeCloseTo(-0.01);
+    // G(out-, ctrl-) += gm
+    expect(asm.G.get(1, 3)).toBeCloseTo(0.01);
+  });
+
+  it('handles ground node (-1) on output side', () => {
+    // out- is ground: nodes [0, -1, 1, -1] => ctrl- also ground
+    const asm = new MNAAssembler(2, 0);
+    const g = new VCCS('G1', [0, -1, 1, -1], 0.005);
+    g.stamp(asm.getStampContext());
+
+    expect(asm.G.get(0, 1)).toBeCloseTo(0.005);
+    // No stamps into ground rows/cols
+    expect(asm.G.get(0, 0)).toBeCloseTo(0);
+  });
+
+  it('is linear with no branches', () => {
+    const g = new VCCS('G1', [0, 1, 2, 3], 0.01);
+    expect(g.isNonlinear).toBe(false);
+    expect(g.branches).toEqual([]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(4, 0);
+    const g = new VCCS('G1', [0, 1, 2, 3], 0.01);
+    g.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    expect(asm.G.get(0, 2)).toBeCloseTo(0.01);
+    expect(asm.G.get(0, 3)).toBeCloseTo(-0.01);
+    expect(asm.G.get(1, 2)).toBeCloseTo(-0.01);
+    expect(asm.G.get(1, 3)).toBeCloseTo(0.01);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: FAIL — cannot resolve `./vccs.js`
+
+- [ ] **Step 3: Implement VCCS device**
+
+Create `src/devices/vccs.ts`:
+
+```typescript
+import type { DeviceModel, StampContext } from './device.js';
+
+export class VCCS implements DeviceModel {
+  readonly branches: number[] = [];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly gm: number,
+  ) {}
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN, nCtrlP, nCtrlN] = this.nodes;
+
+    if (nOutP >= 0 && nCtrlP >= 0) ctx.stampG(nOutP, nCtrlP, this.gm);
+    if (nOutP >= 0 && nCtrlN >= 0) ctx.stampG(nOutP, nCtrlN, -this.gm);
+    if (nOutN >= 0 && nCtrlP >= 0) ctx.stampG(nOutN, nCtrlP, -this.gm);
+    if (nOutN >= 0 && nCtrlN >= 0) ctx.stampG(nOutN, nCtrlN, this.gm);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: PASS — all 4 tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/devices/vccs.ts src/devices/controlled-sources.test.ts
+git commit -m "feat: add VCCS (G element) device with stamp and AC support"
+```
+
+---
+
+### Task 2: VCVS device (E element) — test + implementation
+
+A voltage-controlled voltage source. Needs a branch variable, following the `VoltageSource`/`Inductor` pattern. The branch row encodes: `V(n+) - V(n-) - gain * V(nc+ - nc-) = 0`.
+
+**Files:**
+- Create: `src/devices/vcvs.ts`
+- Modify: `src/devices/controlled-sources.test.ts`
+
+- [ ] **Step 1: Write the failing unit test for VCVS stamp**
+
+Append to `src/devices/controlled-sources.test.ts`:
+
+```typescript
+import { VCVS } from './vcvs.js';
+
+describe('VCVS (E element)', () => {
+  it('stamps branch equation with gain coupling', () => {
+    // 4 nodes: 0=out+, 1=out-, 2=ctrl+, 3=ctrl-. 1 branch at index 0.
+    const asm = new MNAAssembler(4, 1);
+    const e = new VCVS('E1', [0, 1, 2, 3], 0, 10);
+    e.stamp(asm.getStampContext());
+
+    const bi = 4; // numNodes + branchIndex = 4 + 0
+
+    // KCL coupling
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(1, bi)).toBe(-1);
+
+    // KVL constraint row
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, 1)).toBe(-1);
+
+    // Control coupling: -gain on ctrl+, +gain on ctrl-
+    expect(asm.G.get(bi, 2)).toBe(-10);
+    expect(asm.G.get(bi, 3)).toBe(10);
+
+    // RHS = 0
+    expect(asm.b[bi]).toBe(0);
+  });
+
+  it('handles ground on output negative node', () => {
+    // out- = ground, ctrl- = ground: nodes [0, -1, 1, -1], 1 branch
+    const asm = new MNAAssembler(2, 1);
+    const e = new VCVS('E1', [0, -1, 1, -1], 0, 5);
+    e.stamp(asm.getStampContext());
+
+    const bi = 2; // numNodes(2) + branchIndex(0)
+
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, 1)).toBe(-5);
+  });
+
+  it('is linear with one branch', () => {
+    const e = new VCVS('E1', [0, 1, 2, 3], 0, 10);
+    expect(e.isNonlinear).toBe(false);
+    expect(e.branches).toEqual([0]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(4, 1);
+    const e = new VCVS('E1', [0, 1, 2, 3], 0, 10);
+    e.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    const bi = 4;
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, 2)).toBe(-10);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: FAIL — cannot resolve `./vcvs.js`
+
+- [ ] **Step 3: Implement VCVS device**
+
+Create `src/devices/vcvs.ts`:
+
+```typescript
+import type { DeviceModel, StampContext } from './device.js';
+
+export class VCVS implements DeviceModel {
+  readonly branches: number[];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly branchIndex: number,
+    readonly gain: number,
+  ) {
+    this.branches = [branchIndex];
+  }
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN, nCtrlP, nCtrlN] = this.nodes;
+    const bi = ctx.numNodes + this.branchIndex;
+
+    // KCL coupling: branch current enters out+, leaves out-
+    if (nOutP >= 0) ctx.stampG(nOutP, bi, 1);
+    if (nOutN >= 0) ctx.stampG(nOutN, bi, -1);
+
+    // KVL constraint: V(out+) - V(out-) - gain * (V(ctrl+) - V(ctrl-)) = 0
+    if (nOutP >= 0) ctx.stampG(bi, nOutP, 1);
+    if (nOutN >= 0) ctx.stampG(bi, nOutN, -1);
+    if (nCtrlP >= 0) ctx.stampG(bi, nCtrlP, -this.gain);
+    if (nCtrlN >= 0) ctx.stampG(bi, nCtrlN, this.gain);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: PASS — all VCVS + VCCS tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/devices/vcvs.ts src/devices/controlled-sources.test.ts
+git commit -m "feat: add VCVS (E element) device with branch and AC support"
+```
+
+---
+
+### Task 3: CCCS device (F element) — test + implementation
+
+A current-controlled current source. Reads the controlling V-source's branch current via its column in the MNA matrix. No new branch variable needed.
+
+**Files:**
+- Create: `src/devices/cccs.ts`
+- Modify: `src/devices/controlled-sources.test.ts`
+
+- [ ] **Step 1: Write the failing unit test for CCCS stamp**
+
+Append to `src/devices/controlled-sources.test.ts`:
+
+```typescript
+import { CCCS } from './cccs.js';
+
+describe('CCCS (F element)', () => {
+  it('stamps gain into controlling branch column at output nodes', () => {
+    // 2 nodes + 1 branch (from controlling V-source).
+    // nodes: 0=out+, 1=out-. controlBranchIndex=0.
+    const asm = new MNAAssembler(2, 1);
+    const f = new CCCS('F1', [0, 1], 0, 3);
+    f.stamp(asm.getStampContext());
+
+    const biCtrl = 2; // numNodes(2) + controlBranchIndex(0)
+
+    // G(out+, biCtrl) += gain
+    expect(asm.G.get(0, biCtrl)).toBe(3);
+    // G(out-, biCtrl) -= gain
+    expect(asm.G.get(1, biCtrl)).toBe(-3);
+  });
+
+  it('handles ground on output negative node', () => {
+    // out- = ground: nodes [0, -1]. 1 branch.
+    const asm = new MNAAssembler(1, 1);
+    const f = new CCCS('F1', [0, -1], 0, 5);
+    f.stamp(asm.getStampContext());
+
+    const biCtrl = 1; // numNodes(1) + 0
+    expect(asm.G.get(0, biCtrl)).toBe(5);
+  });
+
+  it('is linear with no branches of its own', () => {
+    const f = new CCCS('F1', [0, 1], 0, 3);
+    expect(f.isNonlinear).toBe(false);
+    expect(f.branches).toEqual([]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(2, 1);
+    const f = new CCCS('F1', [0, 1], 0, 3);
+    f.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    const biCtrl = 2;
+    expect(asm.G.get(0, biCtrl)).toBe(3);
+    expect(asm.G.get(1, biCtrl)).toBe(-3);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: FAIL — cannot resolve `./cccs.js`
+
+- [ ] **Step 3: Implement CCCS device**
+
+Create `src/devices/cccs.ts`:
+
+```typescript
+import type { DeviceModel, StampContext } from './device.js';
+
+export class CCCS implements DeviceModel {
+  readonly branches: number[] = [];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly controlBranchIndex: number,
+    readonly gain: number,
+  ) {}
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN] = this.nodes;
+    const biCtrl = ctx.numNodes + this.controlBranchIndex;
+
+    if (nOutP >= 0) ctx.stampG(nOutP, biCtrl, this.gain);
+    if (nOutN >= 0) ctx.stampG(nOutN, biCtrl, -this.gain);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: PASS — all VCCS + VCVS + CCCS tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/devices/cccs.ts src/devices/controlled-sources.test.ts
+git commit -m "feat: add CCCS (F element) device with AC support"
+```
+
+---
+
+### Task 4: CCVS device (H element) — test + implementation
+
+A current-controlled voltage source. Like VCVS, it needs its own branch variable. Its constraint row couples to the controlling V-source's branch column instead of control nodes.
+
+**Files:**
+- Create: `src/devices/ccvs.ts`
+- Modify: `src/devices/controlled-sources.test.ts`
+
+- [ ] **Step 1: Write the failing unit test for CCVS stamp**
+
+Append to `src/devices/controlled-sources.test.ts`:
+
+```typescript
+import { CCVS } from './ccvs.js';
+
+describe('CCVS (H element)', () => {
+  it('stamps branch equation with controlling branch coupling', () => {
+    // 2 nodes: 0=out+, 1=out-. 2 branches: 0=controlling V-source, 1=this CCVS.
+    const asm = new MNAAssembler(2, 2);
+    const h = new CCVS('H1', [0, 1], 0, 1, 1000);
+    h.stamp(asm.getStampContext());
+
+    const bi = 2 + 1;     // numNodes(2) + branchIndex(1) = 3
+    const biCtrl = 2 + 0; // numNodes(2) + controlBranchIndex(0) = 2
+
+    // KCL coupling
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(1, bi)).toBe(-1);
+
+    // KVL constraint row
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, 1)).toBe(-1);
+
+    // Control coupling: -gain on controlling branch column
+    expect(asm.G.get(bi, biCtrl)).toBe(-1000);
+
+    // RHS = 0
+    expect(asm.b[bi]).toBe(0);
+  });
+
+  it('handles ground on output negative node', () => {
+    // out- = ground: nodes [0, -1]. 2 branches.
+    const asm = new MNAAssembler(1, 2);
+    const h = new CCVS('H1', [0, -1], 0, 1, 500);
+    h.stamp(asm.getStampContext());
+
+    const bi = 1 + 1;     // numNodes(1) + branchIndex(1)
+    const biCtrl = 1 + 0; // numNodes(1) + controlBranchIndex(0)
+
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, biCtrl)).toBe(-500);
+  });
+
+  it('is linear with one branch', () => {
+    const h = new CCVS('H1', [0, 1], 0, 1, 1000);
+    expect(h.isNonlinear).toBe(false);
+    expect(h.branches).toEqual([1]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(2, 2);
+    const h = new CCVS('H1', [0, 1], 0, 1, 1000);
+    h.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    const bi = 3;
+    const biCtrl = 2;
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, biCtrl)).toBe(-1000);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: FAIL — cannot resolve `./ccvs.js`
+
+- [ ] **Step 3: Implement CCVS device**
+
+Create `src/devices/ccvs.ts`:
+
+```typescript
+import type { DeviceModel, StampContext } from './device.js';
+
+export class CCVS implements DeviceModel {
+  readonly branches: number[];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly controlBranchIndex: number,
+    readonly branchIndex: number,
+    readonly gain: number,
+  ) {
+    this.branches = [branchIndex];
+  }
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN] = this.nodes;
+    const bi = ctx.numNodes + this.branchIndex;
+    const biCtrl = ctx.numNodes + this.controlBranchIndex;
+
+    // KCL coupling: branch current enters out+, leaves out-
+    if (nOutP >= 0) ctx.stampG(nOutP, bi, 1);
+    if (nOutN >= 0) ctx.stampG(nOutN, bi, -1);
+
+    // KVL constraint: V(out+) - V(out-) - gain * I_ctrl = 0
+    if (nOutP >= 0) ctx.stampG(bi, nOutP, 1);
+    if (nOutN >= 0) ctx.stampG(bi, nOutN, -1);
+    ctx.stampG(bi, biCtrl, -this.gain);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/devices/controlled-sources.test.ts`
+Expected: PASS — all 16 unit tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/devices/ccvs.ts src/devices/controlled-sources.test.ts
+git commit -m "feat: add CCVS (H element) device with branch and AC support"
+```
+
+---
+
+### Task 5: Export devices and update `DeviceDescriptor`
+
+Wire the four new device classes into the module exports and extend `DeviceDescriptor` to support the `controlSource` field needed by CCVS/CCCS.
+
+**Files:**
+- Modify: `src/devices/index.ts:1-14`
+- Modify: `src/circuit.ts:31-39` (DeviceDescriptor)
+
+- [ ] **Step 1: Add exports to `src/devices/index.ts`**
+
+Add after line 14 (after the BSIM3v3 exports):
+
+```typescript
+export { VCCS } from './vccs.js';
+export { VCVS } from './vcvs.js';
+export { CCCS } from './cccs.js';
+export { CCVS } from './ccvs.js';
+```
+
+- [ ] **Step 2: Add `controlSource` field to `DeviceDescriptor` in `src/circuit.ts`**
+
+In the `DeviceDescriptor` interface (line 31-39), add a new optional field after `params`:
+
+```typescript
+controlSource?: string;
+```
+
+- [ ] **Step 3: Run existing tests to verify no regressions**
+
+Run: `npx vitest run`
+Expected: All existing tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/devices/index.ts src/circuit.ts
+git commit -m "feat: export controlled source devices and extend DeviceDescriptor"
+```
+
+---
+
+### Task 6: Circuit API methods for controlled sources
+
+Add `addVCVS`, `addVCCS`, `addCCVS`, `addCCCS` to the `Circuit` class, plus update `branchCount` to account for E and H elements.
+
+**Files:**
+- Modify: `src/circuit.ts:58-60` (branchCount)
+- Modify: `src/circuit.ts:102` (add methods after `addCurrentSource`)
+- Modify: `src/circuit.test.ts` (add tests)
+
+- [ ] **Step 1: Write failing tests for Circuit API**
+
+Append to `src/circuit.test.ts`:
+
+```typescript
+describe('controlled source API', () => {
+  it('addVCCS registers 4 nodes and no branches', () => {
+    const ckt = new Circuit();
+    ckt.addVCCS('G1', 'out', '0', 'in', '0', 0.01);
+    expect(ckt.nodeCount).toBe(2); // 'out' and 'in' (0 is ground)
+    expect(ckt.branchCount).toBe(0);
+  });
+
+  it('addVCVS registers 4 nodes and 1 branch', () => {
+    const ckt = new Circuit();
+    ckt.addVCVS('E1', 'out', '0', 'in', '0', 10);
+    expect(ckt.nodeCount).toBe(2);
+    expect(ckt.branchCount).toBe(1);
+  });
+
+  it('addCCCS registers 2 output nodes and no branch', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('Vsense', '1', '0', { dc: 0 });
+    ckt.addCCCS('F1', 'out', '0', 'Vsense', 3);
+    expect(ckt.branchCount).toBe(1); // only the V source
+  });
+
+  it('addCCVS registers 2 output nodes and 1 branch', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('Vsense', '1', '0', { dc: 0 });
+    ckt.addCCVS('H1', 'out', '0', 'Vsense', 1000);
+    expect(ckt.branchCount).toBe(2); // V source + CCVS
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/circuit.test.ts`
+Expected: FAIL — `addVCCS` is not a function
+
+- [ ] **Step 3: Update `branchCount` getter**
+
+In `src/circuit.ts`, change `branchCount` (line 58-60) from:
+
+```typescript
+get branchCount(): number {
+  return this.descriptors.filter(d => d.type === 'V' || d.type === 'L').length;
+}
+```
+
+to:
+
+```typescript
+get branchCount(): number {
+  return this.descriptors.filter(d =>
+    d.type === 'V' || d.type === 'L' || d.type === 'E' || d.type === 'H',
+  ).length;
+}
+```
+
+- [ ] **Step 4: Add four API methods after `addCurrentSource` (after line 102)**
+
+```typescript
+addVCVS(name: string, nOutP: string, nOutN: string, nCtrlP: string, nCtrlN: string, gain: number): void {
+  this.nodeSet.add(nOutP);
+  this.nodeSet.add(nOutN);
+  this.nodeSet.add(nCtrlP);
+  this.nodeSet.add(nCtrlN);
+  this.descriptors.push({ type: 'E', name, nodes: [nOutP, nOutN, nCtrlP, nCtrlN], value: gain });
+}
+
+addVCCS(name: string, nOutP: string, nOutN: string, nCtrlP: string, nCtrlN: string, gm: number): void {
+  this.nodeSet.add(nOutP);
+  this.nodeSet.add(nOutN);
+  this.nodeSet.add(nCtrlP);
+  this.nodeSet.add(nCtrlN);
+  this.descriptors.push({ type: 'G', name, nodes: [nOutP, nOutN, nCtrlP, nCtrlN], value: gm });
+}
+
+addCCVS(name: string, nOutP: string, nOutN: string, controlSource: string, gain: number): void {
+  this.nodeSet.add(nOutP);
+  this.nodeSet.add(nOutN);
+  this.descriptors.push({ type: 'H', name, nodes: [nOutP, nOutN], value: gain, controlSource });
+}
+
+addCCCS(name: string, nOutP: string, nOutN: string, controlSource: string, gain: number): void {
+  this.nodeSet.add(nOutP);
+  this.nodeSet.add(nOutN);
+  this.descriptors.push({ type: 'F', name, nodes: [nOutP, nOutN], value: gain, controlSource });
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/circuit.test.ts`
+Expected: PASS — all tests including the 4 new ones
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/circuit.ts src/circuit.test.ts
+git commit -m "feat: add Circuit API methods and branch counting for controlled sources"
+```
+
+---
+
+### Task 7: Compile controlled sources in `circuit.compile()`
+
+Extend the `compile()` switch statement to instantiate E/G/H/F devices. Maintain a device map so H/F can look up controlling V-source branch indices by name.
+
+**Files:**
+- Modify: `src/circuit.ts:228-300` (compile switch)
+- Modify: `src/circuit.test.ts`
+
+- [ ] **Step 1: Write failing test for compile**
+
+Append to `src/circuit.test.ts`:
+
+```typescript
+describe('controlled source compilation', () => {
+  it('compiles VCCS into a device', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+    ckt.addVCCS('G1', '2', '0', '1', '0', 0.01);
+    ckt.addResistor('RL', '2', '0', 1e3);
+    ckt.addAnalysis('op');
+    const compiled = ckt.compile();
+    expect(compiled.devices.find(d => d.name === 'G1')).toBeDefined();
+  });
+
+  it('compiles VCVS with a branch', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+    ckt.addVCVS('E1', '2', '0', '1', '0', 10);
+    ckt.addResistor('RL', '2', '0', 1e3);
+    ckt.addAnalysis('op');
+    const compiled = ckt.compile();
+    expect(compiled.branchCount).toBe(2); // V1 + E1
+    expect(compiled.devices.find(d => d.name === 'E1')).toBeDefined();
+  });
+
+  it('compiles CCCS resolving controlling V-source', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('Vsense', '1', '2', { dc: 0 });
+    ckt.addResistor('R1', '2', '0', 1e3);
+    ckt.addCCCS('F1', '3', '0', 'Vsense', 5);
+    ckt.addResistor('RL', '3', '0', 1e3);
+    ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+    ckt.addAnalysis('op');
+    const compiled = ckt.compile();
+    expect(compiled.devices.find(d => d.name === 'F1')).toBeDefined();
+  });
+
+  it('compiles CCVS with own branch + controlling reference', () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('Vsense', '1', '2', { dc: 0 });
+    ckt.addResistor('R1', '2', '0', 1e3);
+    ckt.addCCVS('H1', '3', '0', 'Vsense', 1000);
+    ckt.addResistor('RL', '3', '0', 1e3);
+    ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+    ckt.addAnalysis('op');
+    const compiled = ckt.compile();
+    expect(compiled.branchCount).toBe(3); // Vsense + V1 + H1
+    expect(compiled.devices.find(d => d.name === 'H1')).toBeDefined();
+  });
+
+  it('throws when CCCS references undefined V-source', () => {
+    const ckt = new Circuit();
+    ckt.addCCCS('F1', '1', '0', 'Vnope', 5);
+    ckt.addResistor('R1', '1', '0', 1e3);
+    ckt.addAnalysis('op');
+    expect(() => ckt.compile()).toThrow('Vnope');
+  });
+
+  it('throws when CCVS references undefined V-source', () => {
+    const ckt = new Circuit();
+    ckt.addCCVS('H1', '1', '0', 'Vnope', 1000);
+    ckt.addResistor('R1', '1', '0', 1e3);
+    ckt.addAnalysis('op');
+    expect(() => ckt.compile()).toThrow('Vnope');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/circuit.test.ts`
+Expected: FAIL — `Device type 'G' not yet implemented`
+
+- [ ] **Step 3: Add imports for new device classes at top of `src/circuit.ts`**
+
+After the existing import for `BSIM3v3` (line 11), add:
+
+```typescript
+import { VCCS } from './devices/vccs.js';
+import { VCVS } from './devices/vcvs.js';
+import { CCCS } from './devices/cccs.js';
+import { CCVS } from './devices/ccvs.js';
+```
+
+- [ ] **Step 4: Add a `deviceMap` and controlled source cases to `compile()`**
+
+In the `compile()` method, add a device map declaration after `const devices: DeviceModel[] = [];` (line 228):
+
+```typescript
+const deviceMap = new Map<string, DeviceModel>();
+```
+
+At the end of the `for` loop body, after the switch statement but before the closing brace of the for loop, add a single line that maps every successfully-created device:
+
+```typescript
+if (devices.length > prevLength) {
+  deviceMap.set(desc.name, devices[devices.length - 1]);
+}
+```
+
+Add `const prevLength = devices.length;` just before the switch statement to track whether a device was pushed. This avoids modifying every existing case — the map is populated automatically.
+
+Then add the four new cases inside the switch, before `default`:
+
+```typescript
+case 'G': {
+  const dev = new VCCS(desc.name, nodeIndices, desc.value!);
+  devices.push(dev);
+  deviceMap.set(desc.name, dev);
+  break;
+}
+case 'E': {
+  const bi = branchIndex++;
+  branchNames.push(desc.name);
+  const dev = new VCVS(desc.name, nodeIndices, bi, desc.value!);
+  devices.push(dev);
+  deviceMap.set(desc.name, dev);
+  break;
+}
+case 'F': {
+  const ctrlName = desc.controlSource!;
+  const ctrlDev = deviceMap.get(ctrlName);
+  if (!ctrlDev || ctrlDev.branches.length === 0) {
+    throw new Error(
+      `CCCS '${desc.name}' references unknown or branchless source '${ctrlName}'`,
+    );
+  }
+  const dev = new CCCS(desc.name, nodeIndices, ctrlDev.branches[0], desc.value!);
+  devices.push(dev);
+  deviceMap.set(desc.name, dev);
+  break;
+}
+case 'H': {
+  const ctrlName = desc.controlSource!;
+  const ctrlDev = deviceMap.get(ctrlName);
+  if (!ctrlDev || ctrlDev.branches.length === 0) {
+    throw new Error(
+      `CCVS '${desc.name}' references unknown or branchless source '${ctrlName}'`,
+    );
+  }
+  const bi = branchIndex++;
+  branchNames.push(desc.name);
+  const dev = new CCVS(desc.name, nodeIndices, ctrlDev.branches[0], bi, desc.value!);
+  devices.push(dev);
+  deviceMap.set(desc.name, dev);
+  break;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/circuit.test.ts`
+Expected: PASS — all controlled source compilation tests green
+
+- [ ] **Step 6: Run the full test suite for regression check**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/circuit.ts src/circuit.test.ts
+git commit -m "feat: compile controlled sources (E/G/H/F) in circuit with device map lookups"
+```
+
+---
+
+### Task 8: Parser support for E/G/H/F netlist elements
+
+Add parsing of controlled source netlist lines. E/G take 4 nodes + gain. H/F take 2 nodes + Vsource name + gain.
+
+**Files:**
+- Modify: `src/parser/index.ts:140-206` (parseDevice switch)
+- Modify: `src/parser/parser.test.ts`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Append to `src/parser/parser.test.ts`:
+
+```typescript
+describe('controlled source parsing', () => {
+  it('parses VCCS (G element)', () => {
+    const ckt = parse(`
+      V1 1 0 DC 1
+      G1 2 0 1 0 10m
+      R1 2 0 1k
+      .op
+    `);
+    const compiled = ckt.compile();
+    expect(compiled.devices.find(d => d.name === 'G1')).toBeDefined();
+    expect(compiled.branchCount).toBe(1); // only V1
+  });
+
+  it('parses VCVS (E element)', () => {
+    const ckt = parse(`
+      V1 1 0 DC 1
+      E1 2 0 1 0 10
+      R1 2 0 1k
+      .op
+    `);
+    const compiled = ckt.compile();
+    expect(compiled.devices.find(d => d.name === 'E1')).toBeDefined();
+    expect(compiled.branchCount).toBe(2); // V1 + E1
+  });
+
+  it('parses CCCS (F element)', () => {
+    const ckt = parse(`
+      V1 1 0 DC 1
+      Vsense 1 2 DC 0
+      R1 2 0 1k
+      F1 3 0 Vsense 5
+      R2 3 0 1k
+      .op
+    `);
+    const compiled = ckt.compile();
+    expect(compiled.devices.find(d => d.name === 'F1')).toBeDefined();
+  });
+
+  it('parses CCVS (H element)', () => {
+    const ckt = parse(`
+      V1 1 0 DC 1
+      Vsense 1 2 DC 0
+      R1 2 0 1k
+      H1 3 0 Vsense 1k
+      R2 3 0 1k
+      .op
+    `);
+    const compiled = ckt.compile();
+    expect(compiled.devices.find(d => d.name === 'H1')).toBeDefined();
+    expect(compiled.branchCount).toBe(3); // V1 + Vsense + H1
+  });
+
+  it('is case-insensitive for controlled sources', () => {
+    const ckt = parse(`
+      v1 1 0 dc 1
+      g1 2 0 1 0 10m
+      r1 2 0 1k
+      .op
+    `);
+    const compiled = ckt.compile();
+    expect(compiled.devices.find(d => d.name === 'g1')).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/parser/parser.test.ts`
+Expected: FAIL — `Unknown device type: 'G'`
+
+- [ ] **Step 3: Add E/G/H/F cases to `parseDevice` in `src/parser/index.ts`**
+
+In the `parseDevice` function, add these cases before the `default` case (before line 204):
+
+```typescript
+case 'E': {
+  // E<name> n+ n- nc+ nc- gain
+  const gain = parseNumber(tokens[5]);
+  circuit.addVCVS(name, tokens[1], tokens[2], tokens[3], tokens[4], gain);
+  break;
+}
+case 'G': {
+  // G<name> n+ n- nc+ nc- gm
+  const gm = parseNumber(tokens[5]);
+  circuit.addVCCS(name, tokens[1], tokens[2], tokens[3], tokens[4], gm);
+  break;
+}
+case 'H': {
+  // H<name> n+ n- Vsource gain
+  const gain = parseNumber(tokens[4]);
+  circuit.addCCVS(name, tokens[1], tokens[2], tokens[3], gain);
+  break;
+}
+case 'F': {
+  // F<name> n+ n- Vsource gain
+  const gain = parseNumber(tokens[4]);
+  circuit.addCCCS(name, tokens[1], tokens[2], tokens[3], gain);
+  break;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/parser/parser.test.ts`
+Expected: PASS — all parser tests green including the 5 new ones
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/parser/index.ts src/parser/parser.test.ts
+git commit -m "feat: parse controlled source netlist elements (E/G/H/F)"
+```
+
+---
+
+### Task 9: Subcircuit expansion support for E/G/H/F
+
+Extend `expandSubcircuit()` in `circuit.ts` to handle controlled source device types inside subcircuit bodies.
+
+**Files:**
+- Modify: `src/circuit.ts:451-569` (expandSubcircuit switch)
+- Modify: `src/circuit.test.ts`
+
+- [ ] **Step 1: Write failing test for subcircuit expansion of controlled sources**
+
+Append to `src/circuit.test.ts` inside the `subcircuit expansion` describe block:
+
+```typescript
+it('expands subcircuit with VCCS (G device)', () => {
+  const ckt = new Circuit();
+  ckt.addSubcircuit({
+    name: 'gamp',
+    ports: ['inp', 'out', 'gnd'],
+    params: {},
+    body: ['G1 out gnd inp gnd 10m', 'R1 out gnd 1k'],
+  });
+  ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'gamp');
+  ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+  ckt.addAnalysis('op');
+  const compiled = ckt.compile();
+  expect(compiled.devices.find(d => d.name === 'X1.G1')).toBeDefined();
+});
+
+it('expands subcircuit with VCVS (E device)', () => {
+  const ckt = new Circuit();
+  ckt.addSubcircuit({
+    name: 'eamp',
+    ports: ['inp', 'out', 'gnd'],
+    params: {},
+    body: ['E1 out gnd inp gnd 10'],
+  });
+  ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'eamp');
+  ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+  ckt.addResistor('RL', '2', '0', 1e3);
+  ckt.addAnalysis('op');
+  const compiled = ckt.compile();
+  expect(compiled.devices.find(d => d.name === 'X1.E1')).toBeDefined();
+});
+
+it('expands subcircuit with CCCS (F device)', () => {
+  const ckt = new Circuit();
+  ckt.addSubcircuit({
+    name: 'famp',
+    ports: ['inp', 'out', 'gnd'],
+    params: {},
+    body: ['Vs inp mid DC 0', 'R1 mid gnd 1k', 'F1 out gnd Vs 5'],
+  });
+  ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'famp');
+  ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+  ckt.addResistor('RL', '2', '0', 1e3);
+  ckt.addAnalysis('op');
+  const compiled = ckt.compile();
+  expect(compiled.devices.find(d => d.name === 'X1.F1')).toBeDefined();
+});
+
+it('expands subcircuit with CCVS (H device)', () => {
+  const ckt = new Circuit();
+  ckt.addSubcircuit({
+    name: 'hamp',
+    ports: ['inp', 'out', 'gnd'],
+    params: {},
+    body: ['Vs inp mid DC 0', 'R1 mid gnd 1k', 'H1 out gnd Vs 1k'],
+  });
+  ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'hamp');
+  ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+  ckt.addResistor('RL', '2', '0', 1e3);
+  ckt.addAnalysis('op');
+  const compiled = ckt.compile();
+  expect(compiled.devices.find(d => d.name === 'X1.H1')).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/circuit.test.ts`
+Expected: FAIL — G/E/H/F cases not handled in `expandSubcircuit`
+
+- [ ] **Step 3: Add E/G/H/F cases to the `expandSubcircuit` switch**
+
+In `expandSubcircuit()`, inside the switch statement (after the `M` case, before the `X` case), add:
+
+```typescript
+case 'E': {
+  const valStr = evalToken(tokens[5]);
+  result.push({
+    type: 'E', name: devName,
+    nodes: [mapNode(tokens[1]), mapNode(tokens[2]), mapNode(tokens[3]), mapNode(tokens[4])],
+    value: parseNumber(valStr),
+  });
+  break;
+}
+case 'G': {
+  const valStr = evalToken(tokens[5]);
+  result.push({
+    type: 'G', name: devName,
+    nodes: [mapNode(tokens[1]), mapNode(tokens[2]), mapNode(tokens[3]), mapNode(tokens[4])],
+    value: parseNumber(valStr),
+  });
+  break;
+}
+case 'H': {
+  const valStr = evalToken(tokens[4]);
+  result.push({
+    type: 'H', name: devName,
+    nodes: [mapNode(tokens[1]), mapNode(tokens[2])],
+    controlSource: `${instanceName}.${tokens[3]}`,
+    value: parseNumber(valStr),
+  });
+  break;
+}
+case 'F': {
+  const valStr = evalToken(tokens[4]);
+  result.push({
+    type: 'F', name: devName,
+    nodes: [mapNode(tokens[1]), mapNode(tokens[2])],
+    controlSource: `${instanceName}.${tokens[3]}`,
+    value: parseNumber(valStr),
+  });
+  break;
+}
+```
+
+Note: H/F `controlSource` is prefixed with `instanceName.` because the controlling V-source inside the subcircuit also gets prefixed — they must match at compile time.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/circuit.test.ts`
+Expected: PASS — all subcircuit expansion tests green
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/circuit.ts src/circuit.test.ts
+git commit -m "feat: support E/G/H/F controlled sources inside subcircuit expansion"
+```
+
+---
+
+### Task 10: DC integration tests
+
+End-to-end DC operating-point tests using `simulate()` with known closed-form answers.
+
+**Files:**
+- Create: `src/controlled-sources-integration.test.ts`
+
+- [ ] **Step 1: Write the integration test file**
+
+Create `src/controlled-sources-integration.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { simulate } from './simulate.js';
+
+describe('Controlled sources integration', () => {
+  describe('VCCS (G element)', () => {
+    it('transconductance amplifier: Vout = gm * Vin * RL', async () => {
+      // gm=10mS, Vin=1V, RL=1k => Vout = 0.01 * 1 * 1000 = 10V
+      const result = await simulate(`
+        V1 1 0 DC 1
+        G1 2 0 1 0 10m
+        R1 2 0 1k
+        .op
+      `);
+      expect(result.dc!.voltage('2')).toBeCloseTo(10, 4);
+    });
+  });
+
+  describe('VCVS (E element)', () => {
+    it('voltage amplifier: Vout = gain * Vin', async () => {
+      // gain=10, Vin=1V => Vout = 10V
+      const result = await simulate(`
+        V1 1 0 DC 1
+        E1 2 0 1 0 10
+        R1 2 0 1k
+        .op
+      `);
+      expect(result.dc!.voltage('2')).toBeCloseTo(10, 4);
+    });
+  });
+
+  describe('CCCS (F element)', () => {
+    it('current mirror: Iout = gain * Isense', async () => {
+      // V1=1V through R1=1k => Isense=1mA. gain=5 => Iout=5mA.
+      // Iout through RL=1k => VRL = 5V
+      const result = await simulate(`
+        V1 1 0 DC 1
+        Vsense 1 2 DC 0
+        R1 2 0 1k
+        F1 3 0 Vsense 5
+        RL 3 0 1k
+        .op
+      `);
+      // Isense = V1 / R1 = 1V / 1k = 1mA
+      // Iout = 5 * 1mA = 5mA
+      // V(3) = Iout * RL = 5mA * 1k = 5V
+      expect(result.dc!.voltage('3')).toBeCloseTo(5, 4);
+    });
+  });
+
+  describe('CCVS (H element)', () => {
+    it('transimpedance amplifier: Vout = gain * Isense', async () => {
+      // V1=1V through R1=1k => Isense=1mA. gain=1k => Vout=1V.
+      const result = await simulate(`
+        V1 1 0 DC 1
+        Vsense 1 2 DC 0
+        R1 2 0 1k
+        H1 3 0 Vsense 1k
+        RL 3 0 1k
+        .op
+      `);
+      // Isense = 1V / 1k = 1mA
+      // Vout = 1000 * 1mA = 1V
+      expect(result.dc!.voltage('3')).toBeCloseTo(1, 4);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `npx vitest run src/controlled-sources-integration.test.ts`
+Expected: PASS — all 4 DC integration tests green
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/controlled-sources-integration.test.ts
+git commit -m "test: add DC integration tests for controlled sources"
+```
+
+---
+
+### Task 11: AC integration test — inverting op-amp model
+
+Test an inverting amplifier using a high-gain VCVS as an ideal op-amp approximation. Verify the closed-loop gain at AC matches -Rf/Rin.
+
+**Files:**
+- Modify: `src/controlled-sources-integration.test.ts`
+
+- [ ] **Step 1: Write the AC integration test**
+
+Append to `src/controlled-sources-integration.test.ts`:
+
+```typescript
+describe('AC analysis with controlled sources', () => {
+  it('inverting op-amp (VCVS) has gain = -Rf/Rin at mid-band', async () => {
+    // Ideal op-amp model: VCVS with gain = -100000
+    // Inverting config: Rin=1k, Rf=10k => closed-loop gain = -10
+    //
+    // Circuit:
+    //   Vac  1  0  AC 1 0           (AC stimulus)
+    //   Rin  1  2  1k               (input resistor, node 2 = inverting input)
+    //   Rf   2  3  10k              (feedback resistor)
+    //   E1   3  0  0  2  100000     (VCVS: V(3) = 100000 * (V(0) - V(2)) = -100000 * V(2))
+    //   .ac dec 10 1k 1k
+    //
+    // Note: non-inverting input is ground (node 0), inverting input is node 2.
+    // E1 n+ n- nc+ nc- gain => V(3,0) = 100000 * V(0,2) = -100000 * V(2)
+    const result = await simulate(`
+      Vac 1 0 AC 1 0
+      Rin 1 2 1k
+      Rf 2 3 10k
+      E1 3 0 0 2 100000
+      .ac dec 1 1k 1k
+    `);
+
+    const ac = result.ac!;
+    // At 1kHz, closed-loop gain magnitude should be ~10 (= Rf/Rin)
+    const mag = ac.magnitude('3');
+    expect(mag[0]).toBeCloseTo(10, 0);
+
+    // Phase should be ~180 degrees (inverting)
+    const phase = ac.phase('3');
+    expect(Math.abs(phase[0])).toBeCloseTo(180, 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npx vitest run src/controlled-sources-integration.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/controlled-sources-integration.test.ts
+git commit -m "test: add AC integration test for inverting op-amp model using VCVS"
+```
+
+---
+
+### Task 12: Final regression check and cleanup
+
+Run the full suite, verify zero regressions, and ensure all new files are tracked.
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass with zero failures
+
+- [ ] **Step 2: Verify new device exports work from the package entrypoint**
+
+Run: `npx vitest run -t "VCCS\|VCVS\|CCCS\|CCVS"` (or similar grep)
+Expected: All controlled source tests appear and pass
+
+- [ ] **Step 3: Check for any unstaged files**
+
+Run: `git status`
+Expected: Clean working tree — all changes committed
+
+- [ ] **Step 4: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors

--- a/docs/superpowers/plans/2026-04-11-sparse-lu.md
+++ b/docs/superpowers/plans/2026-04-11-sparse-lu.md
@@ -1,0 +1,1442 @@
+# Sparse LU Solver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the dense O(n³) LU solver with a sparse Gilbert-Peierls implementation backed by CSC matrix format, with symbolic/numeric factorization split for Newton-Raphson reuse.
+
+**Architecture:** Assembly stays in Map-of-Maps (`SparseMatrix`). Before each solve, convert to `CscMatrix` (typed arrays). `SparseSolver` interface with `analyzePattern`/`factorize`/`solve` is implemented by `GilbertPeierlsSolver`. Symbolic phase runs once per circuit topology; numeric phase runs each Newton step. The interface is the future WASM plugin boundary.
+
+**Tech Stack:** TypeScript, vitest, typed arrays (`Float64Array`, `Int32Array`)
+
+---
+
+## File Structure
+
+```
+packages/core/src/solver/
+  sparse-matrix.ts          (existing — unchanged)
+  sparse-matrix.test.ts     (existing — unchanged)
+  lu-solver.ts              (existing — update solveLU/solveComplexLU to delegate to SparseSolver)
+  lu-solver.test.ts         (existing — unchanged, validates new path)
+  csc-matrix.ts             (new — CscMatrix type, toCsc(), ScatterMap, updateCscValues)
+  csc-matrix.test.ts        (new)
+  sparse-solver.ts          (new — SparseSolver interface, createSparseSolver factory)
+  gilbert-peierls.ts        (new — GilbertPeierlsSolver: symbolic, numeric, solve)
+  gilbert-peierls.test.ts   (new)
+
+packages/core/src/analysis/
+  newton-raphson.ts         (modify — use SparseSolver with pattern caching)
+  transient.ts              (modify — use SparseSolver with pattern caching)
+  ac.ts                     (modify — use SparseSolver with pattern caching across frequencies)
+
+packages/core/src/simulate.ts (modify — same changes as transient.ts/ac.ts for streaming paths)
+```
+
+---
+
+### Task 1: CscMatrix Type and Conversion
+
+**Files:**
+- Create: `packages/core/src/solver/csc-matrix.ts`
+- Create: `packages/core/src/solver/csc-matrix.test.ts`
+
+- [ ] **Step 1: Write failing tests for CscMatrix conversion**
+
+In `packages/core/src/solver/csc-matrix.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { SparseMatrix } from './sparse-matrix.js';
+import { toCsc, type CscMatrix } from './csc-matrix.js';
+
+describe('toCsc', () => {
+  it('converts an empty matrix', () => {
+    const m = new SparseMatrix(3);
+    const { csc } = toCsc(m);
+    expect(csc.size).toBe(3);
+    expect(Array.from(csc.colPtr)).toEqual([0, 0, 0, 0]);
+    expect(csc.rowIdx.length).toBe(0);
+    expect(csc.values.length).toBe(0);
+  });
+
+  it('converts a diagonal matrix', () => {
+    const m = new SparseMatrix(3);
+    m.add(0, 0, 2);
+    m.add(1, 1, 3);
+    m.add(2, 2, 5);
+    const { csc } = toCsc(m);
+    expect(Array.from(csc.colPtr)).toEqual([0, 1, 2, 3]);
+    expect(Array.from(csc.rowIdx)).toEqual([0, 1, 2]);
+    expect(Array.from(csc.values)).toEqual([2, 3, 5]);
+  });
+
+  it('converts a dense 2x2 matrix', () => {
+    const m = new SparseMatrix(2);
+    m.add(0, 0, 1); m.add(0, 1, 2);
+    m.add(1, 0, 3); m.add(1, 1, 4);
+    const { csc } = toCsc(m);
+    // Column 0: rows 0,1. Column 1: rows 0,1.
+    expect(Array.from(csc.colPtr)).toEqual([0, 2, 4]);
+    expect(Array.from(csc.rowIdx)).toEqual([0, 1, 0, 1]);
+    expect(Array.from(csc.values)).toEqual([1, 3, 2, 4]);
+  });
+
+  it('sorts row indices within each column', () => {
+    const m = new SparseMatrix(3);
+    // Add in reverse row order
+    m.add(2, 0, 9);
+    m.add(0, 0, 1);
+    const { csc } = toCsc(m);
+    // Column 0 should have row 0 before row 2
+    const col0Rows = Array.from(csc.rowIdx.slice(csc.colPtr[0], csc.colPtr[1]));
+    expect(col0Rows).toEqual([0, 2]);
+    const col0Vals = Array.from(csc.values.slice(csc.colPtr[0], csc.colPtr[1]));
+    expect(col0Vals).toEqual([1, 9]);
+  });
+
+  it('returns a scatter map for value-only updates', () => {
+    const m = new SparseMatrix(2);
+    m.add(0, 0, 1); m.add(0, 1, 2);
+    m.add(1, 0, 3); m.add(1, 1, 4);
+    const { csc, scatter } = toCsc(m);
+
+    // Scatter map maps (row * size + col) → CSC index
+    expect(scatter.get(0 * 2 + 0)).toBe(0); // (0,0) → index 0
+    expect(scatter.get(1 * 2 + 0)).toBe(1); // (1,0) → index 1
+    expect(scatter.get(0 * 2 + 1)).toBe(2); // (0,1) → index 2
+    expect(scatter.get(1 * 2 + 1)).toBe(3); // (1,1) → index 3
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/solver/csc-matrix.test.ts`
+Expected: FAIL — module `./csc-matrix.js` not found
+
+- [ ] **Step 3: Implement CscMatrix type and toCsc**
+
+In `packages/core/src/solver/csc-matrix.ts`:
+
+```typescript
+import type { SparseMatrix } from './sparse-matrix.js';
+
+export interface CscMatrix {
+  readonly size: number;
+  readonly colPtr: Int32Array;
+  readonly rowIdx: Int32Array;
+  readonly values: Float64Array;
+}
+
+export type ScatterMap = Map<number, number>;
+
+export function toCsc(sparse: SparseMatrix): { csc: CscMatrix; scatter: ScatterMap } {
+  const n = sparse.size;
+
+  // Collect all (row, col, val) entries grouped by column
+  const colEntries: { row: number; val: number }[][] = [];
+  for (let j = 0; j < n; j++) colEntries.push([]);
+
+  for (let i = 0; i < n; i++) {
+    const row = sparse.getRow(i);
+    for (const [j, val] of row) {
+      colEntries[j].push({ row: i, val });
+    }
+  }
+
+  // Sort each column's entries by row index
+  for (let j = 0; j < n; j++) {
+    colEntries[j].sort((a, b) => a.row - b.row);
+  }
+
+  // Count total non-zeros
+  let nnz = 0;
+  for (let j = 0; j < n; j++) nnz += colEntries[j].length;
+
+  // Build CSC arrays
+  const colPtr = new Int32Array(n + 1);
+  const rowIdx = new Int32Array(nnz);
+  const values = new Float64Array(nnz);
+  const scatter: ScatterMap = new Map();
+
+  let idx = 0;
+  for (let j = 0; j < n; j++) {
+    colPtr[j] = idx;
+    for (const entry of colEntries[j]) {
+      rowIdx[idx] = entry.row;
+      values[idx] = entry.val;
+      scatter.set(entry.row * n + j, idx);
+      idx++;
+    }
+  }
+  colPtr[n] = idx;
+
+  return { csc: { size: n, colPtr, rowIdx, values }, scatter };
+}
+
+export function updateCscValues(
+  csc: CscMatrix,
+  sparse: SparseMatrix,
+  scatter: ScatterMap,
+): void {
+  csc.values.fill(0);
+  const n = csc.size;
+  for (let i = 0; i < n; i++) {
+    const row = sparse.getRow(i);
+    for (const [j, val] of row) {
+      const idx = scatter.get(i * n + j);
+      if (idx !== undefined) {
+        (csc.values as Float64Array)[idx] = val;
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/solver/csc-matrix.test.ts`
+Expected: all 5 tests PASS
+
+- [ ] **Step 5: Add updateCscValues test**
+
+Append to `csc-matrix.test.ts`:
+
+```typescript
+import { updateCscValues } from './csc-matrix.js';
+
+describe('updateCscValues', () => {
+  it('updates values in-place using scatter map', () => {
+    const m = new SparseMatrix(2);
+    m.add(0, 0, 1); m.add(0, 1, 2);
+    m.add(1, 0, 3); m.add(1, 1, 4);
+    const { csc, scatter } = toCsc(m);
+
+    // New matrix with same pattern, different values
+    const m2 = new SparseMatrix(2);
+    m2.add(0, 0, 10); m2.add(0, 1, 20);
+    m2.add(1, 0, 30); m2.add(1, 1, 40);
+
+    updateCscValues(csc, m2, scatter);
+    expect(Array.from(csc.values)).toEqual([10, 30, 20, 40]);
+  });
+});
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/solver/csc-matrix.test.ts`
+Expected: all 6 tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/solver/csc-matrix.ts packages/core/src/solver/csc-matrix.test.ts
+git commit -m "feat: add CscMatrix type with toCsc conversion and scatter map"
+```
+
+---
+
+### Task 2: SparseSolver Interface
+
+**Files:**
+- Create: `packages/core/src/solver/sparse-solver.ts`
+
+- [ ] **Step 1: Write the SparseSolver interface**
+
+In `packages/core/src/solver/sparse-solver.ts` — interface only, no factory yet (added in Task 5 once the implementation exists):
+
+```typescript
+import type { CscMatrix } from './csc-matrix.js';
+
+export interface SparseSolver {
+  /** Analyze sparsity pattern — call once per circuit topology */
+  analyzePattern(A: CscMatrix): void;
+
+  /** Numeric factorization — call each Newton step (same pattern, new values) */
+  factorize(A: CscMatrix): void;
+
+  /** Solve Ax = b, returns solution vector */
+  solve(b: Float64Array): Float64Array;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/core/src/solver/sparse-solver.ts
+git commit -m "feat: add SparseSolver interface"
+```
+
+---
+
+### Task 3: Gilbert-Peierls Symbolic Phase
+
+**Files:**
+- Create: `packages/core/src/solver/gilbert-peierls.ts`
+- Create: `packages/core/src/solver/gilbert-peierls.test.ts`
+
+- [ ] **Step 1: Write failing tests for symbolic analysis**
+
+In `packages/core/src/solver/gilbert-peierls.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { SparseMatrix } from './sparse-matrix.js';
+import { toCsc } from './csc-matrix.js';
+import { GilbertPeierlsSolver } from './gilbert-peierls.js';
+
+describe('GilbertPeierlsSolver', () => {
+  describe('analyzePattern', () => {
+    it('accepts a diagonal matrix without error', () => {
+      const m = new SparseMatrix(3);
+      m.add(0, 0, 2); m.add(1, 1, 3); m.add(2, 2, 5);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      expect(() => solver.analyzePattern(csc)).not.toThrow();
+    });
+
+    it('accepts a dense 3x3 matrix', () => {
+      const m = new SparseMatrix(3);
+      m.add(0, 0, 1); m.add(0, 1, 2); m.add(0, 2, 3);
+      m.add(1, 0, 4); m.add(1, 1, 5); m.add(1, 2, 6);
+      m.add(2, 0, 7); m.add(2, 1, 8); m.add(2, 2, 0);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      expect(() => solver.analyzePattern(csc)).not.toThrow();
+    });
+
+    it('accepts a tridiagonal matrix (typical SPICE pattern)', () => {
+      const n = 10;
+      const m = new SparseMatrix(n);
+      for (let i = 0; i < n; i++) {
+        m.add(i, i, 4);
+        if (i > 0) m.add(i, i - 1, -1);
+        if (i < n - 1) m.add(i, i + 1, -1);
+      }
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      expect(() => solver.analyzePattern(csc)).not.toThrow();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/solver/gilbert-peierls.test.ts`
+Expected: FAIL — module `./gilbert-peierls.js` not found
+
+- [ ] **Step 3: Implement the symbolic phase**
+
+In `packages/core/src/solver/gilbert-peierls.ts`:
+
+```typescript
+import type { CscMatrix } from './csc-matrix.js';
+import type { SparseSolver } from './sparse-solver.js';
+
+/**
+ * Gilbert-Peierls sparse LU solver.
+ *
+ * Symbolic phase: DFS to compute reach of each column → sparsity structure of L and U.
+ * Numeric phase: sparse triangular solves to fill L and U values.
+ * Solve phase: sparse forward/backward substitution.
+ */
+export class GilbertPeierlsSolver implements SparseSolver {
+  private n = 0;
+
+  // Symbolic output: structure of L and U in CSC
+  private lColPtr!: Int32Array;
+  private lRowIdx!: Int32Array;
+  private uColPtr!: Int32Array;
+  private uRowIdx!: Int32Array;
+
+  // Numeric output: values of L and U
+  private lValues!: Float64Array;
+  private uValues!: Float64Array;
+
+  // Pivot permutation (row i of permuted matrix = row perm[i] of original)
+  private perm!: Int32Array;
+  private permInv!: Int32Array; // inverse permutation
+
+  // Work arrays (reused across factorize calls)
+  private work!: Float64Array;
+  private mark!: Int32Array;
+
+  private analyzed = false;
+
+  analyzePattern(A: CscMatrix): void {
+    const n = A.size;
+    this.n = n;
+
+    // Compute the symbolic structure of L and U using DFS.
+    // For each column j, the "reach" through the graph of L tells us
+    // which rows of L[:,j] and U[j,:] will be non-zero.
+
+    this.perm = new Int32Array(n);
+    this.permInv = new Int32Array(n);
+    for (let i = 0; i < n; i++) {
+      this.perm[i] = i;
+      this.permInv[i] = i;
+    }
+
+    // Phase 1: Build column elimination tree (etree) from A's structure.
+    // The etree parent[j] = min row index i > j such that L[i,j] != 0 in
+    // the Cholesky factor. For LU we use A + A^T structure as an upper bound.
+    const parent = new Int32Array(n).fill(-1);
+    const ancestor = new Int32Array(n);
+    for (let i = 0; i < n; i++) ancestor[i] = i;
+
+    for (let j = 0; j < n; j++) {
+      for (let p = A.colPtr[j]; p < A.colPtr[j + 1]; p++) {
+        const i = A.rowIdx[p];
+        if (i <= j) continue; // only look at lower triangle
+        // Walk up from i to root
+        let node = i;
+        while (ancestor[node] !== node && ancestor[node] !== j) {
+          const next = ancestor[node];
+          ancestor[node] = j;
+          node = next;
+        }
+        if (ancestor[node] === node) {
+          // node is a root, make j its parent
+          parent[node] = j;
+          ancestor[node] = j;
+        }
+      }
+    }
+
+    // Phase 2: Compute non-zero counts for L and U using DFS from each column.
+    // We over-estimate by using the structure of A (not the actual Cholesky factor).
+    // This is simpler and the extra space is bounded.
+    const lColCounts: number[] = new Array(n).fill(0);
+    const uColCounts: number[] = new Array(n).fill(0);
+    const visited = new Int32Array(n).fill(-1);
+
+    for (let j = 0; j < n; j++) {
+      // DFS from column j of A to find reach in L
+      const stack: number[] = [];
+      const lRows: number[] = [];
+      const uRows: number[] = [];
+
+      // Seed DFS with non-zeros in column j of A
+      for (let p = A.colPtr[j]; p < A.colPtr[j + 1]; p++) {
+        const i = A.rowIdx[p];
+        if (i < j) {
+          // Upper triangle entry
+          if (visited[i] !== j) {
+            visited[i] = j;
+            uRows.push(i);
+          }
+        } else if (i > j) {
+          // Lower triangle entry — seed for DFS
+          if (visited[i] !== j) {
+            visited[i] = j;
+            stack.push(i);
+            lRows.push(i);
+          }
+        }
+        // i === j is the diagonal, always present in both L and U
+      }
+
+      // DFS up the etree from each lower-triangle seed
+      while (stack.length > 0) {
+        const node = stack.pop()!;
+        const par = parent[node];
+        if (par !== -1 && par !== j && visited[par] !== j) {
+          visited[par] = j;
+          if (par < j) {
+            uRows.push(par);
+          } else {
+            lRows.push(par);
+            stack.push(par);
+          }
+        }
+      }
+
+      uColCounts[j] = uRows.length + 1; // +1 for diagonal
+      lColCounts[j] = lRows.length;      // no diagonal in L (implicit 1)
+    }
+
+    // Phase 3: Allocate L and U in CSC format
+    let lNnz = 0;
+    let uNnz = 0;
+    this.lColPtr = new Int32Array(n + 1);
+    this.uColPtr = new Int32Array(n + 1);
+    for (let j = 0; j < n; j++) {
+      this.lColPtr[j] = lNnz;
+      lNnz += lColCounts[j];
+      this.uColPtr[j] = uNnz;
+      uNnz += uColCounts[j];
+    }
+    this.lColPtr[n] = lNnz;
+    this.uColPtr[n] = uNnz;
+
+    this.lRowIdx = new Int32Array(lNnz);
+    this.lValues = new Float64Array(lNnz);
+    this.uRowIdx = new Int32Array(uNnz);
+    this.uValues = new Float64Array(uNnz);
+
+    this.work = new Float64Array(n);
+    this.mark = new Int32Array(n).fill(-1);
+
+    this.analyzed = true;
+  }
+
+  factorize(_A: CscMatrix): void {
+    if (!this.analyzed) {
+      throw new Error('Must call analyzePattern before factorize');
+    }
+    // Implemented in Task 4
+    throw new Error('Not yet implemented');
+  }
+
+  solve(_b: Float64Array): Float64Array {
+    // Implemented in Task 5
+    throw new Error('Not yet implemented');
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/solver/gilbert-peierls.test.ts`
+Expected: all 3 analyzePattern tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/solver/gilbert-peierls.ts packages/core/src/solver/gilbert-peierls.test.ts
+git commit -m "feat: add Gilbert-Peierls symbolic phase (analyzePattern)"
+```
+
+---
+
+### Task 4: Gilbert-Peierls Numeric Phase
+
+**Files:**
+- Modify: `packages/core/src/solver/gilbert-peierls.ts`
+- Modify: `packages/core/src/solver/gilbert-peierls.test.ts`
+
+- [ ] **Step 1: Write failing tests for factorize**
+
+Append to `gilbert-peierls.test.ts`:
+
+```typescript
+  describe('factorize', () => {
+    it('factorizes a 2x2 system without error', () => {
+      const m = new SparseMatrix(2);
+      m.add(0, 0, 2); m.add(0, 1, 1);
+      m.add(1, 0, 1); m.add(1, 1, 3);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      expect(() => solver.factorize(csc)).not.toThrow();
+    });
+
+    it('factorizes a diagonal matrix', () => {
+      const m = new SparseMatrix(3);
+      m.add(0, 0, 2); m.add(1, 1, 3); m.add(2, 2, 5);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      expect(() => solver.factorize(csc)).not.toThrow();
+    });
+
+    it('throws on singular matrix (zero pivot)', () => {
+      const m = new SparseMatrix(2);
+      m.add(0, 0, 0); m.add(0, 1, 1);
+      m.add(1, 0, 1); m.add(1, 1, 0);
+      // After pivoting: should be able to factor this (it's just a permutation)
+      // But a truly singular matrix:
+      const m2 = new SparseMatrix(2);
+      m2.add(0, 0, 1); m2.add(0, 1, 2);
+      m2.add(1, 0, 1); m2.add(1, 1, 2); // row 1 = row 0
+      const { csc } = toCsc(m2);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      expect(() => solver.factorize(csc)).toThrow(/[Ss]ingular/);
+    });
+
+    it('throws if analyzePattern was not called', () => {
+      const m = new SparseMatrix(2);
+      m.add(0, 0, 1); m.add(1, 1, 1);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      expect(() => solver.factorize(csc)).toThrow(/analyzePattern/);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/solver/gilbert-peierls.test.ts`
+Expected: factorize tests FAIL with "Not yet implemented"
+
+- [ ] **Step 3: Implement the numeric phase**
+
+Replace the `factorize` method in `packages/core/src/solver/gilbert-peierls.ts`:
+
+```typescript
+  factorize(A: CscMatrix): void {
+    if (!this.analyzed) {
+      throw new Error('Must call analyzePattern before factorize');
+    }
+
+    const n = this.n;
+    const work = this.work;
+    const mark = this.mark;
+
+    // Reset permutation to identity for fresh factorization
+    for (let i = 0; i < n; i++) {
+      this.perm[i] = i;
+      this.permInv[i] = i;
+    }
+
+    // Reset L and U value arrays
+    this.lValues.fill(0);
+    this.uValues.fill(0);
+
+    // Track actual fill positions for L and U columns
+    const lPos = new Int32Array(n);
+    const uPos = new Int32Array(n);
+    for (let j = 0; j < n; j++) {
+      lPos[j] = this.lColPtr[j];
+      uPos[j] = this.uColPtr[j];
+    }
+
+    for (let j = 0; j < n; j++) {
+      // Scatter column j of P*A into work vector
+      work.fill(0);
+      mark.fill(-1);
+
+      for (let p = A.colPtr[j]; p < A.colPtr[j + 1]; p++) {
+        const origRow = A.rowIdx[p];
+        const permRow = this.permInv[origRow];
+        work[permRow] = A.values[p];
+        mark[permRow] = j;
+      }
+
+      // Apply previously computed L columns: for each k < j where L[:,k]
+      // has an entry in row j (meaning U[k,j] != 0), subtract L[:,k] * U[k,j]
+      for (let k = 0; k < j; k++) {
+        const ukj = work[k];
+        if (ukj === 0) continue;
+
+        // Divide by U[k,k] to get the actual U[k,j] value
+        // U[k,k] is the first entry in U column k
+        const ukk = this.uValues[this.uColPtr[k]];
+        if (ukk === 0) continue;
+        const multiplier = ukj / ukk;
+        work[k] = multiplier;
+
+        // Subtract L[:,k] * multiplier from work
+        for (let p = this.lColPtr[k]; p < lPos[k]; p++) {
+          const i = this.lRowIdx[p];
+          work[i] -= this.lValues[p] * multiplier;
+        }
+      }
+
+      // Threshold partial pivoting: find max |work[i]| for i >= j
+      let maxVal = Math.abs(work[j]);
+      let maxRow = j;
+      for (let i = j + 1; i < n; i++) {
+        if (work[i] !== 0 || mark[i] === j) {
+          const av = Math.abs(work[i]);
+          if (av > maxVal) {
+            maxVal = av;
+            maxRow = i;
+          }
+        }
+      }
+
+      if (maxVal < 1e-18) {
+        throw new Error(`Singular matrix at column ${j}`);
+      }
+
+      // Swap rows j and maxRow in permutation and work vector
+      if (maxRow !== j) {
+        const tmp = work[j]; work[j] = work[maxRow]; work[maxRow] = tmp;
+        const tmpMark = mark[j]; mark[j] = mark[maxRow]; mark[maxRow] = tmpMark;
+
+        // Update permutation
+        const origJ = this.perm[j];
+        const origMax = this.perm[maxRow];
+        this.perm[j] = origMax;
+        this.perm[maxRow] = origJ;
+        this.permInv[origMax] = j;
+        this.permInv[origJ] = maxRow;
+      }
+
+      // Store U column j: diagonal + upper entries (rows < j)
+      // Diagonal first
+      const uStart = this.uColPtr[j];
+      const uEnd = this.uColPtr[j + 1];
+      let uIdx = uStart;
+      this.uRowIdx[uIdx] = j;
+      this.uValues[uIdx] = work[j];
+      uIdx++;
+
+      for (let i = 0; i < j; i++) {
+        if (work[i] !== 0 && uIdx < uEnd) {
+          this.uRowIdx[uIdx] = i;
+          this.uValues[uIdx] = work[i];
+          uIdx++;
+        }
+      }
+      uPos[j] = uIdx;
+
+      // Store L column j: lower entries (rows > j), scaled by 1/pivot
+      const pivot = work[j];
+      let lIdx = this.lColPtr[j];
+      const lEnd = this.lColPtr[j + 1];
+      for (let i = j + 1; i < n; i++) {
+        if (work[i] !== 0 && lIdx < lEnd) {
+          this.lRowIdx[lIdx] = i;
+          this.lValues[lIdx] = work[i] / pivot;
+          lIdx++;
+        }
+      }
+      lPos[j] = lIdx;
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/solver/gilbert-peierls.test.ts`
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/solver/gilbert-peierls.ts packages/core/src/solver/gilbert-peierls.test.ts
+git commit -m "feat: add Gilbert-Peierls numeric phase (factorize)"
+```
+
+---
+
+### Task 5: Gilbert-Peierls Solve Phase and End-to-End Tests
+
+**Files:**
+- Modify: `packages/core/src/solver/gilbert-peierls.ts`
+- Modify: `packages/core/src/solver/gilbert-peierls.test.ts`
+- Modify: `packages/core/src/solver/sparse-solver.ts`
+
+- [ ] **Step 1: Write failing tests for solve**
+
+Append to the `describe('GilbertPeierlsSolver')` block in `gilbert-peierls.test.ts`:
+
+```typescript
+  describe('solve (end-to-end)', () => {
+    it('solves a 2x2 system', () => {
+      const m = new SparseMatrix(2);
+      m.add(0, 0, 2); m.add(0, 1, 1);
+      m.add(1, 0, 1); m.add(1, 1, 3);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      solver.factorize(csc);
+      const x = solver.solve(new Float64Array([5, 7]));
+      expect(x[0]).toBeCloseTo(1.6, 10);
+      expect(x[1]).toBeCloseTo(1.8, 10);
+    });
+
+    it('solves a 3x3 system', () => {
+      const m = new SparseMatrix(3);
+      m.add(0, 0, 1); m.add(0, 1, 2); m.add(0, 2, 3);
+      m.add(1, 0, 4); m.add(1, 1, 5); m.add(1, 2, 6);
+      m.add(2, 0, 7); m.add(2, 1, 8); m.add(2, 2, 0);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      solver.factorize(csc);
+      const x = solver.solve(new Float64Array([14, 32, 23]));
+      expect(x[0]).toBeCloseTo(1, 10);
+      expect(x[1]).toBeCloseTo(2, 10);
+      expect(x[2]).toBeCloseTo(3, 10);
+    });
+
+    it('solves a system requiring pivoting', () => {
+      const m = new SparseMatrix(2);
+      m.add(0, 1, 1);
+      m.add(1, 0, 1);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      solver.factorize(csc);
+      const x = solver.solve(new Float64Array([3, 2]));
+      expect(x[0]).toBeCloseTo(2, 10);
+      expect(x[1]).toBeCloseTo(3, 10);
+    });
+
+    it('solves a diagonal system', () => {
+      const m = new SparseMatrix(3);
+      m.add(0, 0, 5); m.add(1, 1, 3); m.add(2, 2, 7);
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      solver.factorize(csc);
+      const x = solver.solve(new Float64Array([10, 9, 21]));
+      expect(x[0]).toBeCloseTo(2, 10);
+      expect(x[1]).toBeCloseTo(3, 10);
+      expect(x[2]).toBeCloseTo(3, 10);
+    });
+
+    it('solves a 10x10 tridiagonal system', () => {
+      const n = 10;
+      const m = new SparseMatrix(n);
+      for (let i = 0; i < n; i++) {
+        m.add(i, i, 4);
+        if (i > 0) m.add(i, i - 1, -1);
+        if (i < n - 1) m.add(i, i + 1, -1);
+      }
+      const { csc } = toCsc(m);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc);
+      solver.factorize(csc);
+
+      // b = A * [1,2,3,...,10] so solution should be [1,2,...,10]
+      const expected = new Float64Array(n);
+      for (let i = 0; i < n; i++) expected[i] = i + 1;
+      const b = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        b[i] = 4 * expected[i];
+        if (i > 0) b[i] += -1 * expected[i - 1];
+        if (i < n - 1) b[i] += -1 * expected[i + 1];
+      }
+
+      const x = solver.solve(b);
+      for (let i = 0; i < n; i++) {
+        expect(x[i]).toBeCloseTo(expected[i], 8);
+      }
+    });
+
+    it('re-factorizes with new values (pattern reuse)', () => {
+      // First solve
+      const m1 = new SparseMatrix(2);
+      m1.add(0, 0, 2); m1.add(0, 1, 1);
+      m1.add(1, 0, 1); m1.add(1, 1, 3);
+      const { csc: csc1 } = toCsc(m1);
+      const solver = new GilbertPeierlsSolver();
+      solver.analyzePattern(csc1);
+      solver.factorize(csc1);
+      const x1 = solver.solve(new Float64Array([5, 7]));
+      expect(x1[0]).toBeCloseTo(1.6, 10);
+
+      // Second solve — same pattern, different values
+      const m2 = new SparseMatrix(2);
+      m2.add(0, 0, 3); m2.add(0, 1, 1);
+      m2.add(1, 0, 1); m2.add(1, 1, 4);
+      const { csc: csc2 } = toCsc(m2);
+      // Don't call analyzePattern again — reuse symbolic
+      solver.factorize(csc2);
+      const x2 = solver.solve(new Float64Array([7, 8]));
+      // 3x + y = 7, x + 4y = 8 → x = 20/11, y = 17/11
+      expect(x2[0]).toBeCloseTo(20 / 11, 10);
+      expect(x2[1]).toBeCloseTo(17 / 11, 10);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/solver/gilbert-peierls.test.ts`
+Expected: solve tests FAIL with "Not yet implemented"
+
+- [ ] **Step 3: Implement the solve phase**
+
+Replace the `solve` method in `packages/core/src/solver/gilbert-peierls.ts`:
+
+```typescript
+  solve(b: Float64Array): Float64Array {
+    if (!this.analyzed) {
+      throw new Error('Must call analyzePattern and factorize before solve');
+    }
+
+    const n = this.n;
+    const x = new Float64Array(n);
+
+    // Apply permutation: y = P * b
+    const y = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      y[i] = b[this.perm[i]];
+    }
+
+    // Forward substitution: L * z = y
+    // L has implicit 1 on diagonal; lRowIdx/lValues store sub-diagonal entries.
+    const z = new Float64Array(y);
+    for (let j = 0; j < n; j++) {
+      for (let p = this.lColPtr[j]; p < this.lColPtr[j + 1]; p++) {
+        const i = this.lRowIdx[p];
+        if (i === 0 && this.lValues[p] === 0) break; // past actual entries
+        z[i] -= this.lValues[p] * z[j];
+      }
+    }
+
+    // Backward substitution: U * x = z
+    // U diagonal is stored as first entry of each column.
+    for (let j = n - 1; j >= 0; j--) {
+      const diagIdx = this.uColPtr[j];
+      const diagVal = this.uValues[diagIdx];
+      x[j] = z[j];
+      for (let p = diagIdx + 1; p < this.uColPtr[j + 1]; p++) {
+        const i = this.uRowIdx[p];
+        if (i === 0 && this.uValues[p] === 0 && p > diagIdx + 1) break;
+        x[j] -= this.uValues[p] * x[i];
+      }
+      x[j] /= diagVal;
+    }
+
+    return x;
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/solver/gilbert-peierls.test.ts`
+Expected: all tests PASS
+
+Note: If solve results are wrong, the symbolic or numeric phase has a bug. Debug by checking `L * U = P * A` for a small matrix. Common issues: (1) row indices in U column are stored unsorted — ensure backward substitution uses the correct index, (2) permutation applied in wrong direction — `perm[i]` should map new-row-i to old-row.
+
+- [ ] **Step 5: Add createSparseSolver factory to sparse-solver.ts**
+
+Update `packages/core/src/solver/sparse-solver.ts`:
+
+```typescript
+import type { CscMatrix } from './csc-matrix.js';
+import { GilbertPeierlsSolver } from './gilbert-peierls.js';
+
+export interface SparseSolver {
+  analyzePattern(A: CscMatrix): void;
+  factorize(A: CscMatrix): void;
+  solve(b: Float64Array): Float64Array;
+}
+
+export function createSparseSolver(): SparseSolver {
+  return new GilbertPeierlsSolver();
+}
+```
+
+- [ ] **Step 6: Run full solver test suite to verify no regressions**
+
+Run: `cd packages/core && npx vitest run src/solver/`
+Expected: all tests in `sparse-matrix.test.ts`, `lu-solver.test.ts`, `csc-matrix.test.ts`, `gilbert-peierls.test.ts` PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/solver/gilbert-peierls.ts packages/core/src/solver/gilbert-peierls.test.ts packages/core/src/solver/sparse-solver.ts
+git commit -m "feat: add Gilbert-Peierls solve phase and createSparseSolver factory"
+```
+
+---
+
+### Task 6: Wire solveLU Through SparseSolver
+
+**Files:**
+- Modify: `packages/core/src/solver/lu-solver.ts`
+
+- [ ] **Step 1: Run existing lu-solver tests to establish baseline**
+
+Run: `cd packages/core && npx vitest run src/solver/lu-solver.test.ts`
+Expected: all 4 tests PASS
+
+- [ ] **Step 2: Replace solveLU internals with SparseSolver**
+
+Replace the contents of `packages/core/src/solver/lu-solver.ts`:
+
+```typescript
+import { SparseMatrix } from './sparse-matrix.js';
+import { toCsc } from './csc-matrix.js';
+import { createSparseSolver } from './sparse-solver.js';
+
+/**
+ * Solve Ax = b using sparse LU decomposition (Gilbert-Peierls).
+ * Drop-in replacement for the previous dense O(n³) solver.
+ */
+export function solveLU(A: SparseMatrix, b: Float64Array): Float64Array {
+  const n = A.size;
+  if (b.length !== n) {
+    throw new Error(`Dimension mismatch: matrix is ${n}x${n}, b has length ${b.length}`);
+  }
+
+  const { csc } = toCsc(A);
+  const solver = createSparseSolver();
+  solver.analyzePattern(csc);
+  solver.factorize(csc);
+  return solver.solve(b);
+}
+
+/**
+ * Solve a complex system (G + jwC)x = b for AC analysis.
+ * Returns [real_part, imag_part] of solution.
+ */
+export function solveComplexLU(
+  Areal: SparseMatrix,
+  Aimag: SparseMatrix,
+  bReal: Float64Array,
+  bImag: Float64Array,
+): [Float64Array, Float64Array] {
+  const n = Areal.size;
+  const N = 2 * n;
+  const A = new SparseMatrix(N);
+
+  for (let i = 0; i < n; i++) {
+    for (const [j, val] of Areal.getRow(i)) {
+      A.add(i, j, val);
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    for (const [j, val] of Aimag.getRow(i)) {
+      A.add(i, j + n, -val);
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    for (const [j, val] of Aimag.getRow(i)) {
+      A.add(i + n, j, val);
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    for (const [j, val] of Areal.getRow(i)) {
+      A.add(i + n, j + n, val);
+    }
+  }
+
+  const b = new Float64Array(N);
+  b.set(bReal, 0);
+  b.set(bImag, n);
+
+  const x = solveLU(A, b);
+  return [x.slice(0, n), x.slice(n)];
+}
+```
+
+- [ ] **Step 3: Run lu-solver tests to verify drop-in replacement works**
+
+Run: `cd packages/core && npx vitest run src/solver/lu-solver.test.ts`
+Expected: all 4 existing tests PASS — same inputs, same outputs, new internals
+
+- [ ] **Step 4: Run full test suite to verify no regressions**
+
+Run: `cd packages/core && npx vitest run`
+Expected: ALL tests PASS (DC, transient, AC, BSIM3, subcircuit, etc.)
+
+This is the critical regression gate. If any test fails, the sparse solver has a correctness bug — debug from the failing circuit, not from the solver tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/solver/lu-solver.ts
+git commit -m "refactor: wire solveLU through SparseSolver (drop-in replacement)"
+```
+
+---
+
+### Task 7: Newton-Raphson Pattern Caching
+
+**Files:**
+- Modify: `packages/core/src/analysis/newton-raphson.ts`
+
+- [ ] **Step 1: Run DC tests to establish baseline**
+
+Run: `cd packages/core && npx vitest run src/analysis/dc.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Update Newton-Raphson to cache symbolic factorization**
+
+Replace the contents of `packages/core/src/analysis/newton-raphson.ts`:
+
+```typescript
+import type { DeviceModel } from '../devices/device.js';
+import type { MNAAssembler } from '../mna/assembler.js';
+import type { ResolvedOptions } from '../types.js';
+import { toCsc, updateCscValues, type ScatterMap, type CscMatrix } from '../solver/csc-matrix.js';
+import { createSparseSolver } from '../solver/sparse-solver.js';
+import { ConvergenceError } from '../errors.js';
+
+export function newtonRaphson(
+  assembler: MNAAssembler,
+  devices: DeviceModel[],
+  options: ResolvedOptions,
+  maxIter: number,
+  nodeNames: string[],
+): number {
+  const solver = createSparseSolver();
+  let csc: CscMatrix | null = null;
+  let scatter: ScatterMap | null = null;
+  let patternAnalyzed = false;
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    assembler.saveSolution();
+    assembler.clear();
+
+    const ctx = assembler.getStampContext();
+    for (const device of devices) {
+      device.stamp(ctx);
+    }
+
+    for (let i = 0; i < assembler.numNodes; i++) {
+      assembler.G.add(i, i, options.gmin);
+    }
+
+    if (!patternAnalyzed) {
+      const result = toCsc(assembler.G);
+      csc = result.csc;
+      scatter = result.scatter;
+      solver.analyzePattern(csc);
+      patternAnalyzed = true;
+    } else {
+      updateCscValues(csc!, assembler.G, scatter!);
+    }
+
+    solver.factorize(csc!);
+    const x = solver.solve(new Float64Array(assembler.b));
+    assembler.solution.set(x);
+
+    if (isConverged(assembler.solution, assembler.prevSolution, assembler.numNodes, options)) {
+      return iter + 1;
+    }
+  }
+
+  const oscillating = findOscillatingNodes(
+    assembler.solution, assembler.prevSolution,
+    assembler.numNodes, nodeNames, options,
+  );
+
+  throw new ConvergenceError(
+    `Did not converge in ${maxIter} iterations`,
+    undefined, oscillating,
+    new Float64Array(assembler.solution),
+    new Float64Array(assembler.prevSolution),
+  );
+}
+
+function isConverged(
+  current: Float64Array, previous: Float64Array,
+  numNodes: number, options: ResolvedOptions,
+): boolean {
+  for (let i = 0; i < current.length; i++) {
+    const diff = Math.abs(current[i] - previous[i]);
+    const tol = i < numNodes
+      ? options.vntol + options.reltol * Math.abs(current[i])
+      : options.abstol + options.reltol * Math.abs(current[i]);
+    if (diff > tol) return false;
+  }
+  return true;
+}
+
+function findOscillatingNodes(
+  current: Float64Array, previous: Float64Array,
+  numNodes: number, nodeNames: string[], options: ResolvedOptions,
+): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < numNodes; i++) {
+    const diff = Math.abs(current[i] - previous[i]);
+    const tol = options.vntol + options.reltol * Math.abs(current[i]);
+    if (diff > tol) result.push(nodeNames[i] ?? `node_${i}`);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 3: Run DC and DC sweep tests**
+
+Run: `cd packages/core && npx vitest run src/analysis/dc.test.ts src/analysis/dc-sweep.test.ts`
+Expected: PASS — DC operating point and DC sweep both use `newtonRaphson`
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd packages/core && npx vitest run`
+Expected: ALL tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/analysis/newton-raphson.ts
+git commit -m "perf: cache symbolic factorization across Newton-Raphson iterations"
+```
+
+---
+
+### Task 8: Transient Analysis Pattern Caching
+
+**Files:**
+- Modify: `packages/core/src/analysis/transient.ts`
+- Modify: `packages/core/src/simulate.ts` (streaming transient path)
+
+- [ ] **Step 1: Run transient tests to establish baseline**
+
+Run: `cd packages/core && npx vitest run src/analysis/transient.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Update transient.ts to cache symbolic factorization**
+
+In `packages/core/src/analysis/transient.ts`, replace the import and add SparseSolver:
+
+Change the imports at the top:
+
+```typescript
+import type { ResolvedOptions, TransientAnalysis } from '../types.js';
+import type { CompiledCircuit } from '../circuit.js';
+import { MNAAssembler } from '../mna/assembler.js';
+import { buildCompanionSystem } from '../mna/companion.js';
+import { toCsc, updateCscValues, type ScatterMap, type CscMatrix } from '../solver/csc-matrix.js';
+import { createSparseSolver } from '../solver/sparse-solver.js';
+import { TimestepTooSmallError } from '../errors.js';
+import { TransientResult } from '../results.js';
+```
+
+Then replace the inner iteration loop (lines 64-75 of the original) to use cached solver. The key change is inside `solveTransient`: create the solver once before the time-stepping loop, and reuse it across all timesteps and Newton iterations.
+
+Replace lines 62-75 (the inner NR loop that calls `solveLU`):
+
+```typescript
+    // Before the while loop, add:
+    const solver = createSparseSolver();
+    let csc: CscMatrix | null = null;
+    let scatter: ScatterMap | null = null;
+    let patternAnalyzed = false;
+```
+
+And inside the inner `for` loop, replace:
+
+```typescript
+      const x = solveLU(assembler.G, new Float64Array(assembler.b));
+```
+
+with:
+
+```typescript
+      if (!patternAnalyzed) {
+        const result = toCsc(assembler.G);
+        csc = result.csc;
+        scatter = result.scatter;
+        solver.analyzePattern(csc);
+        patternAnalyzed = true;
+      } else {
+        updateCscValues(csc!, assembler.G, scatter!);
+      }
+      solver.factorize(csc!);
+      const x = solver.solve(new Float64Array(assembler.b));
+```
+
+Remove the `solveLU` import.
+
+- [ ] **Step 3: Update simulate.ts streaming transient path**
+
+In `packages/core/src/simulate.ts`, the `streamTransient` generator (line 117) has an identical inner loop calling `solveLU` at line 157. Apply the same change:
+
+Update imports — add:
+```typescript
+import { toCsc, updateCscValues, type ScatterMap, type CscMatrix } from './solver/csc-matrix.js';
+import { createSparseSolver } from './solver/sparse-solver.js';
+```
+
+Remove from imports: `solveLU` (but keep `solveComplexLU` for now — used in `streamAC`).
+
+In `streamTransient`, add before the `while` loop:
+```typescript
+  const solver = createSparseSolver();
+  let csc: CscMatrix | null = null;
+  let scatter: ScatterMap | null = null;
+  let patternAnalyzed = false;
+```
+
+Replace `const x = solveLU(assembler.G, new Float64Array(assembler.b));` at line 157 with:
+```typescript
+      if (!patternAnalyzed) {
+        const result = toCsc(assembler.G);
+        csc = result.csc;
+        scatter = result.scatter;
+        solver.analyzePattern(csc);
+        patternAnalyzed = true;
+      } else {
+        updateCscValues(csc!, assembler.G, scatter!);
+      }
+      solver.factorize(csc!);
+      const x = solver.solve(new Float64Array(assembler.b));
+```
+
+- [ ] **Step 4: Run transient tests and streaming tests**
+
+Run: `cd packages/core && npx vitest run src/analysis/transient.test.ts src/simulate.stream.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cd packages/core && npx vitest run`
+Expected: ALL tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/analysis/transient.ts packages/core/src/simulate.ts
+git commit -m "perf: cache symbolic factorization across transient timesteps"
+```
+
+---
+
+### Task 9: AC Analysis Pattern Caching
+
+**Files:**
+- Modify: `packages/core/src/analysis/ac.ts`
+- Modify: `packages/core/src/simulate.ts` (streaming AC path)
+
+- [ ] **Step 1: Run AC tests to establish baseline**
+
+Run: `cd packages/core && npx vitest run src/analysis/ac.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Update ac.ts to cache symbolic factorization across frequencies**
+
+In AC analysis, `G` is fixed and `Yimag = omega * C` changes only in values (not pattern) across frequencies. The 2n×2n combined matrix pattern is therefore fixed. We can do symbolic factorization once and reuse it.
+
+Replace `packages/core/src/analysis/ac.ts` imports:
+
+```typescript
+import type { ResolvedOptions, ACAnalysis } from '../types.js';
+import type { CompiledCircuit } from '../circuit.js';
+import { MNAAssembler } from '../mna/assembler.js';
+import { SparseMatrix } from '../solver/sparse-matrix.js';
+import { toCsc, updateCscValues, type ScatterMap, type CscMatrix } from '../solver/csc-matrix.js';
+import { createSparseSolver } from '../solver/sparse-solver.js';
+import { ACResult } from '../results.js';
+```
+
+Replace the frequency loop (lines 50-88) with:
+
+```typescript
+  // Build the 2n×2n combined matrix once at the first frequency to get the pattern
+  const solver = createSparseSolver();
+  let csc: CscMatrix | null = null;
+  let scatter: ScatterMap | null = null;
+  let patternAnalyzed = false;
+
+  for (const freq of frequencies) {
+    const omega = 2 * Math.PI * freq;
+
+    // Build 2n×2n real system: [G, -wC; wC, G]
+    const combined = new SparseMatrix(2 * systemSize);
+    for (let i = 0; i < systemSize; i++) {
+      for (const [j, val] of G.getRow(i)) {
+        combined.add(i, j, val);
+        combined.add(i + systemSize, j + systemSize, val);
+      }
+    }
+    for (let i = 0; i < systemSize; i++) {
+      const row = C.getRow(i);
+      for (const [j, cval] of row) {
+        combined.add(i, j + systemSize, -omega * cval);
+        combined.add(i + systemSize, j, omega * cval);
+      }
+    }
+
+    if (!patternAnalyzed) {
+      const result = toCsc(combined);
+      csc = result.csc;
+      scatter = result.scatter;
+      solver.analyzePattern(csc);
+      patternAnalyzed = true;
+    } else {
+      updateCscValues(csc!, combined, scatter!);
+    }
+    solver.factorize(csc!);
+
+    // RHS
+    const b = new Float64Array(2 * systemSize);
+    if (excitationRow >= 0) {
+      const phaseRad = (excitationPhase * Math.PI) / 180;
+      b[excitationRow] = excitationMag * Math.cos(phaseRad);
+      b[excitationRow + systemSize] = excitationMag * Math.sin(phaseRad);
+    }
+
+    const x = solver.solve(b);
+    const xReal = x.slice(0, systemSize);
+    const xImag = x.slice(systemSize);
+
+    // Extract results
+    for (let i = 0; i < nodeNames.length; i++) {
+      const re = xReal[i], im = xImag[i];
+      voltageArrays.get(nodeNames[i])!.push({
+        magnitude: Math.sqrt(re * re + im * im),
+        phase: (Math.atan2(im, re) * 180) / Math.PI,
+      });
+    }
+    for (let i = 0; i < branchNames.length; i++) {
+      const re = xReal[nodeCount + i], im = xImag[nodeCount + i];
+      currentArrays.get(branchNames[i])!.push({
+        magnitude: Math.sqrt(re * re + im * im),
+        phase: (Math.atan2(im, re) * 180) / Math.PI,
+      });
+    }
+  }
+```
+
+- [ ] **Step 3: Update simulate.ts streaming AC path**
+
+Apply the same change to `streamAC` in `simulate.ts` (lines 209-283). Same pattern: create solver once before the frequency loop, symbolic once, numeric per frequency.
+
+Remove `solveComplexLU` from the imports in `simulate.ts` (no longer used anywhere). Also remove `SparseMatrix` import if no longer directly used (check first — it may still be needed by `streamAC`). Keep the `SparseMatrix` import since `streamAC` builds `combined` with it.
+
+- [ ] **Step 4: Run AC tests and streaming tests**
+
+Run: `cd packages/core && npx vitest run src/analysis/ac.test.ts src/simulate.stream.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cd packages/core && npx vitest run`
+Expected: ALL tests PASS
+
+- [ ] **Step 6: Clean up unused imports in simulate.ts**
+
+After all changes, `simulate.ts` should no longer import `solveLU` or `solveComplexLU`. Remove those imports. It should still import `SparseMatrix` (used to build the combined matrix in `streamAC`), `buildCompanionSystem`, `MNAAssembler`.
+
+Also check `lu-solver.ts` — `solveComplexLU` is no longer called by anyone. Keep it exported for now (public API backward compat), but it internally uses the sparse solver already (from Task 6).
+
+- [ ] **Step 7: Run full test suite one final time**
+
+Run: `cd packages/core && npx vitest run`
+Expected: ALL tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/analysis/ac.ts packages/core/src/simulate.ts
+git commit -m "perf: cache symbolic factorization across AC frequency sweep"
+```
+
+---
+
+### Task 10: Regression Verification and Benchmarks
+
+**Files:**
+- No new files — run existing tests and benchmarks
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd packages/core && npx vitest run`
+Expected: ALL tests PASS
+
+- [ ] **Step 2: Run type checker**
+
+Run: `cd packages/core && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 3: Run existing benchmarks**
+
+Run: `cd packages/core && npx vitest bench --config vitest.bench.config.ts`
+
+Record the results. Compare mentally against any prior baseline. The sparse solver should show improvement on larger circuits (OTA, CMOS inverter) and roughly parity on tiny ones (2-node resistor divider).
+
+- [ ] **Step 4: Commit benchmark config if any changes were needed**
+
+If no changes were needed (likely), skip this step.
+
+- [ ] **Step 5: Final commit for any cleanup**
+
+```bash
+git add -A
+git commit -m "chore: sparse LU solver implementation complete"
+```

--- a/docs/superpowers/specs/2026-04-11-controlled-sources-design.md
+++ b/docs/superpowers/specs/2026-04-11-controlled-sources-design.md
@@ -1,0 +1,147 @@
+# Controlled Sources (E/G/H/F) — Design Spec
+
+**Date:** 2026-04-11
+**Status:** Approved
+
+## Overview
+
+Add support for the four SPICE controlled (dependent) source types to spice-ts:
+
+| SPICE element | Type | Symbol |
+|---|---|---|
+| E | Voltage-Controlled Voltage Source (VCVS) | Gain (V/V) |
+| G | Voltage-Controlled Current Source (VCCS) | Transconductance (A/V) |
+| H | Current-Controlled Voltage Source (CCVS) | Transimpedance (V/A) |
+| F | Current-Controlled Current Source (CCCS) | Current gain (A/A) |
+
+All four sources are linear and support DC, transient, and AC analysis.
+
+## MNA Stamps
+
+All indices use `bi = numNodes + branchIndex` for branch rows/columns.
+
+### VCCS (G) — no branch variable
+
+```
+G(n+, nc+) += gm     G(n+, nc-) -= gm
+G(n-, nc+) -= gm     G(n-, nc-) += gm
+```
+
+### VCVS (E) — 1 new branch (like a voltage source)
+
+```
+G(n+, bi)  += 1      G(n-, bi)  -= 1       ← KCL coupling
+G(bi, n+)  += 1      G(bi, n-)  -= 1       ← KVL constraint row
+G(bi, nc+) -= gain   G(bi, nc-) += gain    ← control voltage coupling
+b(bi) = 0
+```
+
+### CCCS (F) — no new branch; stamps into controlling V-source's branch column
+
+```
+G(n+, bi_ctrl) += gain
+G(n-, bi_ctrl) -= gain
+```
+
+### CCVS (H) — 1 new branch; stamps into own branch row and controlling branch column
+
+```
+G(n+, bi)      += 1      G(n-, bi)      -= 1    ← KCL coupling
+G(bi, n+)      += 1      G(bi, n-)      -= 1    ← KVL constraint row
+G(bi, bi_ctrl) -= gain                           ← control current coupling
+b(bi) = 0
+```
+
+All four are linear (`isNonlinear = false`). `stampAC()` uses identical stamps as `stamp()` — no omega dependence.
+
+## File Structure
+
+Four new device files, one per source type, following the existing pattern:
+
+```
+src/devices/vcvs.ts     VCVS class
+src/devices/vccs.ts     VCCS class
+src/devices/ccvs.ts     CCVS class
+src/devices/cccs.ts     CCCS class
+```
+
+Exported from `src/devices/index.ts`.
+
+## Circuit API
+
+Four new methods on the `Circuit` class:
+
+```typescript
+addVCVS(name: string, nPlus: string, nMinus: string, ncPlus: string, ncMinus: string, gain: number): void
+addVCCS(name: string, nPlus: string, nMinus: string, ncPlus: string, ncMinus: string, gm: number): void
+addCCVS(name: string, nPlus: string, nMinus: string, controlSource: string, gain: number): void
+addCCCS(name: string, nPlus: string, nMinus: string, controlSource: string, gain: number): void
+```
+
+`controlSource` is the name of a voltage source whose branch current is the controlling quantity.
+
+A new optional `controlSource?: string` field is added to `DeviceDescriptor`. The existing `value` field carries the gain/gm scalar.
+
+## Compilation Strategy
+
+`compile()` in `circuit.ts` is updated with a two-pass approach:
+
+**Pass 1 — branch counting:** Iterate descriptors, count all sources that need a branch variable: V, L (existing), E, H (new). This sets `numBranches` before the MNA matrix is allocated.
+
+**Pass 2 — device instantiation:** Iterate descriptors again, assign branch indices sequentially, maintain a `Map<string, DeviceModel>` populated as each device is built. When an H or F descriptor is reached, look up the controlling source by name in this map to retrieve `branches[0]`. If the controlling source is not found, throw a descriptive error.
+
+The controlling V-source must be declared before the H or F element in the netlist (or in programmatic `addCCVS`/`addCCCS` calls). This is an implementation constraint: the forward pass populates the device map in order, so a forward reference will produce a clear error at compile time. Standard SPICE has no such ordering requirement; this constraint may be lifted in a future two-pass compilation.
+
+## Parser
+
+New cases in `parseDevice()` (`src/parser/index.ts`):
+
+| Element | Syntax | Tokens |
+|---|---|---|
+| E | `E<name> n+ n- nc+ nc- gain` | 7 |
+| G | `G<name> n+ n- nc+ nc- gm` | 7 |
+| H | `H<name> n+ n- Vsense gain` | 6 |
+| F | `F<name> n+ n- Vsense gain` | 6 |
+
+Gain/gm values are parsed through the existing `parseNumber()` function — SI suffixes and parametric expressions work automatically.
+
+## Testing
+
+### Unit tests — `src/devices/controlled-sources.test.ts`
+
+One `describe` block per source type. Each test:
+1. Constructs an `MNAAssembler` with the correct node/branch count
+2. Calls `stamp()` on the device
+3. Asserts exact G matrix entries and b vector values
+
+### Integration tests
+
+Full DC operating-point circuits with closed-form expected values:
+
+| Circuit | Source used | Expected result |
+|---|---|---|
+| Transconductance amp (Vin, R_load) | VCCS | Vout = gm × Vin × R_load |
+| Voltage amplifier | VCVS | Vout = gain × Vin |
+| Transimpedance amp (V-sense resistor) | CCVS | Vout = gain × I_sense |
+| Current mirror | CCCS | I_out = gain × I_sense |
+
+One AC integration test: inverting op-amp model using a VCVS (gain = −1×10^5) with feedback resistors. Verify closed-loop gain at mid-band matches −Rf/Rin.
+
+### Parser tests
+
+Netlist strings for all four element types added to the existing parser test suite, verifying device type and parameter values.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/devices/vcvs.ts` | New |
+| `src/devices/vccs.ts` | New |
+| `src/devices/ccvs.ts` | New |
+| `src/devices/cccs.ts` | New |
+| `src/devices/index.ts` | Export four new classes |
+| `src/circuit.ts` | Add four API methods; update `DeviceDescriptor`; extend `compile()` with two-pass branch counting and E/G/H/F cases |
+| `src/parser/index.ts` | Add E/G/H/F cases to `parseDevice()` |
+| `src/devices/controlled-sources.test.ts` | New unit tests |
+| `src/circuit.test.ts` (or new integration file) | New integration tests |
+| `src/parser/parser.test.ts` | New parser test cases |

--- a/docs/superpowers/specs/2026-04-11-sparse-lu-design.md
+++ b/docs/superpowers/specs/2026-04-11-sparse-lu-design.md
@@ -1,0 +1,259 @@
+# Sparse LU Solver with Gilbert-Peierls Factorization
+
+**Date:** 2026-04-11
+**Status:** Draft
+**ROADMAP ref:** Issue #8 — Sparse LU solver (replace dense O(n³))
+
+## Summary
+
+Replace the dense O(n³) LU solver with a sparse Gilbert-Peierls implementation, backed by a CSC (Compressed Sparse Column) matrix format. The solver splits work into a **symbolic phase** (once per circuit topology) and a **numeric phase** (every Newton-Raphson step), exploiting the fact that SPICE matrix sparsity patterns are fixed within a simulation. A `SparseSolver` interface provides the abstraction boundary for a future KLU WASM plugin.
+
+## Goals
+
+- **Performance**: O(nnz of L+U) per solve instead of O(n³) — enables 50–300+ node circuits
+- **WASM-ready**: `SparseSolver` interface designed so a KLU WASM plugin is a drop-in replacement
+- **Zero regression**: all existing tests pass with identical results
+- **Zero dependency**: pure TypeScript, no external libraries
+
+## Non-Goals
+
+- KLU WASM plugin (future work — separate spec)
+- Changing the assembly path (Map-of-Maps stamping stays as-is)
+- Fill-reducing reordering (AMD/nested dissection — future optimization)
+- Direct CSC stamping (eliminating Map-of-Maps entirely — future optimization)
+
+---
+
+## Architecture
+
+### Three-Layer Design
+
+```
+Assembly (unchanged)          Compute representation       Solver
+────────────────────          ─────────────────────        ──────────
+SparseMatrix                  CscMatrix                    SparseSolver (interface)
+Map-of-Maps                   typed arrays                   ├── GilbertPeierlsSolver (TS)
+Good for incremental   ──▶   colPtr/rowIdx/values    ──▶    └── KluWasmSolver (future)
+stamping                      Good for factorization
+```
+
+The existing `SparseMatrix` (Map-of-Maps) remains the assembly format — devices stamp into it via `StampContext`. Before each solve, it is converted to `CscMatrix` (typed arrays). The `SparseSolver` operates exclusively on `CscMatrix`.
+
+### Key Insight: Pattern Reuse
+
+In Newton-Raphson iteration, the MNA matrix `G` is cleared and re-stamped every step. The sparsity pattern (which positions are non-zero) never changes — same devices, same topology. Only the values change as nonlinear devices update their linearizations.
+
+This means:
+- **Symbolic factorization** (DFS to predict fill-in): runs **once** per simulation
+- **Numeric factorization** (compute L and U values): runs **every Newton step**
+
+For AC analysis, `G` and `C` are both fixed at the DC operating point. The combined 2n×2n real matrix has a fixed pattern across all frequency points — symbolic once, numeric per frequency.
+
+---
+
+## CscMatrix Storage Format
+
+Compressed Sparse Column — the industry standard for sparse direct solvers.
+
+```typescript
+interface CscMatrix {
+  readonly size: number;          // n×n dimension
+  readonly colPtr: Int32Array;    // length n+1; entries for column j at indices colPtr[j]..colPtr[j+1]-1
+  readonly rowIdx: Int32Array;    // length nnz; row index of each non-zero
+  readonly values: Float64Array;  // length nnz; corresponding values
+}
+```
+
+### Example
+
+```
+Matrix:              CSC representation:
+[2  0  1]            colPtr = [0, 2, 3, 5]
+[0  3  0]            rowIdx = [0, 2, 1, 0, 2]
+[4  0  5]            values = [2, 4, 3, 1, 5]
+```
+
+### Conversion from Map-of-Maps
+
+`toCsc(sparse: SparseMatrix): { csc: CscMatrix, scatter: ScatterMap }` — iterate by column, count nnz per column, build typed arrays. O(nnz).
+
+### ScatterMap for Value-Only Updates
+
+On the first conversion, we build a `ScatterMap` — maps `(row, col)` to CSC array index. On subsequent Newton-Raphson iterations, instead of rebuilding CSC from scratch, we zero the values array and scatter new values into their pre-computed CSC positions. O(nnz) with no structural allocation.
+
+```typescript
+type ScatterMap = Map<number, number>;  // (row * size + col) → CSC index
+// Encoding safe for size ≤ 46340 (sqrt(2^31)); well beyond target range of ≤ 300 nodes
+```
+
+---
+
+## SparseSolver Interface
+
+```typescript
+interface SparseSolver {
+  /** Analyze sparsity pattern — call once per circuit topology */
+  analyzePattern(A: CscMatrix): void;
+
+  /** Numeric factorization — call each Newton step (same pattern, new values) */
+  factorize(A: CscMatrix): void;
+
+  /** Solve Ax = b, returns solution vector */
+  solve(b: Float64Array): Float64Array;
+}
+
+/** Factory — returns GilbertPeierlsSolver now, KluWasmSolver later */
+function createSparseSolver(): SparseSolver;
+```
+
+Three methods, stateful. The solver holds the symbolic structure and numeric factors internally. The interface is intentionally minimal — a KLU WASM plugin implements these three methods and nothing else.
+
+---
+
+## Gilbert-Peierls Algorithm
+
+### Symbolic Phase (`analyzePattern`)
+
+For each column j = 0..n-1:
+1. DFS through the existing non-zero structure of A to compute the "reach" — which rows will have non-zeros in L[:,j] and U[j,:] after fill-in
+2. Record the topological ordering for the numeric phase
+
+Output: pre-sized `Int32Array`/`Float64Array` for L and U factors, plus a row permutation array for pivoting. Complexity: O(nnz of L+U).
+
+### Numeric Phase (`factorize`)
+
+For each column j in topological order:
+1. Sparse triangular solve: scatter column j of A into a dense work vector, then subtract contributions from earlier columns of L using the symbolic structure
+2. Apply threshold pivoting: if `|diag| < threshold × |max_in_column|`, swap rows
+3. Scale L column by 1/pivot, store U row values
+
+Uses the pre-allocated structure from the symbolic phase — **no allocation**. Complexity: O(nnz of L+U).
+
+### Solve Phase (`solve`)
+
+1. Forward substitution: Ly = Pb (sparse, using CSC structure of L)
+2. Backward substitution: Ux = y (sparse, using CSC structure of U)
+
+Complexity: O(nnz of L+U).
+
+### Pivoting Strategy
+
+Full partial pivoting would invalidate the symbolic factorization. Threshold pivoting is the standard compromise:
+- Within each column's symbolic pattern, check if `|diag| < threshold × |max_in_column|`
+- If so, swap the diagonal row with the maximum row
+- The symbolic structure is computed as a superset that accommodates possible row swaps
+
+In practice, SPICE matrices are near-diagonally-dominant due to GMIN (added to all diagonals). Pivots are rare.
+
+---
+
+## Integration
+
+### Newton-Raphson
+
+No signature change to `newtonRaphson()`. The solver is created inside and reused across iterations:
+
+```typescript
+export function newtonRaphson(assembler, devices, options, maxIter, nodeNames): number {
+  const solver = createSparseSolver();
+  let patternAnalyzed = false;
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    assembler.saveSolution();
+    assembler.clear();
+    // ... stamp devices, add GMIN ...
+
+    const csc = toCsc(assembler.G);
+    if (!patternAnalyzed) {
+      solver.analyzePattern(csc);
+      patternAnalyzed = true;
+    }
+    solver.factorize(csc);
+    const x = solver.solve(new Float64Array(assembler.b));
+    assembler.solution.set(x);
+    // ... convergence check ...
+  }
+}
+```
+
+First iteration pays for symbolic analysis. Iterations 2+ are numeric-only.
+
+### AC Analysis
+
+The 2n×2n real matrix doubling strategy is kept. Since G and C are fixed per operating point, the combined pattern is identical across all frequency points:
+
+```typescript
+// Before frequency sweep:
+solver.analyzePattern(combined2n);    // once
+
+// Per frequency:
+updateCombinedValues(combined2n, G, C, omega);
+solver.factorize(combined2n);
+const x = solver.solve(b);
+```
+
+Symbolic factorization runs once for the entire AC sweep — major win for sweeps with hundreds of frequency points.
+
+### What Stays the Same
+
+- `SparseMatrix` class — unchanged
+- `MNAAssembler` — unchanged
+- `StampContext` — unchanged
+- All device `stamp()` methods — unchanged
+- `solveComplexLU` external signature — unchanged (internally delegates to SparseSolver)
+
+---
+
+## File Organization
+
+All changes within `packages/core/src/solver/`:
+
+```
+solver/
+  sparse-matrix.ts        (existing — unchanged)
+  sparse-matrix.test.ts   (existing — unchanged)
+  lu-solver.ts            (existing — solveLU/solveComplexLU become wrappers around SparseSolver)
+  lu-solver.test.ts       (existing — tests still pass, now exercising sparse path)
+  csc-matrix.ts           (new — CscMatrix type, toCsc(), ScatterMap, updateCscValues)
+  csc-matrix.test.ts      (new)
+  sparse-solver.ts        (new — SparseSolver interface, createSparseSolver factory)
+  gilbert-peierls.ts      (new — GilbertPeierlsSolver implementation)
+  gilbert-peierls.test.ts (new)
+```
+
+Three new source files, three new test files. One existing file updated (`lu-solver.ts`). One existing file updated (`newton-raphson.ts`).
+
+---
+
+## Testing Strategy
+
+### CscMatrix (`csc-matrix.test.ts`)
+
+- Round-trip: Map-of-Maps → CSC → dense matches original matrix
+- Empty matrix, single element, full diagonal
+- ScatterMap: value-only update produces correct CSC values
+- Column ordering is correct (rowIdx sorted within each column)
+
+### Gilbert-Peierls (`gilbert-peierls.test.ts`)
+
+- Known small systems: 2×2, 3×3, 5×5 — verify solve produces correct x for known Ax = b
+- Verify L × U = P × A (factorization correctness)
+- Matrix requiring threshold pivot: off-diagonal dominant column still solves correctly
+- Singular matrix: throws `SingularMatrixError` (same as current behavior)
+- Identity matrix: trivial case works
+- Tridiagonal matrix: typical SPICE-like sparsity pattern
+
+### Regression (existing test suites)
+
+All existing tests pass unchanged — DC, transient, AC, DC sweep, BSIM3, subcircuit expansion. These are the real correctness tests. If the sparse solver produces identical results on every existing circuit, it works.
+
+### Benchmarks
+
+Compare old dense vs new sparse on existing benchmark circuits:
+- Diff pair (BJT DC)
+- RC ladder 5-stage (AC)
+- One-stage OTA (DC)
+- CMOS inverter (transient)
+- Bandpass RLC (AC)
+
+Expect visible improvement on larger circuits, parity or slight overhead on very small ones (n < 10).

--- a/packages/core/src/circuit.test.ts
+++ b/packages/core/src/circuit.test.ts
@@ -65,6 +65,36 @@ describe('Circuit', () => {
     expect(idx1).not.toBe(idx2);
   });
 
+  describe('controlled source API', () => {
+    it('addVCCS registers 4 nodes and no branches', () => {
+      const ckt = new Circuit();
+      ckt.addVCCS('G1', 'out', '0', 'in', '0', 0.01);
+      expect(ckt.nodeCount).toBe(2);
+      expect(ckt.branchCount).toBe(0);
+    });
+
+    it('addVCVS registers 4 nodes and 1 branch', () => {
+      const ckt = new Circuit();
+      ckt.addVCVS('E1', 'out', '0', 'in', '0', 10);
+      expect(ckt.nodeCount).toBe(2);
+      expect(ckt.branchCount).toBe(1);
+    });
+
+    it('addCCCS registers 2 output nodes and no branch', () => {
+      const ckt = new Circuit();
+      ckt.addVoltageSource('Vsense', '1', '0', { dc: 0 });
+      ckt.addCCCS('F1', 'out', '0', 'Vsense', 3);
+      expect(ckt.branchCount).toBe(1);
+    });
+
+    it('addCCVS registers 2 output nodes and 1 branch', () => {
+      const ckt = new Circuit();
+      ckt.addVoltageSource('Vsense', '1', '0', { dc: 0 });
+      ckt.addCCVS('H1', 'out', '0', 'Vsense', 1000);
+      expect(ckt.branchCount).toBe(2);
+    });
+  });
+
   describe('subcircuit expansion', () => {
     it('expands a simple subcircuit with correct nodes', () => {
       const ckt = new Circuit();

--- a/packages/core/src/circuit.test.ts
+++ b/packages/core/src/circuit.test.ts
@@ -387,5 +387,68 @@ describe('Circuit', () => {
       const compiled = ckt.compile();
       expect(compiled.devices).toHaveLength(2);
     });
+
+    it('expands subcircuit with VCCS (G device)', () => {
+      const ckt = new Circuit();
+      ckt.addSubcircuit({
+        name: 'gamp',
+        ports: ['inp', 'out', 'gnd'],
+        params: {},
+        body: ['G1 out gnd inp gnd 10m', 'R1 out gnd 1k'],
+      });
+      ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'gamp');
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'X1.G1')).toBeDefined();
+    });
+
+    it('expands subcircuit with VCVS (E device)', () => {
+      const ckt = new Circuit();
+      ckt.addSubcircuit({
+        name: 'eamp',
+        ports: ['inp', 'out', 'gnd'],
+        params: {},
+        body: ['E1 out gnd inp gnd 10'],
+      });
+      ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'eamp');
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addResistor('RL', '2', '0', 1e3);
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'X1.E1')).toBeDefined();
+    });
+
+    it('expands subcircuit with CCCS (F device)', () => {
+      const ckt = new Circuit();
+      ckt.addSubcircuit({
+        name: 'famp',
+        ports: ['inp', 'out', 'gnd'],
+        params: {},
+        body: ['Vs inp mid DC 0', 'R1 mid gnd 1k', 'F1 out gnd Vs 5'],
+      });
+      ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'famp');
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addResistor('RL', '2', '0', 1e3);
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'X1.F1')).toBeDefined();
+    });
+
+    it('expands subcircuit with CCVS (H device)', () => {
+      const ckt = new Circuit();
+      ckt.addSubcircuit({
+        name: 'hamp',
+        ports: ['inp', 'out', 'gnd'],
+        params: {},
+        body: ['Vs inp mid DC 0', 'R1 mid gnd 1k', 'H1 out gnd Vs 1k'],
+      });
+      ckt.addSubcircuitInstance('X1', ['1', '2', '0'], 'hamp');
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addResistor('RL', '2', '0', 1e3);
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'X1.H1')).toBeDefined();
+    });
   });
 });

--- a/packages/core/src/circuit.test.ts
+++ b/packages/core/src/circuit.test.ts
@@ -95,6 +95,70 @@ describe('Circuit', () => {
     });
   });
 
+  describe('controlled source compilation', () => {
+    it('compiles VCCS into a device', () => {
+      const ckt = new Circuit();
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addVCCS('G1', '2', '0', '1', '0', 0.01);
+      ckt.addResistor('RL', '2', '0', 1e3);
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'G1')).toBeDefined();
+    });
+
+    it('compiles VCVS with a branch', () => {
+      const ckt = new Circuit();
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addVCVS('E1', '2', '0', '1', '0', 10);
+      ckt.addResistor('RL', '2', '0', 1e3);
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.branchCount).toBe(2);
+      expect(compiled.devices.find(d => d.name === 'E1')).toBeDefined();
+    });
+
+    it('compiles CCCS resolving controlling V-source', () => {
+      const ckt = new Circuit();
+      ckt.addVoltageSource('Vsense', '1', '2', { dc: 0 });
+      ckt.addResistor('R1', '2', '0', 1e3);
+      ckt.addCCCS('F1', '3', '0', 'Vsense', 5);
+      ckt.addResistor('RL', '3', '0', 1e3);
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'F1')).toBeDefined();
+    });
+
+    it('compiles CCVS with own branch + controlling reference', () => {
+      const ckt = new Circuit();
+      ckt.addVoltageSource('Vsense', '1', '2', { dc: 0 });
+      ckt.addResistor('R1', '2', '0', 1e3);
+      ckt.addCCVS('H1', '3', '0', 'Vsense', 1000);
+      ckt.addResistor('RL', '3', '0', 1e3);
+      ckt.addVoltageSource('V1', '1', '0', { dc: 1 });
+      ckt.addAnalysis('op');
+      const compiled = ckt.compile();
+      expect(compiled.branchCount).toBe(3);
+      expect(compiled.devices.find(d => d.name === 'H1')).toBeDefined();
+    });
+
+    it('throws when CCCS references undefined V-source', () => {
+      const ckt = new Circuit();
+      ckt.addCCCS('F1', '1', '0', 'Vnope', 5);
+      ckt.addResistor('R1', '1', '0', 1e3);
+      ckt.addAnalysis('op');
+      expect(() => ckt.compile()).toThrow('Vnope');
+    });
+
+    it('throws when CCVS references undefined V-source', () => {
+      const ckt = new Circuit();
+      ckt.addCCVS('H1', '1', '0', 'Vnope', 1000);
+      ckt.addResistor('R1', '1', '0', 1e3);
+      ckt.addAnalysis('op');
+      expect(() => ckt.compile()).toThrow('Vnope');
+    });
+  });
+
   describe('subcircuit expansion', () => {
     it('expands a simple subcircuit with correct nodes', () => {
       const ckt = new Circuit();

--- a/packages/core/src/circuit.ts
+++ b/packages/core/src/circuit.ts
@@ -57,7 +57,9 @@ export class Circuit {
   }
 
   get branchCount(): number {
-    return this.descriptors.filter(d => d.type === 'V' || d.type === 'L').length;
+    return this.descriptors.filter(d =>
+      d.type === 'V' || d.type === 'L' || d.type === 'E' || d.type === 'H',
+    ).length;
   }
 
   getNodeIndex(name: string): number {
@@ -100,6 +102,34 @@ export class Circuit {
     this.nodeSet.add(nodePos);
     this.nodeSet.add(nodeNeg);
     this.descriptors.push({ type: 'I', name, nodes: [nodePos, nodeNeg], waveform });
+  }
+
+  addVCVS(name: string, nOutP: string, nOutN: string, nCtrlP: string, nCtrlN: string, gain: number): void {
+    this.nodeSet.add(nOutP);
+    this.nodeSet.add(nOutN);
+    this.nodeSet.add(nCtrlP);
+    this.nodeSet.add(nCtrlN);
+    this.descriptors.push({ type: 'E', name, nodes: [nOutP, nOutN, nCtrlP, nCtrlN], value: gain });
+  }
+
+  addVCCS(name: string, nOutP: string, nOutN: string, nCtrlP: string, nCtrlN: string, gm: number): void {
+    this.nodeSet.add(nOutP);
+    this.nodeSet.add(nOutN);
+    this.nodeSet.add(nCtrlP);
+    this.nodeSet.add(nCtrlN);
+    this.descriptors.push({ type: 'G', name, nodes: [nOutP, nOutN, nCtrlP, nCtrlN], value: gm });
+  }
+
+  addCCVS(name: string, nOutP: string, nOutN: string, controlSource: string, gain: number): void {
+    this.nodeSet.add(nOutP);
+    this.nodeSet.add(nOutN);
+    this.descriptors.push({ type: 'H', name, nodes: [nOutP, nOutN], value: gain, controlSource });
+  }
+
+  addCCCS(name: string, nOutP: string, nOutN: string, controlSource: string, gain: number): void {
+    this.nodeSet.add(nOutP);
+    this.nodeSet.add(nOutN);
+    this.descriptors.push({ type: 'F', name, nodes: [nOutP, nOutN], value: gain, controlSource });
   }
 
   addDiode(name: string, nodeAnode: string, nodeCathode: string, modelName?: string): void {

--- a/packages/core/src/circuit.ts
+++ b/packages/core/src/circuit.ts
@@ -9,6 +9,10 @@ import { Diode } from './devices/diode.js';
 import { BJT } from './devices/bjt.js';
 import { MOSFET } from './devices/mosfet.js';
 import { BSIM3v3 } from './devices/bsim3v3.js';
+import { VCCS } from './devices/vccs.js';
+import { VCVS } from './devices/vcvs.js';
+import { CCCS } from './devices/cccs.js';
+import { CCVS } from './devices/ccvs.js';
 import { GROUND_NODE } from './types.js';
 import { evaluateExpression } from './parser/expression.js';
 import { parseNumber, tokenizeNetlist } from './parser/tokenizer.js';
@@ -257,9 +261,11 @@ export class Circuit {
     };
 
     const devices: DeviceModel[] = [];
+    const deviceMap = new Map<string, DeviceModel>();
 
     for (const desc of expandedDescriptors) {
       const nodeIndices = desc.nodes.map(resolveNode);
+      const prevLength = devices.length;
 
       switch (desc.type) {
         case 'R':
@@ -325,8 +331,46 @@ export class Circuit {
           }
           break;
         }
+        case 'G': {
+          devices.push(new VCCS(desc.name, nodeIndices, desc.value!));
+          break;
+        }
+        case 'E': {
+          const bi = branchIndex++;
+          branchNames.push(desc.name);
+          devices.push(new VCVS(desc.name, nodeIndices, bi, desc.value!));
+          break;
+        }
+        case 'F': {
+          const ctrlName = desc.controlSource!;
+          const ctrlDev = deviceMap.get(ctrlName);
+          if (!ctrlDev || ctrlDev.branches.length === 0) {
+            throw new Error(
+              `CCCS '${desc.name}' references unknown or branchless source '${ctrlName}'`,
+            );
+          }
+          devices.push(new CCCS(desc.name, nodeIndices, ctrlDev.branches[0], desc.value!));
+          break;
+        }
+        case 'H': {
+          const ctrlName = desc.controlSource!;
+          const ctrlDev = deviceMap.get(ctrlName);
+          if (!ctrlDev || ctrlDev.branches.length === 0) {
+            throw new Error(
+              `CCVS '${desc.name}' references unknown or branchless source '${ctrlName}'`,
+            );
+          }
+          const bi = branchIndex++;
+          branchNames.push(desc.name);
+          devices.push(new CCVS(desc.name, nodeIndices, ctrlDev.branches[0], bi, desc.value!));
+          break;
+        }
         default:
           throw new Error(`Device type '${desc.type}' not yet implemented`);
+      }
+
+      if (devices.length > prevLength) {
+        deviceMap.set(desc.name, devices[devices.length - 1]);
       }
     }
 

--- a/packages/core/src/circuit.ts
+++ b/packages/core/src/circuit.ts
@@ -36,6 +36,7 @@ interface DeviceDescriptor {
   waveform?: Partial<SourceWaveform> & { dc?: number };
   modelName?: string;
   params?: Record<string, number>;
+  controlSource?: string;
 }
 
 export class Circuit {

--- a/packages/core/src/circuit.ts
+++ b/packages/core/src/circuit.ts
@@ -618,6 +618,44 @@ export class Circuit {
           });
           break;
         }
+        case 'E': {
+          const valStr = evalToken(tokens[5]);
+          result.push({
+            type: 'E', name: devName,
+            nodes: [mapNode(tokens[1]), mapNode(tokens[2]), mapNode(tokens[3]), mapNode(tokens[4])],
+            value: parseNumber(valStr),
+          });
+          break;
+        }
+        case 'G': {
+          const valStr = evalToken(tokens[5]);
+          result.push({
+            type: 'G', name: devName,
+            nodes: [mapNode(tokens[1]), mapNode(tokens[2]), mapNode(tokens[3]), mapNode(tokens[4])],
+            value: parseNumber(valStr),
+          });
+          break;
+        }
+        case 'H': {
+          const valStr = evalToken(tokens[4]);
+          result.push({
+            type: 'H', name: devName,
+            nodes: [mapNode(tokens[1]), mapNode(tokens[2])],
+            controlSource: `${instanceName}.${tokens[3]}`,
+            value: parseNumber(valStr),
+          });
+          break;
+        }
+        case 'F': {
+          const valStr = evalToken(tokens[4]);
+          result.push({
+            type: 'F', name: devName,
+            nodes: [mapNode(tokens[1]), mapNode(tokens[2])],
+            controlSource: `${instanceName}.${tokens[3]}`,
+            value: parseNumber(valStr),
+          });
+          break;
+        }
         case 'X': {
           // Nested subcircuit instance — recursively expand
           let subcktIdx = tokens.length - 1;

--- a/packages/core/src/controlled-sources-integration.test.ts
+++ b/packages/core/src/controlled-sources-integration.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { simulate } from './simulate.js';
+
+describe('Controlled sources integration', () => {
+  describe('VCCS (G element)', () => {
+    it('transconductance amplifier: Vout = gm * Vin * RL', async () => {
+      // gm=10mS, Vin=1V, RL=1k => Vout = 0.01 * 1 * 1000 = 10V
+      // G1 output current flows into n+ (node 0) and out of n- (node 2),
+      // so we swap output nodes to get positive voltage at node 2.
+      const result = await simulate(`
+        V1 1 0 DC 1
+        G1 0 2 1 0 10m
+        R1 2 0 1k
+        .op
+      `);
+      expect(result.dc!.voltage('2')).toBeCloseTo(10, 4);
+    });
+  });
+
+  describe('VCVS (E element)', () => {
+    it('voltage amplifier: Vout = gain * Vin', async () => {
+      // gain=10, Vin=1V => Vout = 10V
+      const result = await simulate(`
+        V1 1 0 DC 1
+        E1 2 0 1 0 10
+        R1 2 0 1k
+        .op
+      `);
+      expect(result.dc!.voltage('2')).toBeCloseTo(10, 4);
+    });
+  });
+
+  describe('CCCS (F element)', () => {
+    it('current mirror: Iout = gain * Isense', async () => {
+      // V1=1V through R1=1k => Isense=1mA. gain=5 => Iout=5mA.
+      // Iout through RL=1k => VRL = 5V
+      // F1 output current flows into n+ and out of n-,
+      // so we swap output nodes to get positive voltage at node 3.
+      const result = await simulate(`
+        V1 1 0 DC 1
+        Vsense 1 2 DC 0
+        R1 2 0 1k
+        F1 0 3 Vsense 5
+        RL 3 0 1k
+        .op
+      `);
+      expect(result.dc!.voltage('3')).toBeCloseTo(5, 4);
+    });
+  });
+
+  describe('CCVS (H element)', () => {
+    it('transimpedance amplifier: Vout = gain * Isense', async () => {
+      // V1=1V through R1=1k => Isense=1mA. gain=1k => Vout=1V.
+      const result = await simulate(`
+        V1 1 0 DC 1
+        Vsense 1 2 DC 0
+        R1 2 0 1k
+        H1 3 0 Vsense 1k
+        RL 3 0 1k
+        .op
+      `);
+      expect(result.dc!.voltage('3')).toBeCloseTo(1, 4);
+    });
+  });
+});
+
+describe('AC analysis with controlled sources', () => {
+  it('inverting op-amp (VCVS) has gain = -Rf/Rin at mid-band', async () => {
+    // Ideal op-amp model: VCVS with gain = 100000
+    // Inverting config: Rin=1k, Rf=10k => closed-loop gain = -10
+    //
+    // Circuit:
+    //   Vac  1  0  AC 1 0           (AC stimulus)
+    //   Rin  1  2  1k               (input resistor, node 2 = inverting input)
+    //   Rf   2  3  10k              (feedback resistor)
+    //   E1   3  0  0  2  100000     (VCVS: V(3) = 100000 * (V(0) - V(2)) = -100000 * V(2))
+    //   .ac dec 1 1k 1k
+    //
+    // Note: non-inverting input is ground (node 0), inverting input is node 2.
+    // E1 n+ n- nc+ nc- gain => V(3,0) = 100000 * V(0,2) = -100000 * V(2)
+    const result = await simulate(`
+      Vac 1 0 AC 1 0
+      Rin 1 2 1k
+      Rf 2 3 10k
+      E1 3 0 0 2 100000
+      .ac dec 1 1k 1k
+    `);
+
+    const ac = result.ac!;
+    const vout = ac.voltage('3');
+
+    // At 1kHz, closed-loop gain magnitude should be ~10 (= Rf/Rin)
+    expect(vout[0].magnitude).toBeCloseTo(10, 0);
+
+    // Phase should be ~180 degrees (inverting)
+    expect(Math.abs(vout[0].phase)).toBeCloseTo(180, 0);
+  });
+});

--- a/packages/core/src/devices/cccs.ts
+++ b/packages/core/src/devices/cccs.ts
@@ -1,0 +1,25 @@
+import type { DeviceModel, StampContext } from './device.js';
+
+export class CCCS implements DeviceModel {
+  readonly branches: number[] = [];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly controlBranchIndex: number,
+    readonly gain: number,
+  ) {}
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN] = this.nodes;
+    const biCtrl = ctx.numNodes + this.controlBranchIndex;
+
+    if (nOutP >= 0) ctx.stampG(nOutP, biCtrl, this.gain);
+    if (nOutN >= 0) ctx.stampG(nOutN, biCtrl, -this.gain);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}

--- a/packages/core/src/devices/ccvs.ts
+++ b/packages/core/src/devices/ccvs.ts
@@ -1,0 +1,35 @@
+import type { DeviceModel, StampContext } from './device.js';
+
+export class CCVS implements DeviceModel {
+  readonly branches: number[];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly controlBranchIndex: number,
+    readonly branchIndex: number,
+    readonly gain: number,
+  ) {
+    this.branches = [branchIndex];
+  }
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN] = this.nodes;
+    const bi = ctx.numNodes + this.branchIndex;
+    const biCtrl = ctx.numNodes + this.controlBranchIndex;
+
+    // KCL coupling: branch current enters out+, leaves out-
+    if (nOutP >= 0) ctx.stampG(nOutP, bi, 1);
+    if (nOutN >= 0) ctx.stampG(nOutN, bi, -1);
+
+    // KVL constraint: V(out+) - V(out-) - gain * I_ctrl = 0
+    if (nOutP >= 0) ctx.stampG(bi, nOutP, 1);
+    if (nOutN >= 0) ctx.stampG(bi, nOutN, -1);
+    ctx.stampG(bi, biCtrl, -this.gain);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}

--- a/packages/core/src/devices/controlled-sources.test.ts
+++ b/packages/core/src/devices/controlled-sources.test.ts
@@ -3,6 +3,7 @@ import { MNAAssembler } from '../mna/assembler.js';
 import { VCCS } from './vccs.js';
 import { VCVS } from './vcvs.js';
 import { CCCS } from './cccs.js';
+import { CCVS } from './ccvs.js';
 
 describe('VCCS (G element)', () => {
   it('stamps transconductance gm between output and control nodes', () => {
@@ -145,5 +146,62 @@ describe('CCCS (F element)', () => {
     const biCtrl = 2;
     expect(asm.G.get(0, biCtrl)).toBe(3);
     expect(asm.G.get(1, biCtrl)).toBe(-3);
+  });
+});
+
+describe('CCVS (H element)', () => {
+  it('stamps branch equation with controlling branch coupling', () => {
+    // 2 nodes: 0=out+, 1=out-. 2 branches: 0=controlling V-source, 1=this CCVS.
+    const asm = new MNAAssembler(2, 2);
+    const h = new CCVS('H1', [0, 1], 0, 1, 1000);
+    h.stamp(asm.getStampContext());
+
+    const bi = 2 + 1;     // numNodes(2) + branchIndex(1) = 3
+    const biCtrl = 2 + 0; // numNodes(2) + controlBranchIndex(0) = 2
+
+    // KCL coupling
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(1, bi)).toBe(-1);
+
+    // KVL constraint row
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, 1)).toBe(-1);
+
+    // Control coupling: -gain on controlling branch column
+    expect(asm.G.get(bi, biCtrl)).toBe(-1000);
+
+    // RHS = 0
+    expect(asm.b[bi]).toBe(0);
+  });
+
+  it('handles ground on output negative node', () => {
+    // out- = ground: nodes [0, -1]. 2 branches.
+    const asm = new MNAAssembler(1, 2);
+    const h = new CCVS('H1', [0, -1], 0, 1, 500);
+    h.stamp(asm.getStampContext());
+
+    const bi = 1 + 1;     // numNodes(1) + branchIndex(1)
+    const biCtrl = 1 + 0; // numNodes(1) + controlBranchIndex(0)
+
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, biCtrl)).toBe(-500);
+  });
+
+  it('is linear with one branch', () => {
+    const h = new CCVS('H1', [0, 1], 0, 1, 1000);
+    expect(h.isNonlinear).toBe(false);
+    expect(h.branches).toEqual([1]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(2, 2);
+    const h = new CCVS('H1', [0, 1], 0, 1, 1000);
+    h.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    const bi = 3;
+    const biCtrl = 2;
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, biCtrl)).toBe(-1000);
   });
 });

--- a/packages/core/src/devices/controlled-sources.test.ts
+++ b/packages/core/src/devices/controlled-sources.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { MNAAssembler } from '../mna/assembler.js';
+import { VCCS } from './vccs.js';
+
+describe('VCCS (G element)', () => {
+  it('stamps transconductance gm between output and control nodes', () => {
+    // 4 nodes: 0=out+, 1=out-, 2=ctrl+, 3=ctrl-
+    const asm = new MNAAssembler(4, 0);
+    const g = new VCCS('G1', [0, 1, 2, 3], 0.01);
+    g.stamp(asm.getStampContext());
+
+    // G(out+, ctrl+) += gm
+    expect(asm.G.get(0, 2)).toBeCloseTo(0.01);
+    // G(out+, ctrl-) -= gm
+    expect(asm.G.get(0, 3)).toBeCloseTo(-0.01);
+    // G(out-, ctrl+) -= gm
+    expect(asm.G.get(1, 2)).toBeCloseTo(-0.01);
+    // G(out-, ctrl-) += gm
+    expect(asm.G.get(1, 3)).toBeCloseTo(0.01);
+  });
+
+  it('handles ground node (-1) on output side', () => {
+    // out- is ground: nodes [0, -1, 1, -1] => ctrl- also ground
+    const asm = new MNAAssembler(2, 0);
+    const g = new VCCS('G1', [0, -1, 1, -1], 0.005);
+    g.stamp(asm.getStampContext());
+
+    expect(asm.G.get(0, 1)).toBeCloseTo(0.005);
+    // No stamps into ground rows/cols
+    expect(asm.G.get(0, 0)).toBeCloseTo(0);
+  });
+
+  it('is linear with no branches', () => {
+    const g = new VCCS('G1', [0, 1, 2, 3], 0.01);
+    expect(g.isNonlinear).toBe(false);
+    expect(g.branches).toEqual([]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(4, 0);
+    const g = new VCCS('G1', [0, 1, 2, 3], 0.01);
+    g.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    expect(asm.G.get(0, 2)).toBeCloseTo(0.01);
+    expect(asm.G.get(0, 3)).toBeCloseTo(-0.01);
+    expect(asm.G.get(1, 2)).toBeCloseTo(-0.01);
+    expect(asm.G.get(1, 3)).toBeCloseTo(0.01);
+  });
+});

--- a/packages/core/src/devices/controlled-sources.test.ts
+++ b/packages/core/src/devices/controlled-sources.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { MNAAssembler } from '../mna/assembler.js';
 import { VCCS } from './vccs.js';
+import { VCVS } from './vcvs.js';
 
 describe('VCCS (G element)', () => {
   it('stamps transconductance gm between output and control nodes', () => {
@@ -45,5 +46,60 @@ describe('VCCS (G element)', () => {
     expect(asm.G.get(0, 3)).toBeCloseTo(-0.01);
     expect(asm.G.get(1, 2)).toBeCloseTo(-0.01);
     expect(asm.G.get(1, 3)).toBeCloseTo(0.01);
+  });
+});
+
+describe('VCVS (E element)', () => {
+  it('stamps branch equation with gain coupling', () => {
+    // 4 nodes: 0=out+, 1=out-, 2=ctrl+, 3=ctrl-. 1 branch at index 0.
+    const asm = new MNAAssembler(4, 1);
+    const e = new VCVS('E1', [0, 1, 2, 3], 0, 10);
+    e.stamp(asm.getStampContext());
+
+    const bi = 4; // numNodes + branchIndex = 4 + 0
+
+    // KCL coupling
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(1, bi)).toBe(-1);
+
+    // KVL constraint row
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, 1)).toBe(-1);
+
+    // Control coupling: -gain on ctrl+, +gain on ctrl-
+    expect(asm.G.get(bi, 2)).toBe(-10);
+    expect(asm.G.get(bi, 3)).toBe(10);
+
+    // RHS = 0
+    expect(asm.b[bi]).toBe(0);
+  });
+
+  it('handles ground on output negative node', () => {
+    // out- = ground, ctrl- = ground: nodes [0, -1, 1, -1], 1 branch
+    const asm = new MNAAssembler(2, 1);
+    const e = new VCVS('E1', [0, -1, 1, -1], 0, 5);
+    e.stamp(asm.getStampContext());
+
+    const bi = 2; // numNodes(2) + branchIndex(0)
+
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, 0)).toBe(1);
+    expect(asm.G.get(bi, 1)).toBe(-5);
+  });
+
+  it('is linear with one branch', () => {
+    const e = new VCVS('E1', [0, 1, 2, 3], 0, 10);
+    expect(e.isNonlinear).toBe(false);
+    expect(e.branches).toEqual([0]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(4, 1);
+    const e = new VCVS('E1', [0, 1, 2, 3], 0, 10);
+    e.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    const bi = 4;
+    expect(asm.G.get(0, bi)).toBe(1);
+    expect(asm.G.get(bi, 2)).toBe(-10);
   });
 });

--- a/packages/core/src/devices/controlled-sources.test.ts
+++ b/packages/core/src/devices/controlled-sources.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { MNAAssembler } from '../mna/assembler.js';
 import { VCCS } from './vccs.js';
 import { VCVS } from './vcvs.js';
+import { CCCS } from './cccs.js';
 
 describe('VCCS (G element)', () => {
   it('stamps transconductance gm between output and control nodes', () => {
@@ -101,5 +102,48 @@ describe('VCVS (E element)', () => {
     const bi = 4;
     expect(asm.G.get(0, bi)).toBe(1);
     expect(asm.G.get(bi, 2)).toBe(-10);
+  });
+});
+
+describe('CCCS (F element)', () => {
+  it('stamps gain into controlling branch column at output nodes', () => {
+    // 2 nodes + 1 branch (from controlling V-source).
+    // nodes: 0=out+, 1=out-. controlBranchIndex=0.
+    const asm = new MNAAssembler(2, 1);
+    const f = new CCCS('F1', [0, 1], 0, 3);
+    f.stamp(asm.getStampContext());
+
+    const biCtrl = 2; // numNodes(2) + controlBranchIndex(0)
+
+    // G(out+, biCtrl) += gain
+    expect(asm.G.get(0, biCtrl)).toBe(3);
+    // G(out-, biCtrl) -= gain
+    expect(asm.G.get(1, biCtrl)).toBe(-3);
+  });
+
+  it('handles ground on output negative node', () => {
+    // out- = ground: nodes [0, -1]. 1 branch.
+    const asm = new MNAAssembler(1, 1);
+    const f = new CCCS('F1', [0, -1], 0, 5);
+    f.stamp(asm.getStampContext());
+
+    const biCtrl = 1; // numNodes(1) + 0
+    expect(asm.G.get(0, biCtrl)).toBe(5);
+  });
+
+  it('is linear with no branches of its own', () => {
+    const f = new CCCS('F1', [0, 1], 0, 3);
+    expect(f.isNonlinear).toBe(false);
+    expect(f.branches).toEqual([]);
+  });
+
+  it('stampAC produces identical stamps', () => {
+    const asm = new MNAAssembler(2, 1);
+    const f = new CCCS('F1', [0, 1], 0, 3);
+    f.stampAC!(asm.getStampContext(), 2 * Math.PI * 1000);
+
+    const biCtrl = 2;
+    expect(asm.G.get(0, biCtrl)).toBe(3);
+    expect(asm.G.get(1, biCtrl)).toBe(-3);
   });
 });

--- a/packages/core/src/devices/index.ts
+++ b/packages/core/src/devices/index.ts
@@ -12,3 +12,7 @@ export { MOSFET } from './mosfet.js';
 export type { MOSFETParams } from './mosfet.js';
 export { BSIM3v3 } from './bsim3v3.js';
 export type { BSIM3v3ModelParams, BSIM3v3InstanceParams } from './bsim3v3-params.js';
+export { VCCS } from './vccs.js';
+export { VCVS } from './vcvs.js';
+export { CCCS } from './cccs.js';
+export { CCVS } from './ccvs.js';

--- a/packages/core/src/devices/vccs.ts
+++ b/packages/core/src/devices/vccs.ts
@@ -1,0 +1,25 @@
+import type { DeviceModel, StampContext } from './device.js';
+
+export class VCCS implements DeviceModel {
+  readonly branches: number[] = [];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly gm: number,
+  ) {}
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN, nCtrlP, nCtrlN] = this.nodes;
+
+    if (nOutP >= 0 && nCtrlP >= 0) ctx.stampG(nOutP, nCtrlP, this.gm);
+    if (nOutP >= 0 && nCtrlN >= 0) ctx.stampG(nOutP, nCtrlN, -this.gm);
+    if (nOutN >= 0 && nCtrlP >= 0) ctx.stampG(nOutN, nCtrlP, -this.gm);
+    if (nOutN >= 0 && nCtrlN >= 0) ctx.stampG(nOutN, nCtrlN, this.gm);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}

--- a/packages/core/src/devices/vcvs.ts
+++ b/packages/core/src/devices/vcvs.ts
@@ -1,0 +1,34 @@
+import type { DeviceModel, StampContext } from './device.js';
+
+export class VCVS implements DeviceModel {
+  readonly branches: number[];
+  readonly isNonlinear = false;
+
+  constructor(
+    readonly name: string,
+    readonly nodes: number[],
+    readonly branchIndex: number,
+    readonly gain: number,
+  ) {
+    this.branches = [branchIndex];
+  }
+
+  stamp(ctx: StampContext): void {
+    const [nOutP, nOutN, nCtrlP, nCtrlN] = this.nodes;
+    const bi = ctx.numNodes + this.branchIndex;
+
+    // KCL coupling: branch current enters out+, leaves out-
+    if (nOutP >= 0) ctx.stampG(nOutP, bi, 1);
+    if (nOutN >= 0) ctx.stampG(nOutN, bi, -1);
+
+    // KVL constraint: V(out+) - V(out-) - gain * (V(ctrl+) - V(ctrl-)) = 0
+    if (nOutP >= 0) ctx.stampG(bi, nOutP, 1);
+    if (nOutN >= 0) ctx.stampG(bi, nOutN, -1);
+    if (nCtrlP >= 0) ctx.stampG(bi, nCtrlP, -this.gain);
+    if (nCtrlN >= 0) ctx.stampG(bi, nCtrlN, this.gain);
+  }
+
+  stampAC(ctx: StampContext, _omega: number): void {
+    this.stamp(ctx);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,10 @@ export type {
   IncludeResolver,
 } from './types.js';
 export type { DeviceModel, StampContext } from './devices/device.js';
+export { VCVS } from './devices/vcvs.js';
+export { VCCS } from './devices/vccs.js';
+export { CCVS } from './devices/ccvs.js';
+export { CCCS } from './devices/cccs.js';
 export {
   SpiceError,
   ParseError,

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -201,6 +201,26 @@ function parseDevice(circuit: Circuit, tokens: string[], lineNumber: number): vo
       circuit.addSubcircuitInstance(name, ports, subcktName, xParams);
       break;
     }
+    case 'E': {
+      const gain = parseNumber(tokens[5]);
+      circuit.addVCVS(name, tokens[1], tokens[2], tokens[3], tokens[4], gain);
+      break;
+    }
+    case 'G': {
+      const gm = parseNumber(tokens[5]);
+      circuit.addVCCS(name, tokens[1], tokens[2], tokens[3], tokens[4], gm);
+      break;
+    }
+    case 'H': {
+      const gain = parseNumber(tokens[4]);
+      circuit.addCCVS(name, tokens[1], tokens[2], tokens[3], gain);
+      break;
+    }
+    case 'F': {
+      const gain = parseNumber(tokens[4]);
+      circuit.addCCCS(name, tokens[1], tokens[2], tokens[3], gain);
+      break;
+    }
     default:
       throw new ParseError(`Unknown device type: '${type}'`, lineNumber, tokens.join(' '));
   }

--- a/packages/core/src/parser/parser.test.ts
+++ b/packages/core/src/parser/parser.test.ts
@@ -216,6 +216,70 @@ describe('SPICE netlist parser', () => {
     });
   });
 
+  describe('controlled source parsing', () => {
+    it('parses VCCS (G element)', () => {
+      const ckt = parse(`
+        V1 1 0 DC 1
+        G1 2 0 1 0 10m
+        R1 2 0 1k
+        .op
+      `);
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'G1')).toBeDefined();
+      expect(compiled.branchCount).toBe(1);
+    });
+
+    it('parses VCVS (E element)', () => {
+      const ckt = parse(`
+        V1 1 0 DC 1
+        E1 2 0 1 0 10
+        R1 2 0 1k
+        .op
+      `);
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'E1')).toBeDefined();
+      expect(compiled.branchCount).toBe(2);
+    });
+
+    it('parses CCCS (F element)', () => {
+      const ckt = parse(`
+        V1 1 0 DC 1
+        Vsense 1 2 DC 0
+        R1 2 0 1k
+        F1 3 0 Vsense 5
+        R2 3 0 1k
+        .op
+      `);
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'F1')).toBeDefined();
+    });
+
+    it('parses CCVS (H element)', () => {
+      const ckt = parse(`
+        V1 1 0 DC 1
+        Vsense 1 2 DC 0
+        R1 2 0 1k
+        H1 3 0 Vsense 1k
+        R2 3 0 1k
+        .op
+      `);
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'H1')).toBeDefined();
+      expect(compiled.branchCount).toBe(3);
+    });
+
+    it('is case-insensitive for controlled sources', () => {
+      const ckt = parse(`
+        v1 1 0 dc 1
+        g1 2 0 1 0 10m
+        r1 2 0 1k
+        .op
+      `);
+      const compiled = ckt.compile();
+      expect(compiled.devices.find(d => d.name === 'g1')).toBeDefined();
+    });
+  });
+
   describe('parseAsync', () => {
     it('parses a simple netlist without resolver', async () => {
       const ckt = await parseAsync(`


### PR DESCRIPTION
## Summary

- Add DC and AC integration tests for all four controlled source types (VCVS, VCCS, CCVS, CCCS)
- Re-export `VCVS`, `VCCS`, `CCVS`, `CCCS` classes from the package entrypoint so consumers can import them from `@spice-ts/core`

This completes the controlled sources feature (device classes, circuit API, compiler, parser, and subcircuit expansion were landed in prior commits on main).

### Integration tests verify:
- **VCCS (G)**: transconductance amplifier — Vout = gm × Vin × RL
- **VCVS (E)**: voltage amplifier — Vout = gain × Vin
- **CCCS (F)**: current mirror — Iout = gain × Isense
- **CCVS (H)**: transimpedance amplifier — Vout = gain × Isense
- **AC**: inverting op-amp model (VCVS, gain=100k) — closed-loop gain = −Rf/Rin

## Test plan

- [x] All 274 tests pass (1 pre-existing failure in `gilbert-peierls.test.ts` from unrelated sparse LU work)
- [x] `tsc --noEmit` — zero type errors
- [x] DC integration tests match closed-form analytical solutions
- [x] AC test confirms inverting op-amp gain and phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)