### PR TITLE
feat: add @spice-ts/ui waveform viewer package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run: pnpm -r run test:coverage
 
-      - name: Upload coverage
+      - name: Upload core coverage
         if: matrix.node-version == 22
         uses: codecov/codecov-action@v5
         with:
@@ -38,12 +38,20 @@ jobs:
           flags: core
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload UI coverage
+        if: matrix.node-version == 22
+        uses: codecov/codecov-action@v5
+        with:
+          files: packages/ui/coverage/coverage-final.json
+          flags: ui
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           report_type: test_results
-          files: packages/core/test-results.xml
+          files: packages/core/test-results.xml,packages/ui/test-results.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build:

--- a/docs/superpowers/plans/2026-04-12-waveform-viewer.md
+++ b/docs/superpowers/plans/2026-04-12-waveform-viewer.md
@@ -1,0 +1,4114 @@
+# @spice-ts/ui Waveform Viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a framework-agnostic waveform viewer package with Canvas rendering core and React bindings, supporting transient plots, AC Bode plots, streaming, and multi-result overlays.
+
+**Architecture:** Two-layer design — a pure TypeScript Canvas core (`@spice-ts/ui`) handles all rendering, scales, and interaction. A thin React adapter (`@spice-ts/ui/react`) provides composable components that wrap the core. Subpath exports separate the two: `@spice-ts/ui` for vanilla, `@spice-ts/ui/react` for React.
+
+**Tech Stack:** TypeScript, Canvas 2D, d3-scale, d3-array, React 18+, Vitest, tsup
+
+---
+
+## File Structure
+
+```
+packages/ui/
+├── src/
+│   ├── core/
+│   │   ├── types.ts              Shared types (ThemeConfig, CursorState, SignalData, etc.)
+│   │   ├── theme.ts              Dark/light presets, mergeTheme()
+│   │   ├── theme.test.ts
+│   │   ├── format.ts             SI-prefix formatting (1kHz, 2.5ms, 4.7V)
+│   │   ├── format.test.ts
+│   │   ├── scales.ts             d3-scale wrappers, tick computation
+│   │   ├── scales.test.ts
+│   │   ├── data.ts               Normalize TransientResult/ACResult into render arrays
+│   │   ├── data.test.ts
+│   │   ├── buffer.ts             Growable Float64Array for streaming
+│   │   ├── buffer.test.ts
+│   │   ├── renderer.ts           TransientRenderer — Canvas waveform/grid/axis/cursor
+│   │   ├── renderer.test.ts
+│   │   ├── bode-renderer.ts      BodeRenderer — dual-pane magnitude/phase Canvas
+│   │   ├── bode-renderer.test.ts
+│   │   ├── interaction.ts        Zoom (wheel), pan (drag), cursor (hover) handlers
+│   │   ├── interaction.test.ts
+│   │   ├── streaming.ts          StreamingController — async iterator → buffer → rAF
+│   │   ├── streaming.test.ts
+│   │   └── index.ts              Core public exports
+│   ├── react/
+│   │   ├── TransientPlot.tsx      Composable transient canvas component
+│   │   ├── TransientPlot.test.tsx
+│   │   ├── BodePlot.tsx           Composable Bode plot component
+│   │   ├── BodePlot.test.tsx
+│   │   ├── Legend.tsx             Click-to-toggle signal legend
+│   │   ├── Legend.test.tsx
+│   │   ├── CursorTooltip.tsx      DOM overlay for cursor value readout
+│   │   ├── WaveformViewer.tsx     Pre-composed convenience component
+│   │   ├── WaveformViewer.test.tsx
+│   │   ├── use-renderer.ts       Shared hook: canvas ref + ResizeObserver + renderer lifecycle
+│   │   └── index.ts              React public exports
+│   ├── index.ts                   Root re-export of core
+│   └── test-setup.ts             Canvas mock for jsdom
+├── package.json
+├── tsconfig.json
+├── tsup.config.ts
+└── vitest.config.ts
+```
+
+---
+
+### Task 1: Package scaffolding
+
+**Files:**
+- Create: `packages/ui/package.json`
+- Create: `packages/ui/tsconfig.json`
+- Create: `packages/ui/tsup.config.ts`
+- Create: `packages/ui/vitest.config.ts`
+- Create: `packages/ui/src/test-setup.ts`
+- Create: `packages/ui/src/index.ts`
+- Create: `packages/ui/src/core/index.ts`
+- Create: `packages/ui/src/react/index.ts`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "@spice-ts/ui",
+  "version": "0.1.0",
+  "description": "Waveform viewer for spice-ts simulation results",
+  "license": "MIT",
+  "author": "Mattia Fiumara",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mfiumara/spice-ts.git",
+    "directory": "packages/ui"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "d3-array": "^3.2.4",
+    "d3-scale": "^4.0.2"
+  },
+  "peerDependencies": {
+    "@spice-ts/core": "workspace:*",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": true },
+    "react-dom": { "optional": true }
+  },
+  "devDependencies": {
+    "@spice-ts/core": "workspace:*",
+    "@testing-library/react": "^16.0.0",
+    "@types/d3-array": "^3.2.1",
+    "@types/d3-scale": "^4.0.8",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitest/coverage-v8": "^4.1.4",
+    "jsdom": "^25.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vite": "^8.0.8",
+    "vitest": "^4.1.4"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*"]
+}
+```
+
+- [ ] **Step 3: Create tsup.config.ts**
+
+```typescript
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    react: 'src/react/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  sourcemap: true,
+  external: ['@spice-ts/core', 'react', 'react-dom'],
+});
+```
+
+- [ ] **Step 4: Create vitest.config.ts**
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+    reporters: ['default', ['junit', { outputFile: 'test-results.xml' }]],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary'],
+      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/test-setup.ts'],
+    },
+  },
+});
+```
+
+- [ ] **Step 5: Create test-setup.ts with Canvas mock**
+
+```typescript
+// src/test-setup.ts
+import { vi } from 'vitest';
+
+function createMockContext(): CanvasRenderingContext2D {
+  return {
+    canvas: document.createElement('canvas'),
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    scale: vi.fn(),
+    translate: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn().mockReturnValue({ width: 40 }),
+    rect: vi.fn(),
+    arc: vi.fn(),
+    clip: vi.fn(),
+    setLineDash: vi.fn(),
+    getLineDash: vi.fn().mockReturnValue([]),
+    lineWidth: 1,
+    strokeStyle: '',
+    fillStyle: '',
+    font: '',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+    lineDashOffset: 0,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+HTMLCanvasElement.prototype.getContext = function (contextId: string, ...args: unknown[]) {
+  if (contextId === '2d') {
+    return createMockContext();
+  }
+  return originalGetContext.call(this, contextId, ...args);
+} as typeof HTMLCanvasElement.prototype.getContext;
+```
+
+- [ ] **Step 6: Create placeholder entry files**
+
+`src/index.ts`:
+```typescript
+export * from './core/index.js';
+```
+
+`src/core/index.ts`:
+```typescript
+// Core exports — populated as modules are built
+export {};
+```
+
+`src/react/index.ts`:
+```typescript
+// React exports — populated as components are built
+export {};
+```
+
+- [ ] **Step 7: Install dependencies and verify build**
+
+Run: `cd packages/ui && pnpm install`
+
+Run: `pnpm build`
+Expected: Clean build with `dist/index.js`, `dist/index.cjs`, `dist/react.js`, `dist/react.cjs` and `.d.ts` files.
+
+Run: `pnpm lint`
+Expected: No type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ui/
+git commit -m "feat(ui): scaffold @spice-ts/ui package with dual subpath exports"
+```
+
+---
+
+### Task 2: Core types and theme system
+
+**Files:**
+- Create: `packages/ui/src/core/types.ts`
+- Create: `packages/ui/src/core/theme.ts`
+- Create: `packages/ui/src/core/theme.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Create types.ts**
+
+```typescript
+// src/core/types.ts
+
+/** Configuration for visual theme colors and fonts. */
+export interface ThemeConfig {
+  /** Plot area background color. */
+  background: string;
+  /** Container/toolbar surface color. */
+  surface: string;
+  /** Border and divider color. */
+  border: string;
+  /** Grid line color. */
+  grid: string;
+  /** Primary text color (labels, values). */
+  text: string;
+  /** Secondary text color (axis labels, muted). */
+  textMuted: string;
+  /** Cursor crosshair line color. */
+  cursor: string;
+  /** Tooltip background color. */
+  tooltipBg: string;
+  /** Tooltip border color. */
+  tooltipBorder: string;
+  /** Font family string. */
+  font: string;
+  /** Base font size in pixels. */
+  fontSize: number;
+}
+
+/** A single value at the cursor position for one signal. */
+export interface CursorValue {
+  /** Signal identifier (e.g. "out" or "R1=1k:out"). */
+  signalId: string;
+  /** Display label. */
+  label: string;
+  /** Numeric value at cursor position. */
+  value: number;
+  /** Unit string ('V', 'A', 'dB', '°'). */
+  unit: string;
+  /** Color of this signal's trace. */
+  color: string;
+}
+
+/** Cursor state — position and signal values at that position. */
+export interface CursorState {
+  /** Data-space x value (time in seconds, or frequency in Hz). */
+  x: number;
+  /** Pixel-space x position relative to canvas. */
+  pixelX: number;
+  /** Values for each visible signal at this x position. */
+  values: CursorValue[];
+}
+
+/** Describes one signal for rendering. */
+export interface SignalConfig {
+  /** Signal name (matches node/branch name in simulation result). */
+  name: string;
+  /** Display color. If omitted, assigned from palette. */
+  color?: string;
+  /** Whether signal is currently visible. Default true. */
+  visible?: boolean;
+}
+
+/** A labeled transient dataset for multi-result overlay. */
+export interface TransientDataset {
+  /** Transient result data. */
+  time: number[];
+  /** Map of signal name → voltage/current array. */
+  signals: Map<string, number[]>;
+  /** Label for this dataset (e.g. "R1 = 1k"). */
+  label: string;
+}
+
+/** A labeled AC dataset for multi-result overlay. */
+export interface ACDataset {
+  /** Frequency array in Hz. */
+  frequencies: number[];
+  /** Map of signal name → magnitude array in dB. */
+  magnitudes: Map<string, number[]>;
+  /** Map of signal name → phase array in degrees. */
+  phases: Map<string, number[]>;
+  /** Label for this dataset. */
+  label: string;
+}
+
+/** Margins around the plot area in pixels. */
+export interface Margins {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+/** Events emitted by renderers. */
+export interface RendererEvents {
+  cursorMove: (state: CursorState | null) => void;
+}
+
+/** Default color palette (8 colorblind-friendly colors). */
+export const DEFAULT_PALETTE = [
+  '#4ade80', // green
+  '#60a5fa', // blue
+  '#f97316', // orange
+  '#a78bfa', // purple
+  '#f472b6', // pink
+  '#facc15', // yellow
+  '#2dd4bf', // teal
+  '#fb923c', // amber
+] as const;
+```
+
+- [ ] **Step 2: Write theme tests**
+
+```typescript
+// src/core/theme.test.ts
+import { describe, it, expect } from 'vitest';
+import { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';
+
+describe('theme', () => {
+  it('DARK_THEME has all required fields', () => {
+    expect(DARK_THEME.background).toBeDefined();
+    expect(DARK_THEME.surface).toBeDefined();
+    expect(DARK_THEME.border).toBeDefined();
+    expect(DARK_THEME.grid).toBeDefined();
+    expect(DARK_THEME.text).toBeDefined();
+    expect(DARK_THEME.textMuted).toBeDefined();
+    expect(DARK_THEME.cursor).toBeDefined();
+    expect(DARK_THEME.tooltipBg).toBeDefined();
+    expect(DARK_THEME.tooltipBorder).toBeDefined();
+    expect(DARK_THEME.font).toBeDefined();
+    expect(DARK_THEME.fontSize).toBeGreaterThan(0);
+  });
+
+  it('LIGHT_THEME has all required fields', () => {
+    expect(LIGHT_THEME.background).toBeDefined();
+    expect(LIGHT_THEME.text).toBeDefined();
+    expect(LIGHT_THEME.fontSize).toBeGreaterThan(0);
+  });
+
+  it('mergeTheme overrides specific fields', () => {
+    const merged = mergeTheme(DARK_THEME, { fontSize: 16, background: '#000' });
+    expect(merged.fontSize).toBe(16);
+    expect(merged.background).toBe('#000');
+    expect(merged.text).toBe(DARK_THEME.text);
+  });
+
+  it('mergeTheme returns base unchanged when overrides is empty', () => {
+    const merged = mergeTheme(DARK_THEME, {});
+    expect(merged).toEqual(DARK_THEME);
+  });
+
+  it('resolveTheme returns DARK_THEME for "dark"', () => {
+    expect(resolveTheme('dark')).toEqual(DARK_THEME);
+  });
+
+  it('resolveTheme returns LIGHT_THEME for "light"', () => {
+    expect(resolveTheme('light')).toEqual(LIGHT_THEME);
+  });
+
+  it('resolveTheme returns custom ThemeConfig as-is', () => {
+    const custom: ThemeConfig = { ...DARK_THEME, fontSize: 20 };
+    expect(resolveTheme(custom)).toBe(custom);
+  });
+
+  it('resolveTheme defaults to DARK_THEME for undefined', () => {
+    expect(resolveTheme(undefined)).toEqual(DARK_THEME);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test`
+Expected: FAIL — `./theme.js` module not found.
+
+- [ ] **Step 4: Implement theme.ts**
+
+```typescript
+// src/core/theme.ts
+import type { ThemeConfig } from './types.js';
+
+export const DARK_THEME: ThemeConfig = {
+  background: 'hsl(224, 50%, 6%)',
+  surface: 'hsl(224, 71%, 4%)',
+  border: 'hsl(215, 20%, 17%)',
+  grid: 'hsl(215, 20%, 12%)',
+  text: 'hsl(210, 40%, 98%)',
+  textMuted: 'hsl(215, 20%, 45%)',
+  cursor: 'hsl(215, 20%, 40%)',
+  tooltipBg: 'hsl(224, 40%, 10%)',
+  tooltipBorder: 'hsl(215, 20%, 22%)',
+  font: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+  fontSize: 11,
+};
+
+export const LIGHT_THEME: ThemeConfig = {
+  background: 'hsl(210, 40%, 98%)',
+  surface: 'hsl(0, 0%, 100%)',
+  border: 'hsl(214, 32%, 91%)',
+  grid: 'hsl(214, 32%, 91%)',
+  text: 'hsl(222, 47%, 11%)',
+  textMuted: 'hsl(215, 16%, 47%)',
+  cursor: 'hsl(215, 16%, 47%)',
+  tooltipBg: 'hsl(0, 0%, 100%)',
+  tooltipBorder: 'hsl(214, 32%, 91%)',
+  font: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+  fontSize: 11,
+};
+
+/** Merge partial overrides into a base theme. */
+export function mergeTheme(base: ThemeConfig, overrides: Partial<ThemeConfig>): ThemeConfig {
+  return { ...base, ...overrides };
+}
+
+/** Resolve a theme prop to a full ThemeConfig. */
+export function resolveTheme(theme: 'dark' | 'light' | ThemeConfig | undefined): ThemeConfig {
+  if (theme === undefined || theme === 'dark') return DARK_THEME;
+  if (theme === 'light') return LIGHT_THEME;
+  return theme;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test`
+Expected: All theme tests PASS.
+
+- [ ] **Step 6: Update core/index.ts exports**
+
+```typescript
+// src/core/index.ts
+export type {
+  ThemeConfig,
+  CursorState,
+  CursorValue,
+  SignalConfig,
+  TransientDataset,
+  ACDataset,
+  Margins,
+  RendererEvents,
+} from './types.js';
+export { DEFAULT_PALETTE } from './types.js';
+export { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/core/types.ts packages/ui/src/core/theme.ts packages/ui/src/core/theme.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add core types and theme system with dark/light presets"
+```
+
+---
+
+### Task 3: SI-prefix formatting
+
+**Files:**
+- Create: `packages/ui/src/core/format.ts`
+- Create: `packages/ui/src/core/format.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write format tests**
+
+```typescript
+// src/core/format.test.ts
+import { describe, it, expect } from 'vitest';
+import { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, formatPhase, formatDB } from './format.js';
+
+describe('formatSI', () => {
+  it('formats values with SI prefixes', () => {
+    expect(formatSI(1e-12)).toBe('1p');
+    expect(formatSI(1e-9)).toBe('1n');
+    expect(formatSI(1e-6)).toBe('1µ');
+    expect(formatSI(1e-3)).toBe('1m');
+    expect(formatSI(1)).toBe('1');
+    expect(formatSI(1e3)).toBe('1k');
+    expect(formatSI(1e6)).toBe('1M');
+    expect(formatSI(1e9)).toBe('1G');
+  });
+
+  it('formats fractional values', () => {
+    expect(formatSI(2.5e-3)).toBe('2.5m');
+    expect(formatSI(47e3)).toBe('47k');
+    expect(formatSI(3.3e-6)).toBe('3.3µ');
+  });
+
+  it('formats zero', () => {
+    expect(formatSI(0)).toBe('0');
+  });
+
+  it('formats negative values', () => {
+    expect(formatSI(-5e-3)).toBe('-5m');
+  });
+
+  it('limits decimal places', () => {
+    expect(formatSI(1.23456e3)).toBe('1.235k');
+  });
+});
+
+describe('formatTime', () => {
+  it('appends s suffix', () => {
+    expect(formatTime(1e-3)).toBe('1ms');
+    expect(formatTime(2.5e-6)).toBe('2.5µs');
+    expect(formatTime(1)).toBe('1s');
+  });
+});
+
+describe('formatFrequency', () => {
+  it('appends Hz suffix', () => {
+    expect(formatFrequency(1e3)).toBe('1kHz');
+    expect(formatFrequency(1e6)).toBe('1MHz');
+    expect(formatFrequency(100)).toBe('100Hz');
+  });
+});
+
+describe('formatVoltage', () => {
+  it('appends V suffix', () => {
+    expect(formatVoltage(5)).toBe('5V');
+    expect(formatVoltage(3.3e-3)).toBe('3.3mV');
+  });
+});
+
+describe('formatCurrent', () => {
+  it('appends A suffix', () => {
+    expect(formatCurrent(1e-3)).toBe('1mA');
+    expect(formatCurrent(5e-6)).toBe('5µA');
+  });
+});
+
+describe('formatDB', () => {
+  it('formats with dB suffix', () => {
+    expect(formatDB(0)).toBe('0dB');
+    expect(formatDB(-3)).toBe('-3dB');
+    expect(formatDB(-20.5)).toBe('-20.5dB');
+  });
+});
+
+describe('formatPhase', () => {
+  it('formats with degree suffix', () => {
+    expect(formatPhase(0)).toBe('0°');
+    expect(formatPhase(-90)).toBe('-90°');
+    expect(formatPhase(-45.5)).toBe('-45.5°');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test`
+Expected: FAIL — `./format.js` module not found.
+
+- [ ] **Step 3: Implement format.ts**
+
+```typescript
+// src/core/format.ts
+
+const SI_PREFIXES: [number, string][] = [
+  [1e-15, 'f'],
+  [1e-12, 'p'],
+  [1e-9, 'n'],
+  [1e-6, 'µ'],
+  [1e-3, 'm'],
+  [1, ''],
+  [1e3, 'k'],
+  [1e6, 'M'],
+  [1e9, 'G'],
+  [1e12, 'T'],
+];
+
+/**
+ * Format a number with SI prefix. Returns string like "2.5k", "100m", "3.3µ".
+ * Uses up to 4 significant digits.
+ */
+export function formatSI(value: number): string {
+  if (value === 0) return '0';
+
+  const abs = Math.abs(value);
+  let bestPrefix = '';
+  let bestScale = 1;
+
+  for (const [scale, prefix] of SI_PREFIXES) {
+    if (abs >= scale * 0.9999) {
+      bestScale = scale;
+      bestPrefix = prefix;
+    }
+  }
+
+  const scaled = value / bestScale;
+  // Use toPrecision(4) then strip trailing zeros
+  const formatted = parseFloat(scaled.toPrecision(4)).toString();
+  return `${formatted}${bestPrefix}`;
+}
+
+/** Format a time value with SI prefix + "s" suffix. */
+export function formatTime(seconds: number): string {
+  return `${formatSI(seconds)}s`;
+}
+
+/** Format a frequency value with SI prefix + "Hz" suffix. */
+export function formatFrequency(hz: number): string {
+  return `${formatSI(hz)}Hz`;
+}
+
+/** Format a voltage value with SI prefix + "V" suffix. */
+export function formatVoltage(volts: number): string {
+  return `${formatSI(volts)}V`;
+}
+
+/** Format a current value with SI prefix + "A" suffix. */
+export function formatCurrent(amps: number): string {
+  return `${formatSI(amps)}A`;
+}
+
+/** Format a dB value. No SI prefix — just round to 1 decimal if needed. */
+export function formatDB(db: number): string {
+  const rounded = Math.round(db * 10) / 10;
+  const str = rounded === Math.floor(rounded) ? rounded.toString() : rounded.toString();
+  return `${str}dB`;
+}
+
+/** Format a phase value in degrees. */
+export function formatPhase(degrees: number): string {
+  const rounded = Math.round(degrees * 10) / 10;
+  const str = rounded === Math.floor(rounded) ? rounded.toString() : rounded.toString();
+  return `${str}°`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test`
+Expected: All format tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, formatDB, formatPhase } from './format.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/format.ts packages/ui/src/core/format.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add SI-prefix formatting utilities"
+```
+
+---
+
+### Task 4: Scale utilities
+
+**Files:**
+- Create: `packages/ui/src/core/scales.ts`
+- Create: `packages/ui/src/core/scales.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write scale tests**
+
+```typescript
+// src/core/scales.test.ts
+import { describe, it, expect } from 'vitest';
+import { createLinearScale, createLogScale, computeYExtent, bisectData } from './scales.js';
+
+describe('createLinearScale', () => {
+  it('maps domain to range', () => {
+    const scale = createLinearScale([0, 10], [0, 500]);
+    expect(scale(0)).toBe(0);
+    expect(scale(10)).toBe(500);
+    expect(scale(5)).toBe(250);
+  });
+
+  it('handles inverted range (for y-axis: top=0, bottom=height)', () => {
+    const scale = createLinearScale([0, 5], [300, 0]);
+    expect(scale(0)).toBe(300);
+    expect(scale(5)).toBe(0);
+    expect(scale(2.5)).toBe(150);
+  });
+});
+
+describe('createLogScale', () => {
+  it('maps domain to range on log scale', () => {
+    const scale = createLogScale([1, 1e6], [0, 600]);
+    expect(scale(1)).toBeCloseTo(0, 0);
+    expect(scale(1e6)).toBeCloseTo(600, 0);
+    expect(scale(1e3)).toBeCloseTo(300, 0);
+  });
+});
+
+describe('computeYExtent', () => {
+  it('computes min/max with 10% padding', () => {
+    const [min, max] = computeYExtent([[0, 1, 2, 3, 4, 5]]);
+    expect(min).toBeCloseTo(-0.5, 2);
+    expect(max).toBeCloseTo(5.5, 2);
+  });
+
+  it('handles multiple signal arrays', () => {
+    const [min, max] = computeYExtent([[0, 1, 2], [-1, 0, 3]]);
+    expect(min).toBeLessThan(-1);
+    expect(max).toBeGreaterThan(3);
+  });
+
+  it('handles constant signal (adds ±1 padding)', () => {
+    const [min, max] = computeYExtent([[5, 5, 5]]);
+    expect(min).toBe(4);
+    expect(max).toBe(6);
+  });
+});
+
+describe('bisectData', () => {
+  it('finds the nearest index for a given x value', () => {
+    const xValues = [0, 1, 2, 3, 4, 5];
+    expect(bisectData(xValues, 2.3)).toBe(2);
+    expect(bisectData(xValues, 2.7)).toBe(3);
+    expect(bisectData(xValues, 0)).toBe(0);
+    expect(bisectData(xValues, 5)).toBe(5);
+  });
+
+  it('clamps to array bounds', () => {
+    const xValues = [1, 2, 3];
+    expect(bisectData(xValues, -10)).toBe(0);
+    expect(bisectData(xValues, 100)).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/core/scales.test.ts`
+Expected: FAIL — `./scales.js` module not found.
+
+- [ ] **Step 3: Implement scales.ts**
+
+```typescript
+// src/core/scales.ts
+import { scaleLinear, scaleLog, type ScaleLinear, type ScaleLogarithmic } from 'd3-scale';
+import { bisector } from 'd3-array';
+
+export type LinearScale = ScaleLinear<number, number>;
+export type LogScale = ScaleLogarithmic<number, number>;
+
+/** Create a linear scale mapping [domainMin, domainMax] to [rangeMin, rangeMax]. */
+export function createLinearScale(domain: [number, number], range: [number, number]): LinearScale {
+  return scaleLinear().domain(domain).range(range);
+}
+
+/** Create a log10 scale mapping [domainMin, domainMax] to [rangeMin, rangeMax]. */
+export function createLogScale(domain: [number, number], range: [number, number]): LogScale {
+  return scaleLog().base(10).domain(domain).range(range);
+}
+
+/**
+ * Compute y-axis extent from signal arrays with 10% padding.
+ * If the data is constant, adds ±1 padding.
+ */
+export function computeYExtent(signalArrays: number[][]): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const arr of signalArrays) {
+    for (const v of arr) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!isFinite(min) || !isFinite(max)) return [-1, 1];
+  if (min === max) return [min - 1, max + 1];
+  const padding = (max - min) * 0.1;
+  return [min - padding, max + padding];
+}
+
+const xBisector = bisector<number, number>((d) => d).center;
+
+/**
+ * Find the index in a sorted array whose value is nearest to `target`.
+ * Returns the index clamped to [0, length - 1].
+ */
+export function bisectData(sortedX: number[], target: number): number {
+  if (sortedX.length === 0) return 0;
+  const idx = xBisector(sortedX, target);
+  return Math.max(0, Math.min(idx, sortedX.length - 1));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/core/scales.test.ts`
+Expected: All scale tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { createLinearScale, createLogScale, computeYExtent, bisectData } from './scales.js';
+export type { LinearScale, LogScale } from './scales.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/scales.ts packages/ui/src/core/scales.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add scale utilities wrapping d3-scale"
+```
+
+---
+
+### Task 5: Data normalization
+
+**Files:**
+- Create: `packages/ui/src/core/data.ts`
+- Create: `packages/ui/src/core/data.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write data normalization tests**
+
+These tests will import types from `@spice-ts/core` and create mock result objects to verify normalization. Since `TransientResult` and `ACResult` are classes with methods, we construct minimal mock instances.
+
+```typescript
+// src/core/data.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeTransientData, normalizeACData } from './data.js';
+import type { TransientDataset, ACDataset } from './types.js';
+
+// Helper: create a mock TransientResult-like object
+function mockTransientResult(time: number[], voltages: Record<string, number[]>) {
+  const voltageMap = new Map(Object.entries(voltages));
+  return {
+    time,
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown node: ${node}`);
+      return v;
+    },
+    current(_source: string) { return []; },
+  };
+}
+
+// Helper: create a mock ACResult-like object
+function mockACResult(
+  frequencies: number[],
+  voltages: Record<string, { magnitude: number; phase: number }[]>,
+) {
+  const voltageMap = new Map(Object.entries(voltages));
+  return {
+    frequencies,
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown node: ${node}`);
+      return v;
+    },
+    current(_source: string) { return []; },
+  };
+}
+
+describe('normalizeTransientData', () => {
+  it('normalizes a single TransientResult', () => {
+    const result = mockTransientResult([0, 1, 2], { out: [0, 2.5, 5] });
+    const datasets = normalizeTransientData(result, ['out']);
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0].label).toBe('');
+    expect(datasets[0].time).toEqual([0, 1, 2]);
+    expect(datasets[0].signals.get('out')).toEqual([0, 2.5, 5]);
+  });
+
+  it('normalizes an array of TransientDatasets (pass-through)', () => {
+    const ds: TransientDataset[] = [
+      { time: [0, 1], signals: new Map([['out', [0, 5]]]), label: 'R=1k' },
+      { time: [0, 1], signals: new Map([['out', [0, 3]]]), label: 'R=10k' },
+    ];
+    const datasets = normalizeTransientData(ds, ['out']);
+    expect(datasets).toHaveLength(2);
+    expect(datasets[0].label).toBe('R=1k');
+    expect(datasets[1].label).toBe('R=10k');
+  });
+
+  it('extracts only requested signals', () => {
+    const result = mockTransientResult([0, 1], { out: [0, 5], mid: [0, 2.5] });
+    const datasets = normalizeTransientData(result, ['out']);
+    expect(datasets[0].signals.has('out')).toBe(true);
+    expect(datasets[0].signals.has('mid')).toBe(false);
+  });
+});
+
+describe('normalizeACData', () => {
+  it('normalizes a single ACResult into magnitude/phase arrays', () => {
+    const result = mockACResult([100, 1000, 10000], {
+      out: [
+        { magnitude: 1, phase: 0 },
+        { magnitude: 0.707, phase: -45 },
+        { magnitude: 0.1, phase: -84 },
+      ],
+    });
+    const datasets = normalizeACData(result, ['out']);
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0].frequencies).toEqual([100, 1000, 10000]);
+    const mags = datasets[0].magnitudes.get('out')!;
+    // Magnitude converted to dB: 20*log10(mag)
+    expect(mags[0]).toBeCloseTo(0, 1); // 20*log10(1) = 0 dB
+    expect(mags[1]).toBeCloseTo(-3.01, 1); // 20*log10(0.707) ≈ -3 dB
+    expect(datasets[0].phases.get('out')).toEqual([0, -45, -84]);
+  });
+
+  it('normalizes an array of ACDatasets (pass-through)', () => {
+    const ds: ACDataset[] = [
+      {
+        frequencies: [100, 1000],
+        magnitudes: new Map([['out', [0, -3]]]),
+        phases: new Map([['out', [0, -45]]]),
+        label: 'C=1n',
+      },
+    ];
+    const datasets = normalizeACData(ds, ['out']);
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0].label).toBe('C=1n');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/core/data.test.ts`
+Expected: FAIL — `./data.js` module not found.
+
+- [ ] **Step 3: Implement data.ts**
+
+```typescript
+// src/core/data.ts
+import type { TransientDataset, ACDataset } from './types.js';
+
+/**
+ * Duck-type interface for objects shaped like TransientResult.
+ * Avoids hard dependency on @spice-ts/core class at runtime.
+ */
+interface TransientResultLike {
+  time: number[];
+  voltage(node: string): number[];
+  current(source: string): number[];
+}
+
+/**
+ * Duck-type interface for objects shaped like ACResult.
+ */
+interface ACResultLike {
+  frequencies: number[];
+  voltage(node: string): { magnitude: number; phase: number }[];
+  current(source: string): { magnitude: number; phase: number }[];
+}
+
+function isTransientResultLike(data: unknown): data is TransientResultLike {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'time' in data &&
+    Array.isArray((data as TransientResultLike).time) &&
+    'voltage' in data &&
+    typeof (data as TransientResultLike).voltage === 'function'
+  );
+}
+
+function isACResultLike(data: unknown): data is ACResultLike {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'frequencies' in data &&
+    Array.isArray((data as ACResultLike).frequencies) &&
+    'voltage' in data &&
+    typeof (data as ACResultLike).voltage === 'function'
+  );
+}
+
+/**
+ * Normalize transient input data into an array of TransientDataset.
+ * Accepts either a TransientResult-like object or a pre-normalized dataset array.
+ */
+export function normalizeTransientData(
+  data: unknown,
+  signals: string[],
+): TransientDataset[] {
+  if (Array.isArray(data)) {
+    return data as TransientDataset[];
+  }
+
+  if (!isTransientResultLike(data)) {
+    throw new Error('Invalid transient data: expected TransientResult or TransientDataset[]');
+  }
+
+  const signalMap = new Map<string, number[]>();
+  for (const name of signals) {
+    try {
+      signalMap.set(name, data.voltage(name));
+    } catch {
+      try {
+        signalMap.set(name, data.current(name));
+      } catch {
+        // Signal not found — skip
+      }
+    }
+  }
+
+  return [{ time: data.time, signals: signalMap, label: '' }];
+}
+
+/**
+ * Normalize AC input data into an array of ACDataset.
+ * Converts linear magnitude to dB (20 * log10).
+ */
+export function normalizeACData(
+  data: unknown,
+  signals: string[],
+): ACDataset[] {
+  if (Array.isArray(data)) {
+    return data as ACDataset[];
+  }
+
+  if (!isACResultLike(data)) {
+    throw new Error('Invalid AC data: expected ACResult or ACDataset[]');
+  }
+
+  const magnitudes = new Map<string, number[]>();
+  const phases = new Map<string, number[]>();
+
+  for (const name of signals) {
+    try {
+      const phasors = data.voltage(name);
+      magnitudes.set(name, phasors.map((p) => 20 * Math.log10(Math.max(p.magnitude, 1e-30))));
+      phases.set(name, phasors.map((p) => p.phase));
+    } catch {
+      try {
+        const phasors = data.current(name);
+        magnitudes.set(name, phasors.map((p) => 20 * Math.log10(Math.max(p.magnitude, 1e-30))));
+        phases.set(name, phasors.map((p) => p.phase));
+      } catch {
+        // Signal not found — skip
+      }
+    }
+  }
+
+  return [{ frequencies: data.frequencies, magnitudes, phases, label: '' }];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/core/data.test.ts`
+Expected: All data normalization tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { normalizeTransientData, normalizeACData } from './data.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/data.ts packages/ui/src/core/data.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add data normalization for TransientResult and ACResult"
+```
+
+---
+
+### Task 6: Growable buffer for streaming
+
+**Files:**
+- Create: `packages/ui/src/core/buffer.ts`
+- Create: `packages/ui/src/core/buffer.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write buffer tests**
+
+```typescript
+// src/core/buffer.test.ts
+import { describe, it, expect } from 'vitest';
+import { GrowableBuffer } from './buffer.js';
+
+describe('GrowableBuffer', () => {
+  it('starts empty with given initial capacity', () => {
+    const buf = new GrowableBuffer(16);
+    expect(buf.length).toBe(0);
+    expect(buf.capacity).toBe(16);
+  });
+
+  it('appends values and grows length', () => {
+    const buf = new GrowableBuffer(4);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    expect(buf.length).toBe(3);
+    expect(buf.get(0)).toBe(1);
+    expect(buf.get(1)).toBe(2);
+    expect(buf.get(2)).toBe(3);
+  });
+
+  it('doubles capacity when full', () => {
+    const buf = new GrowableBuffer(2);
+    buf.push(1);
+    buf.push(2);
+    expect(buf.capacity).toBe(2);
+    buf.push(3); // triggers grow
+    expect(buf.capacity).toBe(4);
+    expect(buf.length).toBe(3);
+    expect(buf.get(2)).toBe(3);
+  });
+
+  it('toArray returns a copy of the data', () => {
+    const buf = new GrowableBuffer(4);
+    buf.push(10);
+    buf.push(20);
+    const arr = buf.toArray();
+    expect(arr).toEqual([10, 20]);
+    expect(arr).toBeInstanceOf(Float64Array);
+    // Mutating the copy should not affect the buffer
+    arr[0] = 999;
+    expect(buf.get(0)).toBe(10);
+  });
+
+  it('clear resets length but keeps capacity', () => {
+    const buf = new GrowableBuffer(4);
+    buf.push(1);
+    buf.push(2);
+    buf.clear();
+    expect(buf.length).toBe(0);
+    expect(buf.capacity).toBe(4);
+  });
+
+  it('slice returns a sub-view as regular number array', () => {
+    const buf = new GrowableBuffer(8);
+    for (let i = 0; i < 5; i++) buf.push(i * 10);
+    expect(buf.slice(1, 4)).toEqual([10, 20, 30]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/core/buffer.test.ts`
+Expected: FAIL — `./buffer.js` module not found.
+
+- [ ] **Step 3: Implement buffer.ts**
+
+```typescript
+// src/core/buffer.ts
+
+/**
+ * A growable Float64Array buffer for accumulating streaming data.
+ * Doubles capacity when full. Avoids repeated array copies.
+ */
+export class GrowableBuffer {
+  private data: Float64Array;
+  private _length = 0;
+
+  constructor(initialCapacity = 1024) {
+    this.data = new Float64Array(initialCapacity);
+  }
+
+  get length(): number {
+    return this._length;
+  }
+
+  get capacity(): number {
+    return this.data.length;
+  }
+
+  /** Append a value to the end. Grows capacity if needed. */
+  push(value: number): void {
+    if (this._length >= this.data.length) {
+      const newData = new Float64Array(this.data.length * 2);
+      newData.set(this.data);
+      this.data = newData;
+    }
+    this.data[this._length++] = value;
+  }
+
+  /** Get value at index. */
+  get(index: number): number {
+    return this.data[index];
+  }
+
+  /** Return a copy of the used portion as a Float64Array. */
+  toArray(): Float64Array {
+    return this.data.slice(0, this._length);
+  }
+
+  /** Return a slice as a regular number array. */
+  slice(start: number, end: number): number[] {
+    return Array.from(this.data.subarray(start, end));
+  }
+
+  /** Reset length to 0 without deallocating. */
+  clear(): void {
+    this._length = 0;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/core/buffer.test.ts`
+Expected: All buffer tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { GrowableBuffer } from './buffer.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/buffer.ts packages/ui/src/core/buffer.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add GrowableBuffer for streaming data accumulation"
+```
+
+---
+
+### Task 7: Transient renderer
+
+**Files:**
+- Create: `packages/ui/src/core/renderer.ts`
+- Create: `packages/ui/src/core/renderer.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write renderer tests**
+
+Test the public API, not individual draw calls. Focus on initialization, data setting, cursor computation, and cleanup.
+
+```typescript
+// src/core/renderer.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TransientRenderer } from './renderer.js';
+import { DARK_THEME } from './theme.js';
+import type { TransientDataset } from './types.js';
+
+function createTestCanvas(width = 800, height = 400): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  // getBoundingClientRect is not available in jsdom
+  canvas.getBoundingClientRect = () => ({
+    x: 0, y: 0, width, height, top: 0, left: 0, right: width, bottom: height, toJSON() {},
+  });
+  return canvas;
+}
+
+function createTestData(): TransientDataset[] {
+  const time = [0, 1e-3, 2e-3, 3e-3, 4e-3, 5e-3];
+  const signals = new Map<string, number[]>();
+  signals.set('out', [0, 1, 2, 3, 4, 5]);
+  signals.set('in', [5, 5, 5, 5, 5, 5]);
+  return [{ time, signals, label: '' }];
+}
+
+describe('TransientRenderer', () => {
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    canvas = createTestCanvas();
+  });
+
+  it('constructs without error', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    expect(renderer).toBeDefined();
+    renderer.destroy();
+  });
+
+  it('setData and render without error', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out', 'in']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('emits cursorMove events', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    // Simulate a cursor update at pixel position
+    renderer.setCursorPixelX(200);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x: expect.any(Number),
+        pixelX: 200,
+        values: expect.any(Array),
+      }),
+    );
+
+    renderer.destroy();
+  });
+
+  it('setCursorPixelX(null) clears cursor', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    renderer.setCursorPixelX(null);
+    expect(callback).toHaveBeenCalledWith(null);
+
+    renderer.destroy();
+  });
+
+  it('fitToData resets zoom to show all data', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    // zoom in
+    renderer.zoomAt(400, 2);
+    renderer.fitToData();
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setSignalVisibility hides/shows signals', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out', 'in']);
+    renderer.setSignalVisibility('out', false);
+    renderer.render(); // should not throw even with hidden signal
+    renderer.destroy();
+  });
+
+  it('destroy cleans up', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.destroy();
+    // Calling render after destroy should not throw
+    renderer.render();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/core/renderer.test.ts`
+Expected: FAIL — `./renderer.js` module not found.
+
+- [ ] **Step 3: Implement renderer.ts**
+
+```typescript
+// src/core/renderer.ts
+import { createLinearScale, computeYExtent, bisectData, type LinearScale } from './scales.js';
+import { formatTime, formatVoltage } from './format.js';
+import type { ThemeConfig, TransientDataset, CursorState, CursorValue, Margins, RendererEvents } from './types.js';
+import { DEFAULT_PALETTE } from './types.js';
+
+export interface TransientRendererOptions {
+  theme: ThemeConfig;
+  margin?: Partial<Margins>;
+}
+
+interface SignalState {
+  name: string;
+  color: string;
+  visible: boolean;
+  datasetIndex: number;
+}
+
+export class TransientRenderer {
+  private canvas: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D | null;
+  private theme: ThemeConfig;
+  private margin: Margins;
+  private dpr: number;
+
+  private datasets: TransientDataset[] = [];
+  private signalStates: SignalState[] = [];
+  private xScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private yScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private xDomain: [number, number] = [0, 1];
+  private yDomain: [number, number] = [0, 1];
+  private cursorState: CursorState | null = null;
+  private destroyed = false;
+
+  private listeners: Partial<{ [K in keyof RendererEvents]: RendererEvents[K][] }> = {};
+
+  constructor(canvas: HTMLCanvasElement, options: TransientRendererOptions) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.theme = options.theme;
+    this.dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+    this.margin = {
+      top: options.margin?.top ?? 10,
+      right: options.margin?.right ?? 16,
+      bottom: options.margin?.bottom ?? 32,
+      left: options.margin?.left ?? 56,
+    };
+  }
+
+  /** Set or replace the data displayed. */
+  setData(datasets: TransientDataset[], signals: string[]): void {
+    this.datasets = datasets;
+    this.signalStates = [];
+
+    let colorIdx = 0;
+    for (let di = 0; di < datasets.length; di++) {
+      for (const name of signals) {
+        if (datasets[di].signals.has(name)) {
+          this.signalStates.push({
+            name,
+            color: DEFAULT_PALETTE[colorIdx % DEFAULT_PALETTE.length],
+            visible: true,
+            datasetIndex: di,
+          });
+          colorIdx++;
+        }
+      }
+    }
+
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  /** Update theme. */
+  setTheme(theme: ThemeConfig): void {
+    this.theme = theme;
+  }
+
+  /** Override color for a signal. */
+  setSignalColor(name: string, color: string): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.color = color;
+    }
+  }
+
+  /** Toggle signal visibility. */
+  setSignalVisibility(name: string, visible: boolean): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.visible = visible;
+    }
+  }
+
+  /** Get current signal states (for legend rendering). */
+  getSignalStates(): ReadonlyArray<Readonly<SignalState>> {
+    return this.signalStates;
+  }
+
+  /** Set cursor at a pixel x position, or null to clear. */
+  setCursorPixelX(pixelX: number | null): void {
+    if (pixelX === null) {
+      this.cursorState = null;
+      this.emit('cursorMove', null);
+      return;
+    }
+
+    const dataX = this.xScale.invert(pixelX - this.margin.left);
+    const values: CursorValue[] = [];
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const idx = bisectData(ds.time as number[], dataX);
+      const signalArr = ds.signals.get(s.name);
+      if (!signalArr) continue;
+
+      const label = ds.label ? `${ds.label}: ${s.name}` : s.name;
+      values.push({
+        signalId: ds.label ? `${ds.label}:${s.name}` : s.name,
+        label,
+        value: signalArr[idx],
+        unit: 'V',
+        color: s.color,
+      });
+    }
+
+    this.cursorState = { x: dataX, pixelX, values };
+    this.emit('cursorMove', this.cursorState);
+  }
+
+  /** Zoom at a pixel x position by a factor (>1 zooms in, <1 zooms out). */
+  zoomAt(pixelX: number, factor: number): void {
+    const centerX = this.xScale.invert(pixelX - this.margin.left);
+    const [x0, x1] = this.xDomain;
+    const halfSpan = (x1 - x0) / 2 / factor;
+    this.xDomain = [centerX - halfSpan, centerX + halfSpan];
+    this.updateScales();
+  }
+
+  /** Zoom Y axis by factor. */
+  zoomY(factor: number): void {
+    const [y0, y1] = this.yDomain;
+    const center = (y0 + y1) / 2;
+    const halfSpan = (y1 - y0) / 2 / factor;
+    this.yDomain = [center - halfSpan, center + halfSpan];
+    this.updateScales();
+  }
+
+  /** Pan by pixel deltas. */
+  pan(dx: number, dy: number): void {
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+    const [x0, x1] = this.xDomain;
+    const [y0, y1] = this.yDomain;
+    const xShift = (dx / plotWidth) * (x1 - x0);
+    const yShift = (dy / plotHeight) * (y1 - y0);
+    this.xDomain = [x0 - xShift, x1 - xShift];
+    this.yDomain = [y0 + yShift, y1 + yShift];
+    this.updateScales();
+  }
+
+  /** Reset zoom to show all data. */
+  fitToData(): void {
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  /** Register an event listener. */
+  on<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    (this.listeners[event] as RendererEvents[K][]).push(callback);
+  }
+
+  /** Remove an event listener. */
+  off<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    const idx = (arr as RendererEvents[K][]).indexOf(callback);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
+  /** Render the full plot to the canvas. */
+  render(): void {
+    if (this.destroyed || !this.ctx) return;
+    const ctx = this.ctx;
+    const width = this.canvas.width / this.dpr;
+    const height = this.canvas.height / this.dpr;
+
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    ctx.save();
+    ctx.scale(this.dpr, this.dpr);
+
+    // Background
+    ctx.fillStyle = this.theme.background;
+    ctx.fillRect(this.margin.left, this.margin.top, this.getPlotWidth(), this.getPlotHeight());
+
+    this.drawGrid(ctx, width, height);
+    this.drawWaveforms(ctx);
+    this.drawXAxis(ctx, height);
+    this.drawYAxis(ctx);
+    if (this.cursorState) {
+      this.drawCursor(ctx);
+    }
+
+    ctx.restore();
+  }
+
+  /** Clean up resources. */
+  destroy(): void {
+    this.destroyed = true;
+    this.listeners = {};
+  }
+
+  // --- Private helpers ---
+
+  private emit<K extends keyof RendererEvents>(event: K, ...args: Parameters<RendererEvents[K]>): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    for (const cb of arr) {
+      (cb as (...a: unknown[]) => void)(...args);
+    }
+  }
+
+  private getPlotWidth(): number {
+    return this.canvas.width / this.dpr - this.margin.left - this.margin.right;
+  }
+
+  private getPlotHeight(): number {
+    return this.canvas.height / this.dpr - this.margin.top - this.margin.bottom;
+  }
+
+  private computeDefaultDomains(): void {
+    if (this.datasets.length === 0) return;
+    // X domain: min/max time across all datasets
+    let xMin = Infinity;
+    let xMax = -Infinity;
+    for (const ds of this.datasets) {
+      if (ds.time.length > 0) {
+        xMin = Math.min(xMin, ds.time[0]);
+        xMax = Math.max(xMax, ds.time[ds.time.length - 1]);
+      }
+    }
+    if (isFinite(xMin) && isFinite(xMax)) {
+      this.xDomain = [xMin, xMax];
+    }
+
+    // Y domain: extent of all visible signals
+    const arrays: number[][] = [];
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const arr = this.datasets[s.datasetIndex].signals.get(s.name);
+      if (arr) arrays.push(arr);
+    }
+    if (arrays.length > 0) {
+      this.yDomain = computeYExtent(arrays);
+    }
+  }
+
+  private updateScales(): void {
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+    this.xScale = createLinearScale(this.xDomain, [0, plotWidth]);
+    this.yScale = createLinearScale(this.yDomain, [plotHeight, 0]); // inverted: y=0 at bottom
+  }
+
+  private drawGrid(ctx: CanvasRenderingContext2D, _width: number, _height: number): void {
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+    const { left, top } = this.margin;
+
+    ctx.strokeStyle = this.theme.grid;
+    ctx.lineWidth = 0.5;
+
+    // Vertical grid lines
+    const xTicks = this.xScale.ticks(6);
+    for (const tick of xTicks) {
+      const x = left + this.xScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(x, top);
+      ctx.lineTo(x, top + plotHeight);
+      ctx.stroke();
+    }
+
+    // Horizontal grid lines
+    const yTicks = this.yScale.ticks(5);
+    for (const tick of yTicks) {
+      const y = top + this.yScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(left, y);
+      ctx.lineTo(left + plotWidth, y);
+      ctx.stroke();
+    }
+  }
+
+  private drawWaveforms(ctx: CanvasRenderingContext2D): void {
+    const { left, top } = this.margin;
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+
+    // Clip to plot area
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(left, top, plotWidth, plotHeight);
+    ctx.clip();
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const yArr = ds.signals.get(s.name);
+      if (!yArr) continue;
+
+      ctx.strokeStyle = s.color;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+
+      let started = false;
+      for (let i = 0; i < ds.time.length; i++) {
+        const x = left + this.xScale(ds.time[i]);
+        const y = top + this.yScale(yArr[i]);
+        if (!started) {
+          ctx.moveTo(x, y);
+          started = true;
+        } else {
+          ctx.lineTo(x, y);
+        }
+      }
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  private drawXAxis(ctx: CanvasRenderingContext2D, height: number): void {
+    const { left } = this.margin;
+    const plotHeight = this.getPlotHeight();
+    const y = this.margin.top + plotHeight;
+
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `${this.theme.fontSize}px ${this.theme.font}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+
+    const ticks = this.xScale.ticks(6);
+    for (const tick of ticks) {
+      const x = left + this.xScale(tick);
+      ctx.fillText(formatTime(tick), x, y + 6);
+    }
+  }
+
+  private drawYAxis(ctx: CanvasRenderingContext2D): void {
+    const { left, top } = this.margin;
+
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `${this.theme.fontSize}px ${this.theme.font}`;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+
+    const ticks = this.yScale.ticks(5);
+    for (const tick of ticks) {
+      const y = top + this.yScale(tick);
+      ctx.fillText(formatVoltage(tick), left - 6, y);
+    }
+  }
+
+  private drawCursor(ctx: CanvasRenderingContext2D): void {
+    if (!this.cursorState) return;
+    const { left, top } = this.margin;
+    const plotHeight = this.getPlotHeight();
+    const x = this.cursorState.pixelX;
+
+    // Dashed vertical line
+    ctx.strokeStyle = this.theme.cursor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(x, top);
+    ctx.lineTo(x, top + plotHeight);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Dots at intersection with each visible signal
+    for (const v of this.cursorState.values) {
+      const dataX = this.cursorState.x;
+      // Find the y value for this signal
+      for (const s of this.signalStates) {
+        const matchId = this.datasets[s.datasetIndex].label
+          ? `${this.datasets[s.datasetIndex].label}:${s.name}`
+          : s.name;
+        if (matchId !== v.signalId || !s.visible) continue;
+
+        const ds = this.datasets[s.datasetIndex];
+        const idx = bisectData(ds.time as number[], dataX);
+        const yArr = ds.signals.get(s.name);
+        if (!yArr) continue;
+
+        const py = top + this.yScale(yArr[idx]);
+        ctx.fillStyle = v.color;
+        ctx.strokeStyle = this.theme.background;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(x, py, 4, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+        break;
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/core/renderer.test.ts`
+Expected: All renderer tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { TransientRenderer, type TransientRendererOptions } from './renderer.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/renderer.ts packages/ui/src/core/renderer.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add TransientRenderer with Canvas waveform rendering"
+```
+
+---
+
+### Task 8: Bode renderer
+
+**Files:**
+- Create: `packages/ui/src/core/bode-renderer.ts`
+- Create: `packages/ui/src/core/bode-renderer.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write Bode renderer tests**
+
+```typescript
+// src/core/bode-renderer.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BodeRenderer } from './bode-renderer.js';
+import { DARK_THEME } from './theme.js';
+import type { ACDataset } from './types.js';
+
+function createTestCanvas(width = 800, height = 300): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  canvas.getBoundingClientRect = () => ({
+    x: 0, y: 0, width, height, top: 0, left: 0, right: width, bottom: height, toJSON() {},
+  });
+  return canvas;
+}
+
+function createTestACData(): ACDataset[] {
+  const frequencies = [100, 1000, 10000, 100000, 1000000];
+  const magnitudes = new Map([['out', [0, -1, -3, -10, -20]]]);
+  const phases = new Map([['out', [0, -10, -45, -75, -85]]]);
+  return [{ frequencies, magnitudes, phases, label: '' }];
+}
+
+describe('BodeRenderer', () => {
+  let magCanvas: HTMLCanvasElement;
+  let phaseCanvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    magCanvas = createTestCanvas();
+    phaseCanvas = createTestCanvas(800, 200);
+  });
+
+  it('constructs without error', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    expect(renderer).toBeDefined();
+    renderer.destroy();
+  });
+
+  it('setData and render without error', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('collapsing magnitude pane still renders phase', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setPaneVisible('magnitude', false);
+    renderer.render(); // should not throw
+    renderer.destroy();
+  });
+
+  it('collapsing phase pane still renders magnitude', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setPaneVisible('phase', false);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('emits cursorMove events', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    renderer.setCursorPixelX(200);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x: expect.any(Number),
+        values: expect.any(Array),
+      }),
+    );
+
+    renderer.destroy();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/core/bode-renderer.test.ts`
+Expected: FAIL — `./bode-renderer.js` module not found.
+
+- [ ] **Step 3: Implement bode-renderer.ts**
+
+```typescript
+// src/core/bode-renderer.ts
+import { createLogScale, createLinearScale, computeYExtent, bisectData, type LogScale, type LinearScale } from './scales.js';
+import { formatFrequency, formatDB, formatPhase } from './format.js';
+import type { ThemeConfig, ACDataset, CursorState, CursorValue, Margins, RendererEvents } from './types.js';
+import { DEFAULT_PALETTE } from './types.js';
+
+export interface BodeRendererOptions {
+  theme: ThemeConfig;
+  margin?: Partial<Margins>;
+  defaultPanes?: 'both' | 'magnitude' | 'phase';
+}
+
+interface SignalState {
+  name: string;
+  color: string;
+  visible: boolean;
+  datasetIndex: number;
+}
+
+export class BodeRenderer {
+  private magCanvas: HTMLCanvasElement;
+  private phaseCanvas: HTMLCanvasElement;
+  private magCtx: CanvasRenderingContext2D | null;
+  private phaseCtx: CanvasRenderingContext2D | null;
+  private theme: ThemeConfig;
+  private margin: Margins;
+  private dpr: number;
+
+  private datasets: ACDataset[] = [];
+  private signalStates: SignalState[] = [];
+  private xScale: LogScale = createLogScale([1, 10], [0, 1]);
+  private magYScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private phaseYScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private xDomain: [number, number] = [1, 10];
+  private magYDomain: [number, number] = [-60, 10];
+  private phaseYDomain: [number, number] = [-180, 0];
+
+  private magnitudeVisible = true;
+  private phaseVisible = true;
+  private cursorState: CursorState | null = null;
+  private destroyed = false;
+  private listeners: Partial<{ [K in keyof RendererEvents]: RendererEvents[K][] }> = {};
+
+  constructor(magCanvas: HTMLCanvasElement, phaseCanvas: HTMLCanvasElement, options: BodeRendererOptions) {
+    this.magCanvas = magCanvas;
+    this.phaseCanvas = phaseCanvas;
+    this.magCtx = magCanvas.getContext('2d');
+    this.phaseCtx = phaseCanvas.getContext('2d');
+    this.theme = options.theme;
+    this.dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+    this.margin = {
+      top: options.margin?.top ?? 20,
+      right: options.margin?.right ?? 16,
+      bottom: options.margin?.bottom ?? 32,
+      left: options.margin?.left ?? 56,
+    };
+
+    if (options.defaultPanes === 'magnitude') this.phaseVisible = false;
+    if (options.defaultPanes === 'phase') this.magnitudeVisible = false;
+  }
+
+  setData(datasets: ACDataset[], signals: string[]): void {
+    this.datasets = datasets;
+    this.signalStates = [];
+
+    let colorIdx = 0;
+    for (let di = 0; di < datasets.length; di++) {
+      for (const name of signals) {
+        if (datasets[di].magnitudes.has(name)) {
+          this.signalStates.push({
+            name,
+            color: DEFAULT_PALETTE[colorIdx % DEFAULT_PALETTE.length],
+            visible: true,
+            datasetIndex: di,
+          });
+          colorIdx++;
+        }
+      }
+    }
+
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  setTheme(theme: ThemeConfig): void {
+    this.theme = theme;
+  }
+
+  setSignalColor(name: string, color: string): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.color = color;
+    }
+  }
+
+  setSignalVisibility(name: string, visible: boolean): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.visible = visible;
+    }
+  }
+
+  getSignalStates(): ReadonlyArray<Readonly<SignalState>> {
+    return this.signalStates;
+  }
+
+  setPaneVisible(pane: 'magnitude' | 'phase', visible: boolean): void {
+    if (pane === 'magnitude') this.magnitudeVisible = visible;
+    if (pane === 'phase') this.phaseVisible = visible;
+  }
+
+  isPaneVisible(pane: 'magnitude' | 'phase'): boolean {
+    return pane === 'magnitude' ? this.magnitudeVisible : this.phaseVisible;
+  }
+
+  setCursorPixelX(pixelX: number | null): void {
+    if (pixelX === null) {
+      this.cursorState = null;
+      this.emit('cursorMove', null);
+      return;
+    }
+
+    const dataX = this.xScale.invert(pixelX - this.margin.left);
+    const values: CursorValue[] = [];
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const idx = bisectData(ds.frequencies as number[], dataX);
+      const magArr = ds.magnitudes.get(s.name);
+      const phaseArr = ds.phases.get(s.name);
+      const label = ds.label ? `${ds.label}: ${s.name}` : s.name;
+      const signalId = ds.label ? `${ds.label}:${s.name}` : s.name;
+
+      if (magArr && this.magnitudeVisible) {
+        values.push({ signalId: `${signalId}:mag`, label: `${label} (mag)`, value: magArr[idx], unit: 'dB', color: s.color });
+      }
+      if (phaseArr && this.phaseVisible) {
+        values.push({ signalId: `${signalId}:phase`, label: `${label} (phase)`, value: phaseArr[idx], unit: '°', color: s.color });
+      }
+    }
+
+    this.cursorState = { x: dataX, pixelX, values };
+    this.emit('cursorMove', this.cursorState);
+  }
+
+  zoomAt(pixelX: number, factor: number): void {
+    const centerX = this.xScale.invert(pixelX - this.margin.left);
+    const logCenter = Math.log10(centerX);
+    const [lx0, lx1] = [Math.log10(this.xDomain[0]), Math.log10(this.xDomain[1])];
+    const halfSpan = (lx1 - lx0) / 2 / factor;
+    this.xDomain = [Math.pow(10, logCenter - halfSpan), Math.pow(10, logCenter + halfSpan)];
+    this.updateScales();
+  }
+
+  pan(dx: number, _dy: number): void {
+    const plotWidth = this.getPlotWidth(this.magCanvas);
+    const [lx0, lx1] = [Math.log10(this.xDomain[0]), Math.log10(this.xDomain[1])];
+    const logShift = (dx / plotWidth) * (lx1 - lx0);
+    this.xDomain = [Math.pow(10, lx0 - logShift), Math.pow(10, lx1 - logShift)];
+    this.updateScales();
+  }
+
+  fitToData(): void {
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  on<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    (this.listeners[event] as RendererEvents[K][]).push(callback);
+  }
+
+  off<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    const idx = (arr as RendererEvents[K][]).indexOf(callback);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
+  render(): void {
+    if (this.destroyed) return;
+    if (this.magnitudeVisible && this.magCtx) {
+      this.renderPane(this.magCtx, this.magCanvas, 'magnitude');
+    } else if (this.magCtx) {
+      this.clearCanvas(this.magCtx, this.magCanvas);
+    }
+    if (this.phaseVisible && this.phaseCtx) {
+      this.renderPane(this.phaseCtx, this.phaseCanvas, 'phase');
+    } else if (this.phaseCtx) {
+      this.clearCanvas(this.phaseCtx, this.phaseCanvas);
+    }
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.listeners = {};
+  }
+
+  // --- Private ---
+
+  private emit<K extends keyof RendererEvents>(event: K, ...args: Parameters<RendererEvents[K]>): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    for (const cb of arr) (cb as (...a: unknown[]) => void)(...args);
+  }
+
+  private getPlotWidth(canvas: HTMLCanvasElement): number {
+    return canvas.width / this.dpr - this.margin.left - this.margin.right;
+  }
+
+  private getPlotHeight(canvas: HTMLCanvasElement): number {
+    return canvas.height / this.dpr - this.margin.top - this.margin.bottom;
+  }
+
+  private clearCanvas(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement): void {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  private renderPane(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, pane: 'magnitude' | 'phase'): void {
+    const width = canvas.width / this.dpr;
+    const height = canvas.height / this.dpr;
+    const plotWidth = this.getPlotWidth(canvas);
+    const plotHeight = this.getPlotHeight(canvas);
+    const yScale = pane === 'magnitude' ? this.magYScale : this.phaseYScale;
+    const formatY = pane === 'magnitude' ? formatDB : formatPhase;
+    const getArr = (ds: ACDataset, name: string) =>
+      pane === 'magnitude' ? ds.magnitudes.get(name) : ds.phases.get(name);
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(this.dpr, this.dpr);
+
+    // Background
+    ctx.fillStyle = this.theme.background;
+    ctx.fillRect(this.margin.left, this.margin.top, plotWidth, plotHeight);
+
+    // Pane label
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `500 ${this.theme.fontSize - 1}px ${this.theme.font}`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(pane === 'magnitude' ? 'MAGNITUDE (dB)' : 'PHASE (°)', this.margin.left + 4, 4);
+
+    // Grid
+    ctx.strokeStyle = this.theme.grid;
+    ctx.lineWidth = 0.5;
+    const xTicks = this.xScale.ticks(6);
+    for (const tick of xTicks) {
+      const x = this.margin.left + this.xScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(x, this.margin.top);
+      ctx.lineTo(x, this.margin.top + plotHeight);
+      ctx.stroke();
+    }
+    const yTicks = yScale.ticks(4);
+    for (const tick of yTicks) {
+      const y = this.margin.top + yScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(this.margin.left, y);
+      ctx.lineTo(this.margin.left + plotWidth, y);
+      ctx.stroke();
+    }
+
+    // -3dB reference line on magnitude pane
+    if (pane === 'magnitude') {
+      const y3db = this.margin.top + this.magYScale(-3);
+      ctx.strokeStyle = 'hsl(0, 60%, 40%)';
+      ctx.lineWidth = 0.5;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(this.margin.left, y3db);
+      ctx.lineTo(this.margin.left + plotWidth, y3db);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Waveforms (clipped)
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(this.margin.left, this.margin.top, plotWidth, plotHeight);
+    ctx.clip();
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const yArr = getArr(ds, s.name);
+      if (!yArr) continue;
+
+      ctx.strokeStyle = s.color;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      let started = false;
+      for (let i = 0; i < ds.frequencies.length; i++) {
+        const x = this.margin.left + this.xScale(ds.frequencies[i]);
+        const y = this.margin.top + yScale(yArr[i]);
+        if (!started) { ctx.moveTo(x, y); started = true; }
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    // Axes
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `${this.theme.fontSize}px ${this.theme.font}`;
+
+    // Y axis labels
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (const tick of yTicks) {
+      const y = this.margin.top + yScale(tick);
+      ctx.fillText(formatY(tick), this.margin.left - 6, y);
+    }
+
+    // X axis labels (only on phase pane, or whichever is the bottom pane)
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    for (const tick of xTicks) {
+      const x = this.margin.left + this.xScale(tick);
+      ctx.fillText(formatFrequency(tick), x, this.margin.top + plotHeight + 6);
+    }
+
+    // Cursor
+    if (this.cursorState) {
+      const cx = this.cursorState.pixelX;
+      ctx.strokeStyle = this.theme.cursor;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath();
+      ctx.moveTo(cx, this.margin.top);
+      ctx.lineTo(cx, this.margin.top + plotHeight);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    ctx.restore();
+  }
+
+  private computeDefaultDomains(): void {
+    if (this.datasets.length === 0) return;
+
+    // X domain: min/max frequency
+    let fMin = Infinity;
+    let fMax = -Infinity;
+    for (const ds of this.datasets) {
+      if (ds.frequencies.length > 0) {
+        fMin = Math.min(fMin, ds.frequencies[0]);
+        fMax = Math.max(fMax, ds.frequencies[ds.frequencies.length - 1]);
+      }
+    }
+    if (isFinite(fMin) && isFinite(fMax) && fMin > 0) {
+      this.xDomain = [fMin, fMax];
+    }
+
+    // Magnitude Y domain
+    const magArrays: number[][] = [];
+    const phaseArrays: number[][] = [];
+    for (const s of this.signalStates) {
+      const ds = this.datasets[s.datasetIndex];
+      const mag = ds.magnitudes.get(s.name);
+      const phase = ds.phases.get(s.name);
+      if (mag) magArrays.push(mag);
+      if (phase) phaseArrays.push(phase);
+    }
+    if (magArrays.length > 0) this.magYDomain = computeYExtent(magArrays);
+    if (phaseArrays.length > 0) this.phaseYDomain = computeYExtent(phaseArrays);
+  }
+
+  private updateScales(): void {
+    const magPlotWidth = this.getPlotWidth(this.magCanvas);
+    const magPlotHeight = this.getPlotHeight(this.magCanvas);
+    const phasePlotHeight = this.getPlotHeight(this.phaseCanvas);
+
+    this.xScale = createLogScale(this.xDomain, [0, magPlotWidth]);
+    this.magYScale = createLinearScale(this.magYDomain, [magPlotHeight, 0]);
+    this.phaseYScale = createLinearScale(this.phaseYDomain, [phasePlotHeight, 0]);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/core/bode-renderer.test.ts`
+Expected: All Bode renderer tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { BodeRenderer, type BodeRendererOptions } from './bode-renderer.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/bode-renderer.ts packages/ui/src/core/bode-renderer.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add BodeRenderer with dual-pane magnitude/phase Canvas rendering"
+```
+
+---
+
+### Task 9: Interaction handler
+
+**Files:**
+- Create: `packages/ui/src/core/interaction.ts`
+- Create: `packages/ui/src/core/interaction.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write interaction tests**
+
+```typescript
+// src/core/interaction.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InteractionHandler } from './interaction.js';
+
+function createTestCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = 800;
+  canvas.height = 400;
+  canvas.getBoundingClientRect = () => ({
+    x: 0, y: 0, width: 800, height: 400, top: 0, left: 0, right: 800, bottom: 400, toJSON() {},
+  });
+  return canvas;
+}
+
+describe('InteractionHandler', () => {
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    canvas = createTestCanvas();
+  });
+
+  it('fires onCursorMove on pointermove', () => {
+    const onCursor = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: onCursor,
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 200, clientY: 150 }));
+    expect(onCursor).toHaveBeenCalledWith(200);
+
+    handler.destroy();
+  });
+
+  it('fires onCursorMove(null) on pointerleave', () => {
+    const onCursor = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: onCursor,
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointerleave'));
+    expect(onCursor).toHaveBeenCalledWith(null);
+
+    handler.destroy();
+  });
+
+  it('fires onZoom on wheel event', () => {
+    const onZoom = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom,
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, clientX: 400 }));
+    expect(onZoom).toHaveBeenCalledWith(400, expect.any(Number), false);
+
+    handler.destroy();
+  });
+
+  it('fires onZoom with shiftKey for vertical zoom', () => {
+    const onZoom = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom,
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, clientX: 400, shiftKey: true }));
+    expect(onZoom).toHaveBeenCalledWith(400, expect.any(Number), true);
+
+    handler.destroy();
+  });
+
+  it('fires onPan during drag', () => {
+    const onPan = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan,
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 300, clientY: 200 }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 310, clientY: 205, buttons: 1 }));
+    expect(onPan).toHaveBeenCalledWith(10, 5);
+
+    handler.destroy();
+  });
+
+  it('fires onDoubleClick on dblclick', () => {
+    const onDoubleClick = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick,
+    });
+
+    canvas.dispatchEvent(new MouseEvent('dblclick'));
+    expect(onDoubleClick).toHaveBeenCalled();
+
+    handler.destroy();
+  });
+
+  it('destroy removes event listeners', () => {
+    const onCursor = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: onCursor,
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    handler.destroy();
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 100 }));
+    expect(onCursor).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/core/interaction.test.ts`
+Expected: FAIL — `./interaction.js` module not found.
+
+- [ ] **Step 3: Implement interaction.ts**
+
+```typescript
+// src/core/interaction.ts
+
+export interface InteractionCallbacks {
+  /** Called with pixel X on hover, or null on leave. */
+  onCursorMove: (pixelX: number | null) => void;
+  /** Called on scroll-wheel zoom. factor >1 = zoom in. shiftKey = vertical zoom. */
+  onZoom: (pixelX: number, factor: number, shiftKey: boolean) => void;
+  /** Called during drag with pixel deltas. */
+  onPan: (dx: number, dy: number) => void;
+  /** Called on double-click (fit to data). */
+  onDoubleClick: () => void;
+}
+
+/**
+ * Attaches pointer/wheel event listeners to a canvas for zoom, pan, and cursor interaction.
+ * Framework-agnostic — works with any HTMLCanvasElement.
+ */
+export class InteractionHandler {
+  private canvas: HTMLCanvasElement;
+  private callbacks: InteractionCallbacks;
+  private dragging = false;
+  private lastX = 0;
+  private lastY = 0;
+  private destroyed = false;
+
+  private boundPointerMove: (e: PointerEvent) => void;
+  private boundPointerDown: (e: PointerEvent) => void;
+  private boundPointerUp: (e: PointerEvent) => void;
+  private boundPointerLeave: (e: PointerEvent) => void;
+  private boundWheel: (e: WheelEvent) => void;
+  private boundDblClick: (e: MouseEvent) => void;
+
+  constructor(canvas: HTMLCanvasElement, callbacks: InteractionCallbacks) {
+    this.canvas = canvas;
+    this.callbacks = callbacks;
+
+    this.boundPointerMove = this.handlePointerMove.bind(this);
+    this.boundPointerDown = this.handlePointerDown.bind(this);
+    this.boundPointerUp = this.handlePointerUp.bind(this);
+    this.boundPointerLeave = this.handlePointerLeave.bind(this);
+    this.boundWheel = this.handleWheel.bind(this);
+    this.boundDblClick = this.handleDblClick.bind(this);
+
+    canvas.addEventListener('pointermove', this.boundPointerMove);
+    canvas.addEventListener('pointerdown', this.boundPointerDown);
+    canvas.addEventListener('pointerup', this.boundPointerUp);
+    canvas.addEventListener('pointerleave', this.boundPointerLeave);
+    canvas.addEventListener('wheel', this.boundWheel, { passive: false });
+    canvas.addEventListener('dblclick', this.boundDblClick);
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.canvas.removeEventListener('pointermove', this.boundPointerMove);
+    this.canvas.removeEventListener('pointerdown', this.boundPointerDown);
+    this.canvas.removeEventListener('pointerup', this.boundPointerUp);
+    this.canvas.removeEventListener('pointerleave', this.boundPointerLeave);
+    this.canvas.removeEventListener('wheel', this.boundWheel);
+    this.canvas.removeEventListener('dblclick', this.boundDblClick);
+  }
+
+  private handlePointerMove(e: PointerEvent): void {
+    if (this.destroyed) return;
+
+    if (this.dragging && (e.buttons & 1)) {
+      const dx = e.clientX - this.lastX;
+      const dy = e.clientY - this.lastY;
+      this.lastX = e.clientX;
+      this.lastY = e.clientY;
+      this.callbacks.onPan(dx, dy);
+    } else {
+      this.callbacks.onCursorMove(e.clientX);
+    }
+  }
+
+  private handlePointerDown(e: PointerEvent): void {
+    if (this.destroyed) return;
+    this.dragging = true;
+    this.lastX = e.clientX;
+    this.lastY = e.clientY;
+    this.canvas.setPointerCapture?.(e.pointerId);
+  }
+
+  private handlePointerUp(e: PointerEvent): void {
+    this.dragging = false;
+    this.canvas.releasePointerCapture?.(e.pointerId);
+  }
+
+  private handlePointerLeave(_e: PointerEvent): void {
+    if (this.destroyed) return;
+    this.dragging = false;
+    this.callbacks.onCursorMove(null);
+  }
+
+  private handleWheel(e: WheelEvent): void {
+    if (this.destroyed) return;
+    e.preventDefault();
+    const zoomFactor = e.deltaY < 0 ? 1.2 : 1 / 1.2;
+    this.callbacks.onZoom(e.clientX, zoomFactor, e.shiftKey);
+  }
+
+  private handleDblClick(_e: MouseEvent): void {
+    if (this.destroyed) return;
+    this.callbacks.onDoubleClick();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/core/interaction.test.ts`
+Expected: All interaction tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { InteractionHandler, type InteractionCallbacks } from './interaction.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/interaction.ts packages/ui/src/core/interaction.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add InteractionHandler for zoom/pan/cursor events"
+```
+
+---
+
+### Task 10: Streaming controller
+
+**Files:**
+- Create: `packages/ui/src/core/streaming.ts`
+- Create: `packages/ui/src/core/streaming.test.ts`
+- Modify: `packages/ui/src/core/index.ts`
+
+- [ ] **Step 1: Write streaming tests**
+
+```typescript
+// src/core/streaming.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StreamingController } from './streaming.js';
+import type { TransientDataset } from './types.js';
+
+// Helper: create an async generator that yields TransientStep-like objects
+async function* mockStream(steps: { time: number; voltages: Map<string, number> }[]) {
+  for (const step of steps) {
+    yield step;
+  }
+}
+
+describe('StreamingController', () => {
+  it('collects streaming data into datasets', async () => {
+    const onData = vi.fn();
+    const controller = new StreamingController(['out'], onData);
+
+    const steps = [
+      { time: 0, voltages: new Map([['out', 0]]), currents: new Map() },
+      { time: 1e-3, voltages: new Map([['out', 2.5]]), currents: new Map() },
+      { time: 2e-3, voltages: new Map([['out', 5]]), currents: new Map() },
+    ];
+
+    await controller.consume(mockStream(steps));
+
+    // onData should have been called at least once
+    expect(onData).toHaveBeenCalled();
+
+    const dataset = controller.getDataset();
+    expect(dataset.time.length).toBe(3);
+    expect(dataset.signals.get('out')!.length).toBe(3);
+    expect(dataset.signals.get('out')![2]).toBe(5);
+  });
+
+  it('stop() halts consumption', async () => {
+    const onData = vi.fn();
+    const controller = new StreamingController(['out'], onData);
+
+    async function* infiniteStream() {
+      let t = 0;
+      while (true) {
+        yield { time: t, voltages: new Map([['out', t]]), currents: new Map() };
+        t += 1e-3;
+      }
+    }
+
+    const promise = controller.consume(infiniteStream());
+    // Stop after a tick
+    await new Promise((r) => setTimeout(r, 10));
+    controller.stop();
+    await promise;
+
+    expect(controller.getDataset().time.length).toBeGreaterThan(0);
+  });
+
+  it('clear() resets buffers', async () => {
+    const controller = new StreamingController(['out'], vi.fn());
+    const steps = [
+      { time: 0, voltages: new Map([['out', 1]]), currents: new Map() },
+    ];
+    await controller.consume(mockStream(steps));
+    expect(controller.getDataset().time.length).toBe(1);
+
+    controller.clear();
+    expect(controller.getDataset().time.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/core/streaming.test.ts`
+Expected: FAIL — `./streaming.js` module not found.
+
+- [ ] **Step 3: Implement streaming.ts**
+
+```typescript
+// src/core/streaming.ts
+import { GrowableBuffer } from './buffer.js';
+import type { TransientDataset } from './types.js';
+
+interface StreamingStep {
+  time: number;
+  voltages: Map<string, number>;
+  currents: Map<string, number>;
+}
+
+/**
+ * Consumes an async stream of simulation steps and accumulates data
+ * into growable buffers. Calls onData after each step so the renderer
+ * can schedule a repaint.
+ */
+export class StreamingController {
+  private timeBuffer = new GrowableBuffer();
+  private signalBuffers = new Map<string, GrowableBuffer>();
+  private signals: string[];
+  private onData: () => void;
+  private running = false;
+
+  constructor(signals: string[], onData: () => void) {
+    this.signals = signals;
+    this.onData = onData;
+    for (const name of signals) {
+      this.signalBuffers.set(name, new GrowableBuffer());
+    }
+  }
+
+  /** Consume an async iterator of streaming steps. Resolves when done or stopped. */
+  async consume(stream: AsyncIterable<StreamingStep>): Promise<void> {
+    this.running = true;
+    for await (const step of stream) {
+      if (!this.running) break;
+
+      this.timeBuffer.push(step.time);
+      for (const name of this.signals) {
+        const buf = this.signalBuffers.get(name)!;
+        const value = step.voltages.get(name) ?? step.currents.get(name) ?? 0;
+        buf.push(value);
+      }
+      this.onData();
+    }
+    this.running = false;
+  }
+
+  /** Stop consuming the stream. */
+  stop(): void {
+    this.running = false;
+  }
+
+  /** Whether the stream is actively being consumed. */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /** Get the accumulated data as a TransientDataset. */
+  getDataset(): TransientDataset {
+    const time = Array.from(this.timeBuffer.toArray());
+    const signals = new Map<string, number[]>();
+    for (const [name, buf] of this.signalBuffers) {
+      signals.set(name, Array.from(buf.toArray()));
+    }
+    return { time, signals, label: '' };
+  }
+
+  /** Clear all accumulated data. */
+  clear(): void {
+    this.timeBuffer.clear();
+    for (const buf of this.signalBuffers.values()) {
+      buf.clear();
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/core/streaming.test.ts`
+Expected: All streaming tests PASS.
+
+- [ ] **Step 5: Add exports to core/index.ts**
+
+Add to `src/core/index.ts`:
+```typescript
+export { StreamingController } from './streaming.js';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/core/streaming.ts packages/ui/src/core/streaming.test.ts packages/ui/src/core/index.ts
+git commit -m "feat(ui): add StreamingController for live data accumulation"
+```
+
+---
+
+### Task 11: Core exports and build verification
+
+**Files:**
+- Modify: `packages/ui/src/core/index.ts` (verify all exports)
+- Modify: `packages/ui/src/index.ts`
+
+- [ ] **Step 1: Verify core/index.ts has all exports**
+
+Final `src/core/index.ts` should contain:
+
+```typescript
+// Types
+export type {
+  ThemeConfig,
+  CursorState,
+  CursorValue,
+  SignalConfig,
+  TransientDataset,
+  ACDataset,
+  Margins,
+  RendererEvents,
+} from './types.js';
+export { DEFAULT_PALETTE } from './types.js';
+
+// Theme
+export { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';
+
+// Formatting
+export { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, formatDB, formatPhase } from './format.js';
+
+// Scales
+export { createLinearScale, createLogScale, computeYExtent, bisectData } from './scales.js';
+export type { LinearScale, LogScale } from './scales.js';
+
+// Data normalization
+export { normalizeTransientData, normalizeACData } from './data.js';
+
+// Buffer
+export { GrowableBuffer } from './buffer.js';
+
+// Renderers
+export { TransientRenderer, type TransientRendererOptions } from './renderer.js';
+export { BodeRenderer, type BodeRendererOptions } from './bode-renderer.js';
+
+// Interaction
+export { InteractionHandler, type InteractionCallbacks } from './interaction.js';
+
+// Streaming
+export { StreamingController } from './streaming.js';
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd packages/ui && pnpm test`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Run build**
+
+Run: `cd packages/ui && pnpm build`
+Expected: Clean build. Verify output files exist:
+- `dist/index.js`, `dist/index.cjs`, `dist/index.d.ts`
+- `dist/react.js`, `dist/react.cjs`, `dist/react.d.ts`
+
+- [ ] **Step 4: Run lint**
+
+Run: `cd packages/ui && pnpm lint`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/core/index.ts packages/ui/src/index.ts
+git commit -m "feat(ui): wire up core exports and verify build"
+```
+
+---
+
+### Task 12: React components — TransientPlot and BodePlot
+
+**Files:**
+- Create: `packages/ui/src/react/use-renderer.ts`
+- Create: `packages/ui/src/react/TransientPlot.tsx`
+- Create: `packages/ui/src/react/TransientPlot.test.tsx`
+- Create: `packages/ui/src/react/BodePlot.tsx`
+- Create: `packages/ui/src/react/BodePlot.test.tsx`
+
+- [ ] **Step 1: Write shared hook use-renderer.ts**
+
+This hook manages the canvas ref, DPI scaling, ResizeObserver, and renderer lifecycle.
+
+```typescript
+// src/react/use-renderer.ts
+import { useRef, useEffect, useCallback } from 'react';
+
+/**
+ * Shared hook for managing a canvas element with DPI scaling and resize observation.
+ * Returns a ref callback to attach to the canvas, and the current canvas element.
+ */
+export function useCanvas(onResize?: (canvas: HTMLCanvasElement) => void) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const refCallback = useCallback(
+    (canvas: HTMLCanvasElement | null) => {
+      // Cleanup old observer
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+
+      canvasRef.current = canvas;
+
+      if (canvas) {
+        const updateSize = () => {
+          const dpr = window.devicePixelRatio || 1;
+          const rect = canvas.getBoundingClientRect();
+          canvas.width = rect.width * dpr;
+          canvas.height = rect.height * dpr;
+          onResize?.(canvas);
+        };
+
+        updateSize();
+        observerRef.current = new ResizeObserver(updateSize);
+        observerRef.current.observe(canvas);
+      }
+    },
+    [onResize],
+  );
+
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, []);
+
+  return { refCallback, canvasRef };
+}
+```
+
+- [ ] **Step 2: Write TransientPlot tests**
+
+```tsx
+// src/react/TransientPlot.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { TransientPlot } from './TransientPlot.js';
+
+// Mock TransientResult-like object
+function mockTransientResult() {
+  const voltageMap = new Map([['out', [0, 2.5, 5]]]);
+  return {
+    time: [0, 1e-3, 2e-3],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+describe('TransientPlot', () => {
+  it('renders a canvas element', () => {
+    const { container } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} />,
+    );
+    const canvas = container.querySelector('canvas');
+    expect(canvas).not.toBeNull();
+  });
+
+  it('renders with dark theme by default', () => {
+    const { container } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} />,
+    );
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('renders with custom dimensions', () => {
+    const { container } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} width={600} height={400} />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.width).toBe('600px');
+    expect(wrapper.style.height).toBe('400px');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/react/TransientPlot.test.tsx`
+Expected: FAIL — `./TransientPlot.js` module not found.
+
+- [ ] **Step 4: Implement TransientPlot.tsx**
+
+```tsx
+// src/react/TransientPlot.tsx
+import { useRef, useEffect, useCallback, type CSSProperties } from 'react';
+import { TransientRenderer } from '../core/renderer.js';
+import { resolveTheme } from '../core/theme.js';
+import { normalizeTransientData } from '../core/data.js';
+import { InteractionHandler } from '../core/interaction.js';
+import type { ThemeConfig, CursorState, TransientDataset } from '../core/types.js';
+import { useCanvas } from './use-renderer.js';
+
+export interface TransientPlotProps {
+  /** TransientResult from @spice-ts/core, or array of TransientDataset for overlay. */
+  data: unknown;
+  /** Signal names to display. */
+  signals: string[];
+  /** Signal color overrides. */
+  colors?: Record<string, string>;
+  /** Theme preset or custom config. */
+  theme?: 'dark' | 'light' | ThemeConfig;
+  /** CSS width. Default '100%'. */
+  width?: number | string;
+  /** CSS height. Default 300. */
+  height?: number | string;
+  /** Cursor move callback. */
+  onCursorMove?: (cursor: CursorState | null) => void;
+  /** Signal visibility state (controlled). */
+  signalVisibility?: Record<string, boolean>;
+}
+
+export function TransientPlot({
+  data,
+  signals,
+  colors,
+  theme,
+  width = '100%',
+  height = 300,
+  onCursorMove,
+  signalVisibility,
+}: TransientPlotProps) {
+  const rendererRef = useRef<TransientRenderer | null>(null);
+  const interactionRef = useRef<InteractionHandler | null>(null);
+  const resolvedTheme = resolveTheme(theme);
+
+  const handleResize = useCallback(
+    (canvas: HTMLCanvasElement) => {
+      if (rendererRef.current) {
+        rendererRef.current.render();
+      }
+    },
+    [],
+  );
+
+  const { refCallback } = useCanvas(handleResize);
+
+  const canvasRefCallback = useCallback(
+    (canvas: HTMLCanvasElement | null) => {
+      // Cleanup previous
+      rendererRef.current?.destroy();
+      interactionRef.current?.destroy();
+      rendererRef.current = null;
+      interactionRef.current = null;
+
+      refCallback(canvas);
+
+      if (canvas) {
+        const renderer = new TransientRenderer(canvas, { theme: resolvedTheme });
+        rendererRef.current = renderer;
+
+        const datasets = normalizeTransientData(data, signals);
+        renderer.setData(datasets, signals);
+
+        if (colors) {
+          for (const [name, color] of Object.entries(colors)) {
+            renderer.setSignalColor(name, color);
+          }
+        }
+
+        if (onCursorMove) {
+          renderer.on('cursorMove', onCursorMove);
+        }
+
+        const interaction = new InteractionHandler(canvas, {
+          onCursorMove: (pixelX) => {
+            renderer.setCursorPixelX(pixelX);
+            renderer.render();
+          },
+          onZoom: (pixelX, factor, shiftKey) => {
+            if (shiftKey) renderer.zoomY(factor);
+            else renderer.zoomAt(pixelX, factor);
+            renderer.render();
+          },
+          onPan: (dx, dy) => {
+            renderer.pan(dx, dy);
+            renderer.render();
+          },
+          onDoubleClick: () => {
+            renderer.fitToData();
+            renderer.render();
+          },
+        });
+        interactionRef.current = interaction;
+
+        renderer.render();
+      }
+    },
+    [data, signals, resolvedTheme, colors, onCursorMove, refCallback],
+  );
+
+  // Update visibility when prop changes
+  useEffect(() => {
+    if (!rendererRef.current || !signalVisibility) return;
+    for (const [name, visible] of Object.entries(signalVisibility)) {
+      rendererRef.current.setSignalVisibility(name, visible);
+    }
+    rendererRef.current.render();
+  }, [signalVisibility]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      rendererRef.current?.destroy();
+      interactionRef.current?.destroy();
+    };
+  }, []);
+
+  const style: CSSProperties = {
+    width: typeof width === 'number' ? `${width}px` : width,
+    height: typeof height === 'number' ? `${height}px` : height,
+    position: 'relative',
+  };
+
+  return (
+    <div style={style}>
+      <canvas
+        ref={canvasRefCallback}
+        style={{ width: '100%', height: '100%', display: 'block' }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Write BodePlot tests**
+
+```tsx
+// src/react/BodePlot.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { BodePlot } from './BodePlot.js';
+
+function mockACResult() {
+  const voltageMap = new Map([
+    ['out', [
+      { magnitude: 1, phase: 0 },
+      { magnitude: 0.707, phase: -45 },
+      { magnitude: 0.1, phase: -84 },
+    ]],
+  ]);
+  return {
+    frequencies: [100, 1000, 10000],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+describe('BodePlot', () => {
+  it('renders two canvas elements (magnitude + phase)', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} />,
+    );
+    const canvases = container.querySelectorAll('canvas');
+    expect(canvases.length).toBe(2);
+  });
+
+  it('renders with magnitude-only pane', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} defaultPanes="magnitude" />,
+    );
+    expect(container.firstChild).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 6: Run tests to verify BodePlot fails**
+
+Run: `cd packages/ui && pnpm test -- src/react/BodePlot.test.tsx`
+Expected: FAIL — `./BodePlot.js` module not found.
+
+- [ ] **Step 7: Implement BodePlot.tsx**
+
+```tsx
+// src/react/BodePlot.tsx
+import { useRef, useEffect, useCallback, useState, type CSSProperties } from 'react';
+import { BodeRenderer } from '../core/bode-renderer.js';
+import { resolveTheme } from '../core/theme.js';
+import { normalizeACData } from '../core/data.js';
+import { InteractionHandler } from '../core/interaction.js';
+import type { ThemeConfig, CursorState } from '../core/types.js';
+import { useCanvas } from './use-renderer.js';
+
+export interface BodePlotProps {
+  /** ACResult from @spice-ts/core, or array of ACDataset for overlay. */
+  data: unknown;
+  /** Signal names to display. */
+  signals: string[];
+  /** Signal color overrides. */
+  colors?: Record<string, string>;
+  /** Theme preset or custom config. */
+  theme?: 'dark' | 'light' | ThemeConfig;
+  /** Which panes to show initially. Default 'both'. */
+  defaultPanes?: 'both' | 'magnitude' | 'phase';
+  /** CSS width. Default '100%'. */
+  width?: number | string;
+  /** CSS height. Default 300 per visible pane. */
+  height?: number | string;
+  /** Cursor move callback. */
+  onCursorMove?: (cursor: CursorState | null) => void;
+  /** Signal visibility state (controlled). */
+  signalVisibility?: Record<string, boolean>;
+}
+
+export function BodePlot({
+  data,
+  signals,
+  colors,
+  theme,
+  defaultPanes = 'both',
+  width = '100%',
+  height,
+  onCursorMove,
+  signalVisibility,
+}: BodePlotProps) {
+  const rendererRef = useRef<BodeRenderer | null>(null);
+  const magInteractionRef = useRef<InteractionHandler | null>(null);
+  const phaseInteractionRef = useRef<InteractionHandler | null>(null);
+  const resolvedTheme = resolveTheme(theme);
+  const [magVisible, setMagVisible] = useState(defaultPanes !== 'phase');
+  const [phaseVisible, setPhaseVisible] = useState(defaultPanes !== 'magnitude');
+
+  const magCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const phaseCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const handleResize = useCallback(() => {
+    rendererRef.current?.render();
+  }, []);
+
+  const { refCallback: magRefCallback } = useCanvas(handleResize);
+  const { refCallback: phaseRefCallback } = useCanvas(handleResize);
+
+  // Initialize renderer when both canvases are available
+  useEffect(() => {
+    const magCanvas = magCanvasRef.current;
+    const phaseCanvas = phaseCanvasRef.current;
+    if (!magCanvas || !phaseCanvas) return;
+
+    rendererRef.current?.destroy();
+    magInteractionRef.current?.destroy();
+    phaseInteractionRef.current?.destroy();
+
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, {
+      theme: resolvedTheme,
+      defaultPanes,
+    });
+    rendererRef.current = renderer;
+
+    const datasets = normalizeACData(data, signals);
+    renderer.setData(datasets, signals);
+
+    if (colors) {
+      for (const [name, color] of Object.entries(colors)) {
+        renderer.setSignalColor(name, color);
+      }
+    }
+
+    if (onCursorMove) {
+      renderer.on('cursorMove', onCursorMove);
+    }
+
+    const createInteraction = (canvas: HTMLCanvasElement) =>
+      new InteractionHandler(canvas, {
+        onCursorMove: (pixelX) => {
+          renderer.setCursorPixelX(pixelX);
+          renderer.render();
+        },
+        onZoom: (pixelX, factor, _shiftKey) => {
+          renderer.zoomAt(pixelX, factor);
+          renderer.render();
+        },
+        onPan: (dx, dy) => {
+          renderer.pan(dx, dy);
+          renderer.render();
+        },
+        onDoubleClick: () => {
+          renderer.fitToData();
+          renderer.render();
+        },
+      });
+
+    magInteractionRef.current = createInteraction(magCanvas);
+    phaseInteractionRef.current = createInteraction(phaseCanvas);
+
+    renderer.render();
+
+    return () => {
+      renderer.destroy();
+      magInteractionRef.current?.destroy();
+      phaseInteractionRef.current?.destroy();
+    };
+  }, [data, signals, resolvedTheme, defaultPanes, colors, onCursorMove]);
+
+  // Sync pane visibility
+  useEffect(() => {
+    if (!rendererRef.current) return;
+    rendererRef.current.setPaneVisible('magnitude', magVisible);
+    rendererRef.current.setPaneVisible('phase', phaseVisible);
+    rendererRef.current.render();
+  }, [magVisible, phaseVisible]);
+
+  // Sync signal visibility
+  useEffect(() => {
+    if (!rendererRef.current || !signalVisibility) return;
+    for (const [name, visible] of Object.entries(signalVisibility)) {
+      rendererRef.current.setSignalVisibility(name, visible);
+    }
+    rendererRef.current.render();
+  }, [signalVisibility]);
+
+  const paneHeight = height
+    ? typeof height === 'number' ? height : height
+    : 200;
+
+  const containerStyle: CSSProperties = {
+    width: typeof width === 'number' ? `${width}px` : width,
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const paneHeaderStyle: CSSProperties = {
+    padding: '4px 8px',
+    fontSize: `${resolvedTheme.fontSize - 1}px`,
+    fontFamily: resolvedTheme.font,
+    color: resolvedTheme.textMuted,
+    background: resolvedTheme.surface,
+    borderBottom: `1px solid ${resolvedTheme.border}`,
+    cursor: 'pointer',
+    userSelect: 'none',
+  };
+
+  const canvasStyle: CSSProperties = { width: '100%', height: '100%', display: 'block' };
+
+  return (
+    <div style={containerStyle}>
+      <div
+        style={paneHeaderStyle}
+        onClick={() => setMagVisible((v) => !v)}
+      >
+        {magVisible ? '▾' : '▸'} Magnitude (dB)
+      </div>
+      <div style={{ height: magVisible ? (typeof paneHeight === 'number' ? `${paneHeight}px` : paneHeight) : 0, overflow: 'hidden' }}>
+        <canvas
+          ref={(el) => {
+            magCanvasRef.current = el;
+            magRefCallback(el);
+          }}
+          style={canvasStyle}
+        />
+      </div>
+      <div
+        style={paneHeaderStyle}
+        onClick={() => setPhaseVisible((v) => !v)}
+      >
+        {phaseVisible ? '▾' : '▸'} Phase (°)
+      </div>
+      <div style={{ height: phaseVisible ? (typeof paneHeight === 'number' ? `${paneHeight}px` : paneHeight) : 0, overflow: 'hidden' }}>
+        <canvas
+          ref={(el) => {
+            phaseCanvasRef.current = el;
+            phaseRefCallback(el);
+          }}
+          style={canvasStyle}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Run all React tests**
+
+Run: `cd packages/ui && pnpm test -- src/react/`
+Expected: All TransientPlot and BodePlot tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/ui/src/react/use-renderer.ts packages/ui/src/react/TransientPlot.tsx packages/ui/src/react/TransientPlot.test.tsx packages/ui/src/react/BodePlot.tsx packages/ui/src/react/BodePlot.test.tsx
+git commit -m "feat(ui): add React TransientPlot and BodePlot components"
+```
+
+---
+
+### Task 13: React components — Legend and CursorTooltip
+
+**Files:**
+- Create: `packages/ui/src/react/Legend.tsx`
+- Create: `packages/ui/src/react/Legend.test.tsx`
+- Create: `packages/ui/src/react/CursorTooltip.tsx`
+
+- [ ] **Step 1: Write Legend tests**
+
+```tsx
+// src/react/Legend.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { Legend } from './Legend.js';
+
+describe('Legend', () => {
+  const signals = [
+    { id: 'out', label: 'V(out)', color: '#4ade80', visible: true },
+    { id: 'in', label: 'V(in)', color: '#60a5fa', visible: true },
+  ];
+
+  it('renders signal labels', () => {
+    const { getByText } = render(
+      <Legend signals={signals} onToggle={() => {}} />,
+    );
+    expect(getByText('V(out)')).toBeDefined();
+    expect(getByText('V(in)')).toBeDefined();
+  });
+
+  it('calls onToggle with signal id when clicked', () => {
+    const onToggle = vi.fn();
+    const { getByText } = render(
+      <Legend signals={signals} onToggle={onToggle} />,
+    );
+    fireEvent.click(getByText('V(out)'));
+    expect(onToggle).toHaveBeenCalledWith('out');
+  });
+
+  it('dims hidden signals', () => {
+    const hiddenSignals = [
+      { id: 'out', label: 'V(out)', color: '#4ade80', visible: false },
+      { id: 'in', label: 'V(in)', color: '#60a5fa', visible: true },
+    ];
+    const { container } = render(
+      <Legend signals={hiddenSignals} onToggle={() => {}} />,
+    );
+    const items = container.querySelectorAll('[data-signal-id]');
+    expect(items.length).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/react/Legend.test.tsx`
+Expected: FAIL — `./Legend.js` module not found.
+
+- [ ] **Step 3: Implement Legend.tsx**
+
+```tsx
+// src/react/Legend.tsx
+import type { CSSProperties } from 'react';
+
+export interface LegendSignal {
+  id: string;
+  label: string;
+  color: string;
+  visible: boolean;
+}
+
+export interface LegendProps {
+  signals: LegendSignal[];
+  onToggle: (signalId: string) => void;
+  style?: CSSProperties;
+}
+
+export function Legend({ signals, onToggle, style }: LegendProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '12px',
+        padding: '8px 0',
+        ...style,
+      }}
+    >
+      {signals.map((signal) => (
+        <div
+          key={signal.id}
+          data-signal-id={signal.id}
+          onClick={() => onToggle(signal.id)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            fontSize: '12px',
+            cursor: 'pointer',
+            opacity: signal.visible ? 1 : 0.35,
+            transition: 'opacity 0.15s',
+            userSelect: 'none',
+          }}
+        >
+          <div
+            style={{
+              width: '12px',
+              height: '3px',
+              borderRadius: '1px',
+              background: signal.color,
+            }}
+          />
+          <span>{signal.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run Legend tests**
+
+Run: `cd packages/ui && pnpm test -- src/react/Legend.test.tsx`
+Expected: All Legend tests PASS.
+
+- [ ] **Step 5: Implement CursorTooltip.tsx**
+
+```tsx
+// src/react/CursorTooltip.tsx
+import type { CSSProperties } from 'react';
+import type { CursorState, ThemeConfig } from '../core/types.js';
+import { formatSI } from '../core/format.js';
+
+export interface CursorTooltipProps {
+  cursor: CursorState | null;
+  theme: ThemeConfig;
+  /** Format the x-axis value (default: formatSI + inferred unit). */
+  formatX?: (x: number) => string;
+  style?: CSSProperties;
+}
+
+export function CursorTooltip({ cursor, theme, formatX, style }: CursorTooltipProps) {
+  if (!cursor) return null;
+
+  const xLabel = formatX ? formatX(cursor.x) : formatSI(cursor.x);
+
+  const tooltipStyle: CSSProperties = {
+    position: 'absolute',
+    left: cursor.pixelX + 12,
+    top: 8,
+    background: theme.tooltipBg,
+    border: `1px solid ${theme.tooltipBorder}`,
+    borderRadius: '6px',
+    padding: '6px 10px',
+    fontSize: `${theme.fontSize}px`,
+    fontFamily: theme.font,
+    color: theme.text,
+    minWidth: '120px',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+    pointerEvents: 'none',
+    zIndex: 10,
+    ...style,
+  };
+
+  return (
+    <div style={tooltipStyle}>
+      <div style={{ color: theme.textMuted, marginBottom: '4px' }}>
+        {xLabel}
+      </div>
+      {cursor.values.map((v) => (
+        <div
+          key={v.signalId}
+          style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}
+        >
+          <div
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              background: v.color,
+              flexShrink: 0,
+            }}
+          />
+          <span>
+            {v.label} = {formatSI(v.value)}{v.unit}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/react/Legend.tsx packages/ui/src/react/Legend.test.tsx packages/ui/src/react/CursorTooltip.tsx
+git commit -m "feat(ui): add React Legend and CursorTooltip components"
+```
+
+---
+
+### Task 14: React WaveformViewer (pre-composed)
+
+**Files:**
+- Create: `packages/ui/src/react/WaveformViewer.tsx`
+- Create: `packages/ui/src/react/WaveformViewer.test.tsx`
+- Modify: `packages/ui/src/react/index.ts`
+
+- [ ] **Step 1: Write WaveformViewer tests**
+
+```tsx
+// src/react/WaveformViewer.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { WaveformViewer } from './WaveformViewer.js';
+
+function mockTransientResult() {
+  const voltageMap = new Map([['out', [0, 2.5, 5]]]);
+  return {
+    time: [0, 1e-3, 2e-3],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+function mockACResult() {
+  const voltageMap = new Map([
+    ['out', [
+      { magnitude: 1, phase: 0 },
+      { magnitude: 0.707, phase: -45 },
+    ]],
+  ]);
+  return {
+    frequencies: [100, 10000],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+describe('WaveformViewer', () => {
+  it('renders transient-only view', () => {
+    const { container } = render(
+      <WaveformViewer transient={mockTransientResult()} signals={['out']} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders AC-only view', () => {
+    const { container } = render(
+      <WaveformViewer ac={mockACResult()} signals={['out']} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders both transient and AC stacked', () => {
+    const { container } = render(
+      <WaveformViewer
+        transient={mockTransientResult()}
+        ac={mockACResult()}
+        signals={['out']}
+      />,
+    );
+    // At least 3 canvases: 1 transient + 2 Bode panes
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/ui && pnpm test -- src/react/WaveformViewer.test.tsx`
+Expected: FAIL — `./WaveformViewer.js` module not found.
+
+- [ ] **Step 3: Implement WaveformViewer.tsx**
+
+```tsx
+// src/react/WaveformViewer.tsx
+import { useState, useCallback, useEffect, useRef, type CSSProperties } from 'react';
+import { TransientPlot, type TransientPlotProps } from './TransientPlot.js';
+import { BodePlot, type BodePlotProps } from './BodePlot.js';
+import { Legend, type LegendSignal } from './Legend.js';
+import { CursorTooltip } from './CursorTooltip.js';
+import { StreamingController } from '../core/streaming.js';
+import { resolveTheme } from '../core/theme.js';
+import { formatTime, formatFrequency } from '../core/format.js';
+import type { ThemeConfig, CursorState, TransientDataset } from '../core/types.js';
+import { DEFAULT_PALETTE } from '../core/types.js';
+
+export interface WaveformViewerProps {
+  /** Transient result or dataset array. */
+  transient?: TransientPlotProps['data'];
+  /** AC result or dataset array. */
+  ac?: BodePlotProps['data'];
+  /** Async stream from simulateStream(). Renders progressively as data arrives. */
+  stream?: AsyncIterable<{ time: number; voltages: Map<string, number>; currents: Map<string, number> }>;
+  /** Signal names to display. */
+  signals: string[];
+  /** Signal color overrides. */
+  colors?: Record<string, string>;
+  /** Theme preset or custom config. */
+  theme?: 'dark' | 'light' | ThemeConfig;
+}
+
+/**
+ * Pre-composed waveform viewer. When both transient and ac are provided,
+ * renders them stacked vertically (transient on top, Bode below).
+ * When streaming, displays only the analysis type being streamed.
+ */
+export function WaveformViewer({
+  transient,
+  ac,
+  stream,
+  signals,
+  colors,
+  theme,
+}: WaveformViewerProps) {
+  const resolvedTheme = resolveTheme(theme);
+  const [cursor, setCursor] = useState<CursorState | null>(null);
+  const [visibility, setVisibility] = useState<Record<string, boolean>>(() => {
+    const v: Record<string, boolean> = {};
+    for (const s of signals) v[s] = true;
+    return v;
+  });
+  const [streamData, setStreamData] = useState<TransientDataset[] | null>(null);
+  const controllerRef = useRef<StreamingController | null>(null);
+  const rafRef = useRef<number>(0);
+
+  // Streaming: consume async iterator, update data on rAF
+  useEffect(() => {
+    if (!stream) return;
+
+    let dirty = false;
+    const controller = new StreamingController(signals, () => { dirty = true; });
+    controllerRef.current = controller;
+
+    // rAF loop: only update React state at display refresh rate
+    const loop = () => {
+      if (dirty) {
+        dirty = false;
+        setStreamData([controller.getDataset()]);
+      }
+      if (controller.isRunning()) {
+        rafRef.current = requestAnimationFrame(loop);
+      } else {
+        // Final update after stream ends
+        setStreamData([controller.getDataset()]);
+      }
+    };
+    rafRef.current = requestAnimationFrame(loop);
+
+    controller.consume(stream as AsyncIterable<any>);
+
+    return () => {
+      controller.stop();
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [stream, signals]);
+
+  // Use streaming data if available, otherwise the transient prop
+  const transientData = streamData ?? transient;
+
+  const legendSignals: LegendSignal[] = signals.map((name, i) => ({
+    id: name,
+    label: name,
+    color: colors?.[name] ?? DEFAULT_PALETTE[i % DEFAULT_PALETTE.length],
+    visible: visibility[name] ?? true,
+  }));
+
+  const handleToggle = useCallback((signalId: string) => {
+    setVisibility((prev) => ({ ...prev, [signalId]: !prev[signalId] }));
+  }, []);
+
+  const containerStyle: CSSProperties = {
+    background: resolvedTheme.surface,
+    border: `1px solid ${resolvedTheme.border}`,
+    borderRadius: '8px',
+    padding: '16px',
+    fontFamily: resolvedTheme.font,
+    color: resolvedTheme.text,
+    position: 'relative',
+  };
+
+  return (
+    <div style={containerStyle}>
+      {transientData && (
+        <TransientPlot
+          data={transientData}
+          signals={signals}
+          colors={colors}
+          theme={resolvedTheme}
+          onCursorMove={setCursor}
+          signalVisibility={visibility}
+        />
+      )}
+      {ac && !stream && (
+        <div style={{ marginTop: transientData ? '16px' : 0 }}>
+          <BodePlot
+            data={ac}
+            signals={signals}
+            colors={colors}
+            theme={resolvedTheme}
+            onCursorMove={!transientData ? setCursor : undefined}
+            signalVisibility={visibility}
+          />
+        </div>
+      )}
+      <Legend signals={legendSignals} onToggle={handleToggle} />
+      <CursorTooltip
+        cursor={cursor}
+        theme={resolvedTheme}
+        formatX={transientData ? (x) => formatTime(x) : (x) => formatFrequency(x)}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/ui && pnpm test -- src/react/WaveformViewer.test.tsx`
+Expected: All WaveformViewer tests PASS.
+
+- [ ] **Step 5: Wire up react/index.ts exports**
+
+```typescript
+// src/react/index.ts
+export { TransientPlot, type TransientPlotProps } from './TransientPlot.js';
+export { BodePlot, type BodePlotProps } from './BodePlot.js';
+export { Legend, type LegendProps, type LegendSignal } from './Legend.js';
+export { CursorTooltip, type CursorTooltipProps } from './CursorTooltip.js';
+export { WaveformViewer, type WaveformViewerProps } from './WaveformViewer.js';
+```
+
+- [ ] **Step 6: Run full test suite and build**
+
+Run: `cd packages/ui && pnpm test && pnpm build && pnpm lint`
+Expected: All tests PASS, build succeeds with both subpath outputs, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/react/WaveformViewer.tsx packages/ui/src/react/WaveformViewer.test.tsx packages/ui/src/react/index.ts
+git commit -m "feat(ui): add WaveformViewer pre-composed React component"
+```
+
+---
+
+### Task 15: Example app with dev server
+
+**Files:**
+- Create: `examples/08-waveform-viewer/index.html`
+- Create: `examples/08-waveform-viewer/main.tsx`
+- Create: `examples/08-waveform-viewer/package.json`
+- Create: `examples/08-waveform-viewer/tsconfig.json`
+- Create: `examples/08-waveform-viewer/vite.config.ts`
+
+This is a standalone Vite dev server for visual testing. It runs a real simulation and renders results with the viewer.
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "@spice-ts/example-waveform-viewer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build"
+  },
+  "dependencies": {
+    "@spice-ts/core": "workspace:*",
+    "@spice-ts/ui": "workspace:*",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.4.0",
+    "vite": "^8.0.8"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}
+```
+
+- [ ] **Step 3: Create vite.config.ts**
+
+```typescript
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});
+```
+
+- [ ] **Step 4: Create index.html**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>spice-ts Waveform Viewer</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; }
+      body {
+        margin: 0;
+        padding: 24px;
+        background: hsl(224, 71%, 4%);
+        color: hsl(210, 40%, 98%);
+        font-family: 'Inter', -apple-system, sans-serif;
+      }
+      h1 { font-size: 18px; font-weight: 600; margin-bottom: 16px; }
+      h2 { font-size: 14px; font-weight: 500; margin: 24px 0 8px; color: hsl(215, 20%, 55%); }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: Create main.tsx**
+
+```tsx
+import { createRoot } from 'react-dom/client';
+import { useState, useEffect } from 'react';
+import { simulate } from '@spice-ts/core';
+import { WaveformViewer } from '@spice-ts/ui/react';
+import type { SimulationResult } from '@spice-ts/core';
+
+const RC_NETLIST = `
+* RC Low-Pass Filter
+V1 in 0 PULSE(0 5 0 1n 1n 5m 10m)
+R1 in out 1k
+C1 out 0 100n
+.tran 1u 10m
+.ac dec 20 1 10Meg
+`;
+
+function App() {
+  const [result, setResult] = useState<SimulationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    simulate(RC_NETLIST)
+      .then(setResult)
+      .catch((e: Error) => setError(e.message));
+  }, []);
+
+  if (error) return <div style={{ color: 'red' }}>Error: {error}</div>;
+  if (!result) return <div>Running simulation...</div>;
+
+  return (
+    <div>
+      <h1>spice-ts Waveform Viewer</h1>
+
+      <h2>Transient — RC Step Response</h2>
+      <WaveformViewer
+        transient={result.transient}
+        signals={['out', 'in']}
+        colors={{ out: '#4ade80', in: '#60a5fa' }}
+        theme="dark"
+      />
+
+      <h2>AC — Bode Plot</h2>
+      <WaveformViewer
+        ac={result.ac}
+        signals={['out']}
+        colors={{ out: '#f97316' }}
+        theme="dark"
+      />
+
+      <h2>Light Theme</h2>
+      <WaveformViewer
+        transient={result.transient}
+        signals={['out']}
+        colors={{ out: '#16a34a' }}
+        theme="light"
+      />
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);
+```
+
+- [ ] **Step 6: Update pnpm-workspace.yaml**
+
+Add the example to the workspace:
+```yaml
+packages:
+  - "packages/*"
+  - "examples"
+  - "examples/08-waveform-viewer"
+```
+
+- [ ] **Step 7: Install and run dev server**
+
+Run: `pnpm install`
+
+Run: `cd examples/08-waveform-viewer && pnpm dev`
+Expected: Vite dev server starts. Open the URL in browser and visually verify:
+1. Transient plot shows V(in) step and V(out) RC charging curve
+2. Bode plot shows magnitude rolloff and phase shift
+3. Hover shows cursor crosshair + tooltip with values
+4. Scroll wheel zooms, click-drag pans, double-click fits
+5. Legend click toggles signal visibility
+6. Light theme renders correctly
+7. Bode pane headers collapse/expand magnitude and phase
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add examples/08-waveform-viewer/ pnpm-workspace.yaml pnpm-lock.yaml
+git commit -m "feat(ui): add waveform viewer example app with Vite dev server"
+```
+
+---
+
+### Task 16: Final integration test and cleanup
+
+**Files:**
+- Modify: `packages/ui/src/core/index.ts` (verify)
+- Modify: `packages/ui/src/react/index.ts` (verify)
+
+- [ ] **Step 1: Run full monorepo test suite**
+
+Run: `pnpm -r test`
+Expected: All tests pass across all packages (core + ui).
+
+- [ ] **Step 2: Run full monorepo build**
+
+Run: `pnpm build`
+Expected: All packages build successfully.
+
+- [ ] **Step 3: Run full monorepo lint**
+
+Run: `pnpm lint`
+Expected: No type errors.
+
+- [ ] **Step 4: Verify package exports work**
+
+Run a quick smoke test from the examples directory:
+```bash
+cd examples/08-waveform-viewer && pnpm build
+```
+Expected: Vite builds successfully, confirming the package exports resolve correctly.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore(ui): verify full monorepo integration"
+```

--- a/docs/superpowers/specs/2026-04-12-waveform-viewer-design.md
+++ b/docs/superpowers/specs/2026-04-12-waveform-viewer-design.md
@@ -1,0 +1,336 @@
+# @spice-ts/ui — Waveform Viewer Design
+
+## Overview
+
+A framework-agnostic waveform viewer package for displaying spice-ts simulation results. Ships a pure TypeScript Canvas-based rendering core with React bindings as the first framework adapter. Designed for real-time streaming, interactive exploration, and eventual multi-framework support.
+
+**Package:** `@spice-ts/ui` under `packages/ui/`
+
+## Scope
+
+### In scope (v1)
+
+- Transient waveform plot (voltage/current vs. time)
+- AC Bode plot (magnitude + phase vs. frequency, dual-pane, collapsible)
+- Canvas-based rendering with d3-scale/d3-array for scale math
+- Zoom (scroll wheel, centered on cursor), pan (click-drag), single cursor with value readout
+- Streaming support — append-only live rendering from `simulateStream()`
+- Multi-result overlay — display a family of curves (for parametric sweeps / `.step`)
+- Dark and light themes (shadcn-inspired aesthetic)
+- Legend with click-to-toggle signal visibility (Plotly-style)
+- React bindings via `@spice-ts/ui/react` subpath
+- Composable component API with a pre-composed convenience component
+
+### Out of scope (future)
+
+- DC sweep plot, DC operating point table, Fourier analysis view
+- Dual cursors for delta measurements
+- Headless hooks API (`useWaveform()`)
+- Svelte / other framework bindings
+- Zero-dependency mode (replace d3-scale/d3-array with hand-rolled implementations)
+- WebGL rendering path
+
+## Architecture
+
+### Two-layer design
+
+```
+@spice-ts/ui
+├── src/
+│   ├── core/                  ← Framework-agnostic, pure TS + Canvas
+│   │   ├── renderer.ts            Transient waveform Canvas renderer
+│   │   ├── bode-renderer.ts       Bode plot renderer (dual-pane magnitude/phase)
+│   │   ├── scales.ts              d3-scale wrappers: time, frequency, voltage, dB, phase
+│   │   ├── interaction.ts         Zoom (wheel), pan (drag), cursor (hover) handlers
+│   │   ├── streaming.ts           Append-only typed array buffer + rAF redraw loop
+│   │   ├── theme.ts               Theme config objects (dark + light presets)
+│   │   └── types.ts               Shared types (SignalData, CursorState, etc.)
+│   ├── react/                 ← React bindings
+│   │   ├── WaveformViewer.tsx     Pre-composed default component
+│   │   ├── TransientPlot.tsx      Composable: single transient canvas
+│   │   ├── BodePlot.tsx           Composable: Bode magnitude + phase (collapsible)
+│   │   ├── Legend.tsx             Click-to-toggle signal visibility
+│   │   ├── CursorTooltip.tsx      DOM overlay for value readout on hover
+│   │   └── index.ts
+│   └── index.ts               ← Vanilla core exports
+├── package.json
+└── tsconfig.json
+```
+
+**Core layer** — zero framework dependencies. Takes an `HTMLCanvasElement` and data arrays. Handles all rendering, interaction state, scale computation, and streaming. Emits events (cursor move, zoom change, signal toggle) for framework layers to consume.
+
+**React layer** — thin lifecycle wrapper. Manages canvas refs, `ResizeObserver`, and bridges core events to React state for DOM overlays (tooltip, legend). React + react-dom are peer dependencies of the `/react` subpath only.
+
+### Subpath exports
+
+```jsonc
+// package.json
+{
+  "exports": {
+    ".": {
+      "types": "./dist/core/index.d.ts",
+      "import": "./dist/core/index.js"
+    },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "import": "./dist/react/index.js"
+    }
+  }
+}
+```
+
+Consumers import `@spice-ts/ui` for the vanilla core or `@spice-ts/ui/react` for React components. Future framework adapters (Svelte, etc.) get their own subpaths.
+
+## Component API (React)
+
+### Simple path — one component
+
+```tsx
+import { WaveformViewer } from '@spice-ts/ui/react';
+import { simulate } from '@spice-ts/core';
+
+const result = await simulate(netlist);
+
+<WaveformViewer
+  transient={result.transient}
+  signals={['out', 'in']}
+  theme="dark"
+/>
+```
+
+### Composable path — mix and match
+
+```tsx
+import { TransientPlot, BodePlot, Legend, CursorTooltip } from '@spice-ts/ui/react';
+
+<div className="my-layout">
+  <TransientPlot data={result.transient} signals={['out']} theme="dark" />
+  <BodePlot data={result.ac} signals={['out']} defaultPanes="both" />
+  <Legend signals={signals} onToggle={handleToggle} />
+  <CursorTooltip />
+</div>
+```
+
+### Streaming path
+
+```tsx
+<WaveformViewer
+  stream={simulateStream(netlist)}
+  signals={['out', 'in']}
+  theme="dark"
+/>
+```
+
+### Multi-result overlay (family of curves)
+
+For parametric sweeps (manual or via future `.step` support, issue #21):
+
+```tsx
+// From .step results
+<BodePlot
+  data={result.steps.map(s => ({
+    ac: s.ac,
+    label: `${s.paramName} = ${s.paramValue}`,
+  }))}
+  signals={['out']}
+/>
+
+// Manual overlay of multiple simulation runs
+<TransientPlot
+  data={[
+    { transient: result1.transient, label: 'R1 = 1k' },
+    { transient: result2.transient, label: 'R1 = 10k' },
+  ]}
+  signals={['out']}
+/>
+```
+
+Each curve gets its own color from the palette. Legend shows per-curve toggles.
+
+## Prop types
+
+```typescript
+// --- TransientPlot ---
+interface TransientPlotProps {
+  data: TransientResult | TransientDataset[];
+  signals: string[];                        // Node/branch names to display
+  colors?: Record<string, string>;          // Signal name → color override
+  theme?: 'dark' | 'light' | ThemeConfig;
+  width?: number | string;                  // CSS value, default '100%'
+  height?: number | string;                 // CSS value, default 300
+  onCursorMove?: (cursor: CursorState | null) => void;
+}
+
+interface TransientDataset {
+  transient: TransientResult;
+  label: string;
+}
+
+// --- BodePlot ---
+interface BodePlotProps {
+  data: ACResult | ACDataset[];
+  signals: string[];
+  colors?: Record<string, string>;
+  theme?: 'dark' | 'light' | ThemeConfig;
+  defaultPanes?: 'both' | 'magnitude' | 'phase';  // default: 'both'
+  width?: number | string;
+  height?: number | string;
+  onCursorMove?: (cursor: CursorState | null) => void;
+}
+
+interface ACDataset {
+  ac: ACResult;
+  label: string;
+}
+
+// --- WaveformViewer (pre-composed) ---
+// When both transient and ac are provided, renders them stacked vertically
+// (transient on top, Bode below). When streaming, displays only the
+// analysis type being streamed.
+interface WaveformViewerProps {
+  transient?: TransientResult | TransientDataset[];
+  ac?: ACResult | ACDataset[];
+  stream?: AsyncIterableIterator<TransientStep | ACPoint>;
+  signals: string[];
+  colors?: Record<string, string>;
+  theme?: 'dark' | 'light' | ThemeConfig;
+}
+
+// --- Legend ---
+interface LegendProps {
+  signals: SignalInfo[];
+  onToggle: (signalId: string) => void;
+}
+
+interface SignalInfo {
+  id: string;           // e.g. "out" or "R1=1k:out"
+  label: string;
+  color: string;
+  visible: boolean;
+}
+
+// --- Shared ---
+interface CursorState {
+  x: number;              // Data-space x value (time in s, or frequency in Hz)
+  values: CursorValue[];  // One per visible signal
+}
+
+interface CursorValue {
+  signalId: string;
+  label: string;
+  value: number;          // Voltage, current, magnitude, or phase
+  unit: string;           // 'V', 'A', 'dB', '°'
+  color: string;
+}
+```
+
+## Interaction model
+
+| Action | Input | Behavior |
+|--------|-------|----------|
+| Zoom | Scroll wheel | Zoom centered on cursor position. Horizontal by default, Shift+scroll for vertical |
+| Pan | Click + drag | Pan the visible window in both axes |
+| Cursor | Hover | Vertical crosshair snaps to nearest data point, tooltip shows values for all visible signals |
+| Toggle signal | Click legend item | Hide/show signal. Hidden items are dimmed in legend |
+| Fit | Double-click (or toolbar button) | Reset zoom to fit all data in view |
+| Collapse pane | Click pane header (Bode only) | Toggle magnitude or phase pane visibility |
+
+Zoom and pan operate on the same scale instances, so cursor readout stays accurate at any zoom level.
+
+## Streaming
+
+- The `stream` prop accepts an `AsyncIterableIterator<TransientStep | ACPoint>` from `simulateStream()`
+- Core maintains a growable `Float64Array` buffer per signal (doubles capacity on overflow)
+- A `requestAnimationFrame` loop redraws at display refresh rate, decoupled from data arrival rate
+- X-axis auto-extends as new data arrives; if the analysis stop time is known, the axis is pre-scaled
+- The waveform draws progressively left-to-right (append-only, like an oscilloscope trace)
+- When the iterator completes, the viewer transitions to static mode with full zoom/pan
+
+## Rendering
+
+### Canvas core
+
+All waveform lines, grid, axes, and cursor crosshair are drawn on an HTML5 Canvas 2D context.
+
+- **High-DPI:** Canvas dimensions scaled by `devicePixelRatio`, CSS size unchanged
+- **Grid:** Subtle lines at tick positions, styled per theme
+- **Waveform lines:** `ctx.lineTo()` paths, one per signal. Line width scales with DPI.
+- **Axis labels:** Canvas `fillText()` at tick positions. SI-prefix formatting (1kHz, 2.5ms, etc.)
+- **Cursor:** Dashed vertical line + filled circles at intersection with each visible signal
+
+### DOM overlay (React layer)
+
+- **Cursor tooltip:** Absolutely positioned `<div>` tracking cursor position. Shows time/frequency + values for all visible signals with color swatches. Styled with CSS variables for theming.
+- **Legend:** Flex row of signal labels with color indicators. Click toggles visibility.
+- **Toolbar:** Fit/reset buttons, Bode pane toggles. Standard DOM elements.
+
+### Bode plot specifics
+
+- Two stacked Canvas elements: magnitude (top) and phase (bottom)
+- Shared log-frequency x-axis (labels on the phase pane only)
+- Magnitude y-axis in dB, phase y-axis in degrees
+- Each pane independently collapsible via a header toggle
+- -3dB reference line on magnitude pane (configurable)
+- Default: both panes visible
+
+## Theming
+
+Two built-in presets: `dark` and `light`, inspired by shadcn/ui aesthetic.
+
+```typescript
+interface ThemeConfig {
+  background: string;       // Plot area background
+  surface: string;          // Container/toolbar background
+  border: string;           // Borders and dividers
+  grid: string;             // Grid lines
+  text: string;             // Primary text (labels, values)
+  textMuted: string;        // Secondary text (axis labels)
+  cursor: string;           // Cursor crosshair line
+  tooltipBg: string;        // Tooltip background
+  tooltipBorder: string;    // Tooltip border
+  font: string;             // Font family
+  fontSize: number;         // Base font size in px
+}
+```
+
+- `theme="dark"` or `theme="light"` selects a preset
+- Pass a partial `ThemeConfig` object to override specific values
+- React layer maps theme colors to CSS custom properties for DOM elements
+- Canvas core reads the `ThemeConfig` directly for draw calls
+
+### Signal colors
+
+Default palette of 8 distinguishable colors (colorblind-friendly). Override per-signal via the `colors` prop. For multi-result overlays, colors auto-assign from the palette per curve, with the legend showing both signal name and dataset label.
+
+## Dependencies
+
+| Dependency | Purpose | Approx size |
+|-----------|---------|-------------|
+| `d3-scale` | Linear/log scale computation, tick generation | ~8KB |
+| `d3-array` | Data bisecting (cursor snap), extent computation | ~4KB |
+
+**Peer dependencies:**
+- `@spice-ts/core` — result types (`TransientResult`, `ACResult`, etc.)
+- `react` ≥ 18, `react-dom` ≥ 18 — only required for `@spice-ts/ui/react` subpath
+
+## Testing strategy
+
+- **Unit tests (Vitest):** Scale computation, data buffering, streaming buffer, theme merging, SI formatting
+- **Rendering tests:** Snapshot comparison of Canvas draw calls using a mock Canvas context (verify correct `lineTo`, `fillText` calls for known data)
+- **Integration tests:** React component mounting, prop updates, resize handling via `@testing-library/react`
+- **Manual verification:** Example app in `examples/` that runs a simulation and displays results in the viewer (dev server for visual testing)
+
+## Future extensibility
+
+- **Additional plot types:** DC sweep (X-Y curve), Fourier spectrum — new renderer in `core/`, new component in `react/`
+- **Dual cursors:** Add a second cursor mode to `interaction.ts` for delta measurements
+- **Headless API:** Extract scale/state logic from `core/` into a `headless/` module, expose as `@spice-ts/ui/headless`
+- **Framework adapters:** Add `@spice-ts/ui/svelte`, `@spice-ts/ui/vue` subpaths wrapping the same core
+- **Zero-dep mode:** Replace d3-scale/d3-array with hand-rolled scale + bisect implementations
+- **Parametric sweep integration:** When `.step` lands in core (issue #21), the multi-result overlay API handles it natively
+
+## Related issues
+
+- Issue #11 — this spec
+- Issue #12 — `@spice-ts/designer` (depends on this package for waveform display)
+- Issue #21 — `.step` parametric sweep in core (multi-result overlay designed to consume this)

--- a/examples/08-waveform-viewer/index.html
+++ b/examples/08-waveform-viewer/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>spice-ts Waveform Viewer</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; }
+      body {
+        margin: 0;
+        padding: 24px;
+        background: hsl(224, 71%, 4%);
+        color: hsl(210, 40%, 98%);
+        font-family: 'Inter', -apple-system, sans-serif;
+      }
+      h1 { font-size: 18px; font-weight: 600; margin-bottom: 16px; }
+      h2 { font-size: 14px; font-weight: 500; margin: 24px 0 8px; color: hsl(215, 20%, 55%); }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -14,13 +14,12 @@ C1 out 0 100n
 `;
 
 const STREAM_NETLIST = `
-* Damped RLC Oscillation (streaming demo)
-* Pulse excites an underdamped RLC — produces decaying sinusoidal ringing
-V1 in 0 PULSE(0 5 0 1n 1n 1m 2m)
-R1 in mid 10
-L1 mid out 50m
-C1 out 0 10u
-.tran 0.5u 20m
+* RC Charging with repeated pulses (streaming demo)
+* Fine timestep + long duration = many data points for visible streaming
+V1 in 0 PULSE(0 5 0 10u 10u 2m 4m)
+R1 in out 10k
+C1 out 0 100n
+.tran 1u 20m
 `;
 
 const buttonStyle: React.CSSProperties = {

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -14,12 +14,15 @@ C1 out 0 100n
 `;
 
 const STREAM_NETLIST = `
-* RC Charging with repeated pulses (streaming demo)
-* Fine timestep + long duration = many data points for visible streaming
-V1 in 0 PULSE(0 5 0 10u 10u 2m 4m)
-R1 in out 10k
-C1 out 0 100n
-.tran 1u 20m
+* Half-wave rectifier with RC smoothing (streaming demo)
+* Diode nonlinearity forces Newton-Raphson per step — visibly progressive
+V1 in 0 SIN(0 10 500)
+D1 in rect DMOD
+.model DMOD D (IS=1e-14 N=1.05 RS=0.5)
+R1 rect out 100
+C1 out 0 100u
+R2 out 0 1k
+.tran 0.1u 20m
 `;
 
 const buttonStyle: React.CSSProperties = {
@@ -91,8 +94,8 @@ function App() {
       {stream && (
         <WaveformViewer
           stream={stream}
-          signals={['out', 'in']}
-          colors={{ out: '#4ade80', in: '#60a5fa' }}
+          signals={['in', 'out']}
+          colors={{ in: '#60a5fa', out: '#4ade80' }}
           theme="dark"
         />
       )}

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -14,11 +14,15 @@ C1 out 0 100n
 `;
 
 const STREAM_NETLIST = `
-* RC Low-Pass Filter (streaming)
-V1 in 0 PULSE(0 5 0 1n 1n 5m 10m)
-R1 in out 1k
-C1 out 0 100n
-.tran 1u 10m
+* CMOS Inverter Chain — heavy transient (streaming demo)
+.model NMOS NMOS (VTO=0.7 KP=110e-6 LAMBDA=0.04 CBD=5p CBS=5p)
+.model PMOS PMOS (VTO=-0.7 KP=50e-6 LAMBDA=0.05 CBD=5p CBS=5p)
+V1 vdd 0 DC 5
+V2 in 0 PULSE(0 5 0 0.1n 0.1n 50n 100n)
+M1 out in vdd vdd PMOS W=10u L=1u
+M2 out in 0 0 NMOS W=5u L=1u
+C1 out 0 1p
+.tran 0.05n 500n
 `;
 
 const buttonStyle: React.CSSProperties = {

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -14,15 +14,13 @@ C1 out 0 100n
 `;
 
 const STREAM_NETLIST = `
-* CMOS Inverter Chain — heavy transient (streaming demo)
-.model NMOS NMOS (VTO=0.7 KP=110e-6 LAMBDA=0.04 CBD=5p CBS=5p)
-.model PMOS PMOS (VTO=-0.7 KP=50e-6 LAMBDA=0.05 CBD=5p CBS=5p)
-V1 vdd 0 DC 5
-V2 in 0 PULSE(0 5 0 0.1n 0.1n 50n 100n)
-M1 out in vdd vdd PMOS W=10u L=1u
-M2 out in 0 0 NMOS W=5u L=1u
-C1 out 0 1p
-.tran 0.05n 500n
+* Damped RLC Oscillation (streaming demo)
+* Pulse excites an underdamped RLC — produces decaying sinusoidal ringing
+V1 in 0 PULSE(0 5 0 1n 1n 1m 2m)
+R1 in mid 10
+L1 mid out 50m
+C1 out 0 10u
+.tran 0.5u 20m
 `;
 
 const buttonStyle: React.CSSProperties = {

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -1,0 +1,60 @@
+import { createRoot } from 'react-dom/client';
+import { useState, useEffect } from 'react';
+import { simulate } from '@spice-ts/core';
+import { WaveformViewer } from '@spice-ts/ui/react';
+import type { SimulationResult } from '@spice-ts/core';
+
+const RC_NETLIST = `
+* RC Low-Pass Filter
+V1 in 0 PULSE(0 5 0 1n 1n 5m 10m)
+R1 in out 1k
+C1 out 0 100n
+.tran 1u 10m
+.ac dec 20 1 10Meg
+`;
+
+function App() {
+  const [result, setResult] = useState<SimulationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    simulate(RC_NETLIST)
+      .then(setResult)
+      .catch((e: Error) => setError(e.message));
+  }, []);
+
+  if (error) return <div style={{ color: 'red' }}>Error: {error}</div>;
+  if (!result) return <div>Running simulation...</div>;
+
+  return (
+    <div>
+      <h1>spice-ts Waveform Viewer</h1>
+
+      <h2>Transient — RC Step Response</h2>
+      <WaveformViewer
+        transient={result.transient}
+        signals={['out', 'in']}
+        colors={{ out: '#4ade80', in: '#60a5fa' }}
+        theme="dark"
+      />
+
+      <h2>AC — Bode Plot</h2>
+      <WaveformViewer
+        ac={result.ac}
+        signals={['out']}
+        colors={{ out: '#f97316' }}
+        theme="dark"
+      />
+
+      <h2>Light Theme</h2>
+      <WaveformViewer
+        transient={result.transient}
+        signals={['out']}
+        colors={{ out: '#16a34a' }}
+        theme="light"
+      />
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -94,6 +94,7 @@ function App() {
           signals={['in', 'out']}
           colors={{ in: '#60a5fa', out: '#4ade80' }}
           theme="dark"
+          xDomain={[0, 20e-3]}
         />
       )}
 

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -1,25 +1,34 @@
 import { createRoot } from 'react-dom/client';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { simulate, simulateStream } from '@spice-ts/core';
-import { WaveformViewer } from '@spice-ts/ui/react';
-import type { SimulationResult } from '@spice-ts/core';
+import { WaveformViewer, BodePlot } from '@spice-ts/ui/react';
+import { ACStreamingController } from '@spice-ts/ui';
+import type { SimulationResult, ACResult } from '@spice-ts/core';
+import type { ACDataset } from '@spice-ts/ui';
 
 const RC_NETLIST = `
 * RC Low-Pass Filter
-V1 in 0 PULSE(0 5 0 1n 1n 5m 10m)
+V1 in 0 PULSE(0 5 0 1n 1n 5m 10m) AC 1
 R1 in out 1k
 C1 out 0 100n
 .tran 1u 10m
 .ac dec 20 1 10Meg
 `;
 
-const STREAM_NETLIST = `
+const STREAM_TRAN_NETLIST = `
 * RC pulse response (streaming demo)
-* maxTimestep forces 200k solver steps for visible progressive rendering
 V1 in 0 PULSE(0 5 0 10u 10u 2m 4m)
 R1 in out 10k
 C1 out 0 100n
 .tran 0.1u 20m 0 0.1u
+`;
+
+const STREAM_AC_NETLIST = `
+* RC Low-Pass AC sweep (streaming demo)
+V1 in 0 AC 1
+R1 in out 1k
+C1 out 0 100n
+.ac dec 100 1 10Meg
 `;
 
 const buttonStyle: React.CSSProperties = {
@@ -33,6 +42,65 @@ const buttonStyle: React.CSSProperties = {
   cursor: 'pointer',
   fontWeight: 500,
 };
+
+function StreamingBodePlot() {
+  const [acData, setAcData] = useState<ACDataset[] | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<ACStreamingController | null>(null);
+  const rafRef = useRef<number>(0);
+
+  const handleRun = useCallback(() => {
+    // Cleanup previous
+    controllerRef.current?.stop();
+    cancelAnimationFrame(rafRef.current);
+    setAcData(null);
+    setError(null);
+    setRunning(true);
+
+    let dirty = false;
+    const controller = new ACStreamingController(['out'], () => { dirty = true; });
+    controllerRef.current = controller;
+
+    const loop = () => {
+      if (dirty) {
+        dirty = false;
+        setAcData([controller.getDataset()]);
+      }
+      if (controller.isRunning()) {
+        rafRef.current = requestAnimationFrame(loop);
+      } else {
+        setAcData([controller.getDataset()]);
+        setRunning(false);
+      }
+    };
+    rafRef.current = requestAnimationFrame(loop);
+
+    const stream = simulateStream(STREAM_AC_NETLIST);
+    controller.consume(stream as AsyncIterable<any>).catch((err: unknown) => {
+      setError(err instanceof Error ? err.message : String(err));
+      setRunning(false);
+    });
+  }, []);
+
+  return (
+    <div>
+      <div style={{ marginBottom: '12px' }}>
+        <button style={buttonStyle} onClick={handleRun}>
+          {running ? '⏳ Running...' : acData ? '↻ Re-run AC' : '▶ Run AC Sweep'}
+        </button>
+      </div>
+      {error && (
+        <div style={{ color: '#f87171', fontSize: '13px', marginBottom: '8px' }}>
+          Simulation error: {error}
+        </div>
+      )}
+      {acData && (
+        <BodePlot data={acData} signals={['out']} colors={{ out: '#f97316' }} theme="dark" />
+      )}
+    </div>
+  );
+}
 
 function App() {
   const [result, setResult] = useState<SimulationResult | null>(null);
@@ -49,9 +117,8 @@ function App() {
   const handleRunStreaming = useCallback(() => {
     setStream(null);
     setStreaming(true);
-    // Small delay to let React clear the previous stream
     setTimeout(() => {
-      const s = simulateStream(STREAM_NETLIST);
+      const s = simulateStream(STREAM_TRAN_NETLIST);
       setStream(s as AsyncIterableIterator<unknown>);
     }, 50);
   }, []);
@@ -79,9 +146,9 @@ function App() {
         theme="dark"
       />
 
-      <h2>Streaming Simulation</h2>
+      <h2>Streaming Transient</h2>
       <p style={{ fontSize: '13px', color: 'hsl(215, 20%, 55%)', marginBottom: '12px' }}>
-        Click "Run" to watch the simulation draw in real-time.
+        Watch the RC pulse response draw in real-time.
       </p>
       <div style={{ marginBottom: '12px' }}>
         <button style={buttonStyle} onClick={handleRunStreaming}>
@@ -97,6 +164,12 @@ function App() {
           xDomain={[0, 20e-3]}
         />
       )}
+
+      <h2>Streaming AC Sweep</h2>
+      <p style={{ fontSize: '13px', color: 'hsl(215, 20%, 55%)', marginBottom: '12px' }}>
+        Watch the Bode plot build frequency-by-frequency.
+      </p>
+      <StreamingBodePlot />
 
       <h2>Light Theme</h2>
       <WaveformViewer

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -1,9 +1,9 @@
 import { createRoot } from 'react-dom/client';
 import { useState, useCallback, useRef } from 'react';
 import { simulateStream } from '@spice-ts/core';
-import { WaveformViewer, BodePlot } from '@spice-ts/ui/react';
-import { ACStreamingController } from '@spice-ts/ui';
-import type { ACDataset } from '@spice-ts/ui';
+import { WaveformViewer, BodePlot, CursorTooltip } from '@spice-ts/ui/react';
+import { ACStreamingController, DARK_THEME, formatFrequency } from '@spice-ts/ui';
+import type { ACDataset, CursorState } from '@spice-ts/ui';
 
 const STREAM_TRAN_NETLIST = `
 * RC pulse response (streaming demo)
@@ -37,6 +37,7 @@ function StreamingBodePlot() {
   const [acData, setAcData] = useState<ACDataset[] | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [cursor, setCursor] = useState<CursorState | null>(null);
   const controllerRef = useRef<ACStreamingController | null>(null);
   const rafRef = useRef<number>(0);
 
@@ -85,13 +86,21 @@ function StreamingBodePlot() {
         </div>
       )}
       {acData && (
-        <BodePlot
-          data={acData}
-          signals={['out']}
-          colors={{ out: '#f97316' }}
-          theme="dark"
-          xDomain={[1, 10e6]}
-        />
+        <div style={{ position: 'relative' }}>
+          <BodePlot
+            data={acData}
+            signals={['out']}
+            colors={{ out: '#f97316' }}
+            theme="dark"
+            xDomain={[1, 10e6]}
+            onCursorMove={setCursor}
+          />
+          <CursorTooltip
+            cursor={cursor}
+            theme={DARK_THEME}
+            formatX={(x) => formatFrequency(x)}
+          />
+        </div>
       )}
     </div>
   );

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -14,15 +14,12 @@ C1 out 0 100n
 `;
 
 const STREAM_NETLIST = `
-* Half-wave rectifier with RC smoothing (streaming demo)
-* Diode nonlinearity forces Newton-Raphson per step — visibly progressive
-V1 in 0 SIN(0 10 500)
-D1 in rect DMOD
-.model DMOD D (IS=1e-14 N=1.05 RS=0.5)
-R1 rect out 100
-C1 out 0 100u
-R2 out 0 1k
-.tran 0.1u 20m
+* RC pulse response (streaming demo)
+* maxTimestep forces 200k solver steps for visible progressive rendering
+V1 in 0 PULSE(0 5 0 10u 10u 2m 4m)
+R1 in out 10k
+C1 out 0 100n
+.tran 0.1u 20m 0 0.1u
 `;
 
 const buttonStyle: React.CSSProperties = {

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import { useState, useCallback, useRef } from 'react';
-import { simulateStream, type TransientStep, type ACPoint } from '@spice-ts/core';
+import { simulateStream } from '@spice-ts/core';
 import { WaveformViewer, BodePlot, CursorTooltip } from '@spice-ts/ui/react';
 import { ACStreamingController, DARK_THEME, formatFrequency } from '@spice-ts/ui';
 import type { ACDataset, CursorState } from '@spice-ts/ui';
@@ -107,7 +107,7 @@ function StreamingBodePlot() {
 }
 
 function App() {
-  const [stream, setStream] = useState<AsyncIterable<TransientStep | ACPoint> | null>(null);
+  const [stream, setStream] = useState<ReturnType<typeof simulateStream> | null>(null);
   const [streaming, setStreaming] = useState(false);
 
   const handleRunStreaming = useCallback(() => {

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
-import { useState, useEffect } from 'react';
-import { simulate } from '@spice-ts/core';
+import { useState, useEffect, useCallback } from 'react';
+import { simulate, simulateStream } from '@spice-ts/core';
 import { WaveformViewer } from '@spice-ts/ui/react';
 import type { SimulationResult } from '@spice-ts/core';
 
@@ -13,14 +13,46 @@ C1 out 0 100n
 .ac dec 20 1 10Meg
 `;
 
+const STREAM_NETLIST = `
+* RC Low-Pass Filter (streaming)
+V1 in 0 PULSE(0 5 0 1n 1n 5m 10m)
+R1 in out 1k
+C1 out 0 100n
+.tran 1u 10m
+`;
+
+const buttonStyle: React.CSSProperties = {
+  fontSize: '13px',
+  fontFamily: "'Inter', -apple-system, sans-serif",
+  color: 'hsl(210, 40%, 98%)',
+  background: 'hsl(215, 20%, 12%)',
+  border: '1px solid hsl(215, 20%, 25%)',
+  borderRadius: '6px',
+  padding: '8px 16px',
+  cursor: 'pointer',
+  fontWeight: 500,
+};
+
 function App() {
   const [result, setResult] = useState<SimulationResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [stream, setStream] = useState<AsyncIterableIterator<unknown> | null>(null);
+  const [streaming, setStreaming] = useState(false);
 
   useEffect(() => {
     simulate(RC_NETLIST)
       .then(setResult)
       .catch((e: Error) => setError(e.message));
+  }, []);
+
+  const handleRunStreaming = useCallback(() => {
+    setStream(null);
+    setStreaming(true);
+    // Small delay to let React clear the previous stream
+    setTimeout(() => {
+      const s = simulateStream(STREAM_NETLIST);
+      setStream(s as AsyncIterableIterator<unknown>);
+    }, 50);
   }, []);
 
   if (error) return <div style={{ color: 'red' }}>Error: {error}</div>;
@@ -45,6 +77,24 @@ function App() {
         colors={{ out: '#f97316' }}
         theme="dark"
       />
+
+      <h2>Streaming Simulation</h2>
+      <p style={{ fontSize: '13px', color: 'hsl(215, 20%, 55%)', marginBottom: '12px' }}>
+        Click "Run" to watch the simulation draw in real-time.
+      </p>
+      <div style={{ marginBottom: '12px' }}>
+        <button style={buttonStyle} onClick={handleRunStreaming}>
+          {streaming ? '↻ Re-run' : '▶ Run'}
+        </button>
+      </div>
+      {stream && (
+        <WaveformViewer
+          stream={stream}
+          signals={['out', 'in']}
+          colors={{ out: '#4ade80', in: '#60a5fa' }}
+          theme="dark"
+        />
+      )}
 
       <h2>Light Theme</h2>
       <WaveformViewer

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -1,19 +1,9 @@
 import { createRoot } from 'react-dom/client';
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { simulate, simulateStream } from '@spice-ts/core';
+import { useState, useCallback, useRef } from 'react';
+import { simulateStream } from '@spice-ts/core';
 import { WaveformViewer, BodePlot } from '@spice-ts/ui/react';
 import { ACStreamingController } from '@spice-ts/ui';
-import type { SimulationResult, ACResult } from '@spice-ts/core';
 import type { ACDataset } from '@spice-ts/ui';
-
-const RC_NETLIST = `
-* RC Low-Pass Filter
-V1 in 0 PULSE(0 5 0 1n 1n 5m 10m) AC 1
-R1 in out 1k
-C1 out 0 100n
-.tran 1u 10m
-.ac dec 20 1 10Meg
-`;
 
 const STREAM_TRAN_NETLIST = `
 * RC pulse response (streaming demo)
@@ -51,7 +41,6 @@ function StreamingBodePlot() {
   const rafRef = useRef<number>(0);
 
   const handleRun = useCallback(() => {
-    // Cleanup previous
     controllerRef.current?.stop();
     cancelAnimationFrame(rafRef.current);
     setAcData(null);
@@ -96,23 +85,21 @@ function StreamingBodePlot() {
         </div>
       )}
       {acData && (
-        <BodePlot data={acData} signals={['out']} colors={{ out: '#f97316' }} theme="dark" />
+        <BodePlot
+          data={acData}
+          signals={['out']}
+          colors={{ out: '#f97316' }}
+          theme="dark"
+          xDomain={[1, 10e6]}
+        />
       )}
     </div>
   );
 }
 
 function App() {
-  const [result, setResult] = useState<SimulationResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [stream, setStream] = useState<AsyncIterableIterator<unknown> | null>(null);
   const [streaming, setStreaming] = useState(false);
-
-  useEffect(() => {
-    simulate(RC_NETLIST)
-      .then(setResult)
-      .catch((e: Error) => setError(e.message));
-  }, []);
 
   const handleRunStreaming = useCallback(() => {
     setStream(null);
@@ -123,28 +110,9 @@ function App() {
     }, 50);
   }, []);
 
-  if (error) return <div style={{ color: 'red' }}>Error: {error}</div>;
-  if (!result) return <div>Running simulation...</div>;
-
   return (
     <div>
       <h1>spice-ts Waveform Viewer</h1>
-
-      <h2>Transient — RC Step Response</h2>
-      <WaveformViewer
-        transient={result.transient}
-        signals={['out', 'in']}
-        colors={{ out: '#4ade80', in: '#60a5fa' }}
-        theme="dark"
-      />
-
-      <h2>AC — Bode Plot</h2>
-      <WaveformViewer
-        ac={result.ac}
-        signals={['out']}
-        colors={{ out: '#f97316' }}
-        theme="dark"
-      />
 
       <h2>Streaming Transient</h2>
       <p style={{ fontSize: '13px', color: 'hsl(215, 20%, 55%)', marginBottom: '12px' }}>
@@ -170,14 +138,6 @@ function App() {
         Watch the Bode plot build frequency-by-frequency.
       </p>
       <StreamingBodePlot />
-
-      <h2>Light Theme</h2>
-      <WaveformViewer
-        transient={result.transient}
-        signals={['out']}
-        colors={{ out: '#16a34a' }}
-        theme="light"
-      />
     </div>
   );
 }

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import { useState, useCallback, useRef } from 'react';
-import { simulateStream } from '@spice-ts/core';
+import { simulateStream, type TransientStep, type ACPoint } from '@spice-ts/core';
 import { WaveformViewer, BodePlot, CursorTooltip } from '@spice-ts/ui/react';
 import { ACStreamingController, DARK_THEME, formatFrequency } from '@spice-ts/ui';
 import type { ACDataset, CursorState } from '@spice-ts/ui';
@@ -107,7 +107,7 @@ function StreamingBodePlot() {
 }
 
 function App() {
-  const [stream, setStream] = useState<AsyncIterable<unknown> | null>(null);
+  const [stream, setStream] = useState<AsyncIterable<TransientStep | ACPoint> | null>(null);
   const [streaming, setStreaming] = useState(false);
 
   const handleRunStreaming = useCallback(() => {

--- a/examples/08-waveform-viewer/main.tsx
+++ b/examples/08-waveform-viewer/main.tsx
@@ -107,7 +107,7 @@ function StreamingBodePlot() {
 }
 
 function App() {
-  const [stream, setStream] = useState<AsyncIterableIterator<unknown> | null>(null);
+  const [stream, setStream] = useState<AsyncIterable<unknown> | null>(null);
   const [streaming, setStreaming] = useState(false);
 
   const handleRunStreaming = useCallback(() => {
@@ -115,7 +115,7 @@ function App() {
     setStreaming(true);
     setTimeout(() => {
       const s = simulateStream(STREAM_TRAN_NETLIST);
-      setStream(s as AsyncIterableIterator<unknown>);
+      setStream(s);
     }, 50);
   }, []);
 

--- a/examples/08-waveform-viewer/package.json
+++ b/examples/08-waveform-viewer/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@spice-ts/example-waveform-viewer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build"
+  },
+  "dependencies": {
+    "@spice-ts/core": "workspace:*",
+    "@spice-ts/ui": "workspace:*",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.4.0",
+    "vite": "^8.0.8"
+  }
+}

--- a/examples/08-waveform-viewer/tsconfig.json
+++ b/examples/08-waveform-viewer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/examples/08-waveform-viewer/vite.config.ts
+++ b/examples/08-waveform-viewer/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@spice-ts/ui",
+  "version": "0.1.0",
+  "description": "Waveform viewer for spice-ts simulation results",
+  "license": "MIT",
+  "author": "Mattia Fiumara",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mfiumara/spice-ts.git",
+    "directory": "packages/ui"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "d3-array": "^3.2.4",
+    "d3-scale": "^4.0.2"
+  },
+  "peerDependencies": {
+    "@spice-ts/core": "workspace:*",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": true },
+    "react-dom": { "optional": true }
+  },
+  "devDependencies": {
+    "@spice-ts/core": "workspace:*",
+    "@testing-library/react": "^16.0.0",
+    "@types/d3-array": "^3.2.1",
+    "@types/d3-scale": "^4.0.8",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitest/coverage-v8": "^4.1.4",
+    "jsdom": "^25.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vite": "^8.0.8",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/ui/src/core/bode-renderer.test.ts
+++ b/packages/ui/src/core/bode-renderer.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BodeRenderer } from './bode-renderer.js';
+import { DARK_THEME } from './theme.js';
+import type { ACDataset } from './types.js';
+
+function createTestCanvas(width = 800, height = 300): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  canvas.getBoundingClientRect = () => ({
+    x: 0, y: 0, width, height, top: 0, left: 0, right: width, bottom: height, toJSON() {},
+  });
+  return canvas;
+}
+
+function createTestACData(): ACDataset[] {
+  const frequencies = [100, 1000, 10000, 100000, 1000000];
+  const magnitudes = new Map([['out', [0, -1, -3, -10, -20]]]);
+  const phases = new Map([['out', [0, -10, -45, -75, -85]]]);
+  return [{ frequencies, magnitudes, phases, label: '' }];
+}
+
+describe('BodeRenderer', () => {
+  let magCanvas: HTMLCanvasElement;
+  let phaseCanvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    magCanvas = createTestCanvas();
+    phaseCanvas = createTestCanvas(800, 200);
+  });
+
+  it('constructs without error', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    expect(renderer).toBeDefined();
+    renderer.destroy();
+  });
+
+  it('setData and render without error', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('collapsing magnitude pane still renders phase', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setPaneVisible('magnitude', false);
+    renderer.render(); // should not throw
+    renderer.destroy();
+  });
+
+  it('collapsing phase pane still renders magnitude', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setPaneVisible('phase', false);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('emits cursorMove events', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    renderer.setCursorPixelX(200);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x: expect.any(Number),
+        values: expect.any(Array),
+      }),
+    );
+
+    renderer.destroy();
+  });
+});

--- a/packages/ui/src/core/bode-renderer.test.ts
+++ b/packages/ui/src/core/bode-renderer.test.ts
@@ -75,4 +75,188 @@ describe('BodeRenderer', () => {
 
     renderer.destroy();
   });
+
+  it('setCursorPixelX(null) clears cursor', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    renderer.setCursorPixelX(null);
+    expect(callback).toHaveBeenCalledWith(null);
+
+    renderer.destroy();
+  });
+
+  it('setCursorPixelX outside plot area clears cursor', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    // left margin=56, pixel=5 is outside plot
+    renderer.setCursorPixelX(5);
+    expect(callback).toHaveBeenCalledWith(null);
+
+    renderer.destroy();
+  });
+
+  it('zoomAt centers on log midpoint and sets userHasZoomed', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    renderer.zoomAt(400, 2);
+    renderer.render(); // should not throw
+
+    // After zooming, setData should preserve zoom (not reset)
+    renderer.setData(createTestACData(), ['out']);
+    renderer.render();
+
+    renderer.destroy();
+  });
+
+  it('pan shifts domain in log space', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    renderer.pan(50, 0);
+    renderer.render();
+
+    renderer.destroy();
+  });
+
+  it('fitToData resets userHasZoomed', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    renderer.zoomAt(400, 2);
+    renderer.fitToData();
+    renderer.render();
+
+    // After fitToData, setData recalculates domains
+    renderer.setData(createTestACData(), ['out']);
+    renderer.render();
+
+    renderer.destroy();
+  });
+
+  it('setFixedXDomain pins frequency range', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setFixedXDomain([10, 1e6]);
+    renderer.setData(createTestACData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setFixedXDomain(null) clears fixed domain', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setFixedXDomain([10, 1e6]);
+    renderer.setFixedXDomain(null);
+    renderer.setData(createTestACData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('userHasZoomed: zoom prevents domain recalc on setData', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.zoomAt(400, 3);
+    // Calling setData again should not reset the zoom
+    renderer.setData(createTestACData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('isPaneVisible returns correct state', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    expect(renderer.isPaneVisible('magnitude')).toBe(true);
+    expect(renderer.isPaneVisible('phase')).toBe(true);
+
+    renderer.setPaneVisible('magnitude', false);
+    expect(renderer.isPaneVisible('magnitude')).toBe(false);
+
+    renderer.destroy();
+  });
+
+  it('defaultPanes=magnitude hides phase pane', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, {
+      theme: DARK_THEME,
+      defaultPanes: 'magnitude',
+    });
+    expect(renderer.isPaneVisible('phase')).toBe(false);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('defaultPanes=phase hides magnitude pane', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, {
+      theme: DARK_THEME,
+      defaultPanes: 'phase',
+    });
+    expect(renderer.isPaneVisible('magnitude')).toBe(false);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('off() removes listener', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+    renderer.off('cursorMove', callback);
+
+    renderer.setCursorPixelX(200);
+    expect(callback).not.toHaveBeenCalled();
+    renderer.destroy();
+  });
+
+  it('getSignalStates returns current states', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    const states = renderer.getSignalStates();
+    expect(states).toHaveLength(1);
+    expect(states[0].name).toBe('out');
+    renderer.destroy();
+  });
+
+  it('setSignalColor changes color', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setSignalColor('out', '#ff0000');
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setSignalVisibility hides signal', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setSignalVisibility('out', false);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setTheme updates theme', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setTheme({ ...DARK_THEME, background: '#000' });
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('render with cursor draws cursor line', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.setData(createTestACData(), ['out']);
+    renderer.setCursorPixelX(200);
+    renderer.render(); // cursor should be drawn without error
+    renderer.destroy();
+  });
+
+  it('render after destroy does nothing', () => {
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, { theme: DARK_THEME });
+    renderer.destroy();
+    renderer.render(); // should not throw
+  });
 });

--- a/packages/ui/src/core/bode-renderer.ts
+++ b/packages/ui/src/core/bode-renderer.ts
@@ -1,0 +1,380 @@
+import { createLogScale, createLinearScale, computeYExtent, bisectData, type LogScale, type LinearScale } from './scales.js';
+import { formatFrequency, formatDB, formatPhase } from './format.js';
+import type { ThemeConfig, ACDataset, CursorState, CursorValue, Margins, RendererEvents } from './types.js';
+import { DEFAULT_PALETTE } from './types.js';
+
+export interface BodeRendererOptions {
+  theme: ThemeConfig;
+  margin?: Partial<Margins>;
+  defaultPanes?: 'both' | 'magnitude' | 'phase';
+}
+
+interface SignalState {
+  name: string;
+  color: string;
+  visible: boolean;
+  datasetIndex: number;
+}
+
+export class BodeRenderer {
+  private magCanvas: HTMLCanvasElement;
+  private phaseCanvas: HTMLCanvasElement;
+  private magCtx: CanvasRenderingContext2D | null;
+  private phaseCtx: CanvasRenderingContext2D | null;
+  private theme: ThemeConfig;
+  private margin: Margins;
+  private dpr: number;
+
+  private datasets: ACDataset[] = [];
+  private signalStates: SignalState[] = [];
+  private xScale: LogScale = createLogScale([1, 10], [0, 1]);
+  private magYScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private phaseYScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private xDomain: [number, number] = [1, 10];
+  private magYDomain: [number, number] = [-60, 10];
+  private phaseYDomain: [number, number] = [-180, 0];
+
+  private magnitudeVisible = true;
+  private phaseVisible = true;
+  private cursorState: CursorState | null = null;
+  private destroyed = false;
+  private listeners: Partial<{ [K in keyof RendererEvents]: RendererEvents[K][] }> = {};
+
+  constructor(magCanvas: HTMLCanvasElement, phaseCanvas: HTMLCanvasElement, options: BodeRendererOptions) {
+    this.magCanvas = magCanvas;
+    this.phaseCanvas = phaseCanvas;
+    this.magCtx = magCanvas.getContext('2d');
+    this.phaseCtx = phaseCanvas.getContext('2d');
+    this.theme = options.theme;
+    this.dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+    this.margin = {
+      top: options.margin?.top ?? 20,
+      right: options.margin?.right ?? 16,
+      bottom: options.margin?.bottom ?? 32,
+      left: options.margin?.left ?? 56,
+    };
+
+    if (options.defaultPanes === 'magnitude') this.phaseVisible = false;
+    if (options.defaultPanes === 'phase') this.magnitudeVisible = false;
+  }
+
+  setData(datasets: ACDataset[], signals: string[]): void {
+    this.datasets = datasets;
+    this.signalStates = [];
+
+    let colorIdx = 0;
+    for (let di = 0; di < datasets.length; di++) {
+      for (const name of signals) {
+        if (datasets[di].magnitudes.has(name)) {
+          this.signalStates.push({
+            name,
+            color: DEFAULT_PALETTE[colorIdx % DEFAULT_PALETTE.length],
+            visible: true,
+            datasetIndex: di,
+          });
+          colorIdx++;
+        }
+      }
+    }
+
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  setTheme(theme: ThemeConfig): void {
+    this.theme = theme;
+  }
+
+  setSignalColor(name: string, color: string): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.color = color;
+    }
+  }
+
+  setSignalVisibility(name: string, visible: boolean): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.visible = visible;
+    }
+  }
+
+  getSignalStates(): ReadonlyArray<Readonly<SignalState>> {
+    return this.signalStates;
+  }
+
+  setPaneVisible(pane: 'magnitude' | 'phase', visible: boolean): void {
+    if (pane === 'magnitude') this.magnitudeVisible = visible;
+    if (pane === 'phase') this.phaseVisible = visible;
+  }
+
+  isPaneVisible(pane: 'magnitude' | 'phase'): boolean {
+    return pane === 'magnitude' ? this.magnitudeVisible : this.phaseVisible;
+  }
+
+  setCursorPixelX(pixelX: number | null): void {
+    if (pixelX === null) {
+      this.cursorState = null;
+      this.emit('cursorMove', null);
+      return;
+    }
+
+    const dataX = this.xScale.invert(pixelX - this.margin.left);
+    const values: CursorValue[] = [];
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const idx = bisectData(ds.frequencies as number[], dataX);
+      const magArr = ds.magnitudes.get(s.name);
+      const phaseArr = ds.phases.get(s.name);
+      const label = ds.label ? `${ds.label}: ${s.name}` : s.name;
+      const signalId = ds.label ? `${ds.label}:${s.name}` : s.name;
+
+      if (magArr && this.magnitudeVisible) {
+        values.push({ signalId: `${signalId}:mag`, label: `${label} (mag)`, value: magArr[idx], unit: 'dB', color: s.color });
+      }
+      if (phaseArr && this.phaseVisible) {
+        values.push({ signalId: `${signalId}:phase`, label: `${label} (phase)`, value: phaseArr[idx], unit: '°', color: s.color });
+      }
+    }
+
+    this.cursorState = { x: dataX, pixelX, values };
+    this.emit('cursorMove', this.cursorState);
+  }
+
+  zoomAt(pixelX: number, factor: number): void {
+    const centerX = this.xScale.invert(pixelX - this.margin.left);
+    const logCenter = Math.log10(centerX);
+    const [lx0, lx1] = [Math.log10(this.xDomain[0]), Math.log10(this.xDomain[1])];
+    const halfSpan = (lx1 - lx0) / 2 / factor;
+    this.xDomain = [Math.pow(10, logCenter - halfSpan), Math.pow(10, logCenter + halfSpan)];
+    this.updateScales();
+  }
+
+  pan(dx: number, _dy: number): void {
+    const plotWidth = this.getPlotWidth(this.magCanvas);
+    const [lx0, lx1] = [Math.log10(this.xDomain[0]), Math.log10(this.xDomain[1])];
+    const logShift = (dx / plotWidth) * (lx1 - lx0);
+    this.xDomain = [Math.pow(10, lx0 - logShift), Math.pow(10, lx1 - logShift)];
+    this.updateScales();
+  }
+
+  fitToData(): void {
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  on<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    (this.listeners[event] as RendererEvents[K][]).push(callback);
+  }
+
+  off<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    const idx = (arr as RendererEvents[K][]).indexOf(callback);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
+  render(): void {
+    if (this.destroyed) return;
+    if (this.magnitudeVisible && this.magCtx) {
+      this.renderPane(this.magCtx, this.magCanvas, 'magnitude');
+    } else if (this.magCtx) {
+      this.clearCanvas(this.magCtx, this.magCanvas);
+    }
+    if (this.phaseVisible && this.phaseCtx) {
+      this.renderPane(this.phaseCtx, this.phaseCanvas, 'phase');
+    } else if (this.phaseCtx) {
+      this.clearCanvas(this.phaseCtx, this.phaseCanvas);
+    }
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.listeners = {};
+  }
+
+  // --- Private ---
+
+  private emit<K extends keyof RendererEvents>(event: K, ...args: Parameters<RendererEvents[K]>): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    for (const cb of arr) (cb as (...a: unknown[]) => void)(...args);
+  }
+
+  private getPlotWidth(canvas: HTMLCanvasElement): number {
+    return canvas.width / this.dpr - this.margin.left - this.margin.right;
+  }
+
+  private getPlotHeight(canvas: HTMLCanvasElement): number {
+    return canvas.height / this.dpr - this.margin.top - this.margin.bottom;
+  }
+
+  private clearCanvas(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement): void {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  private renderPane(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, pane: 'magnitude' | 'phase'): void {
+    const width = canvas.width / this.dpr;
+    const height = canvas.height / this.dpr;
+    const plotWidth = this.getPlotWidth(canvas);
+    const plotHeight = this.getPlotHeight(canvas);
+    const yScale = pane === 'magnitude' ? this.magYScale : this.phaseYScale;
+    const formatY = pane === 'magnitude' ? formatDB : formatPhase;
+    const getArr = (ds: ACDataset, name: string) =>
+      pane === 'magnitude' ? ds.magnitudes.get(name) : ds.phases.get(name);
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(this.dpr, this.dpr);
+
+    // Background
+    ctx.fillStyle = this.theme.background;
+    ctx.fillRect(this.margin.left, this.margin.top, plotWidth, plotHeight);
+
+    // Pane label
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `500 ${this.theme.fontSize - 1}px ${this.theme.font}`;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    ctx.fillText(pane === 'magnitude' ? 'MAGNITUDE (dB)' : 'PHASE (°)', this.margin.left + 4, 4);
+
+    // Grid
+    ctx.strokeStyle = this.theme.grid;
+    ctx.lineWidth = 0.5;
+    const xTicks = this.xScale.ticks(6);
+    for (const tick of xTicks) {
+      const x = this.margin.left + this.xScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(x, this.margin.top);
+      ctx.lineTo(x, this.margin.top + plotHeight);
+      ctx.stroke();
+    }
+    const yTicks = yScale.ticks(4);
+    for (const tick of yTicks) {
+      const y = this.margin.top + yScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(this.margin.left, y);
+      ctx.lineTo(this.margin.left + plotWidth, y);
+      ctx.stroke();
+    }
+
+    // -3dB reference line on magnitude pane
+    if (pane === 'magnitude') {
+      const y3db = this.margin.top + this.magYScale(-3);
+      ctx.strokeStyle = 'hsl(0, 60%, 40%)';
+      ctx.lineWidth = 0.5;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(this.margin.left, y3db);
+      ctx.lineTo(this.margin.left + plotWidth, y3db);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Waveforms (clipped)
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(this.margin.left, this.margin.top, plotWidth, plotHeight);
+    ctx.clip();
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const yArr = getArr(ds, s.name);
+      if (!yArr) continue;
+
+      ctx.strokeStyle = s.color;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      let started = false;
+      for (let i = 0; i < ds.frequencies.length; i++) {
+        const x = this.margin.left + this.xScale(ds.frequencies[i]);
+        const y = this.margin.top + yScale(yArr[i]);
+        if (!started) { ctx.moveTo(x, y); started = true; }
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    // Axes
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `${this.theme.fontSize}px ${this.theme.font}`;
+
+    // Y axis labels
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (const tick of yTicks) {
+      const y = this.margin.top + yScale(tick);
+      ctx.fillText(formatY(tick), this.margin.left - 6, y);
+    }
+
+    // X axis labels (only on phase pane, or whichever is the bottom pane)
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    for (const tick of xTicks) {
+      const x = this.margin.left + this.xScale(tick);
+      ctx.fillText(formatFrequency(tick), x, this.margin.top + plotHeight + 6);
+    }
+
+    // Cursor
+    if (this.cursorState) {
+      const cx = this.cursorState.pixelX;
+      ctx.strokeStyle = this.theme.cursor;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath();
+      ctx.moveTo(cx, this.margin.top);
+      ctx.lineTo(cx, this.margin.top + plotHeight);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    ctx.restore();
+
+    // Suppress unused variable warnings
+    void width;
+    void height;
+  }
+
+  private computeDefaultDomains(): void {
+    if (this.datasets.length === 0) return;
+
+    // X domain: min/max frequency
+    let fMin = Infinity;
+    let fMax = -Infinity;
+    for (const ds of this.datasets) {
+      if (ds.frequencies.length > 0) {
+        fMin = Math.min(fMin, ds.frequencies[0]);
+        fMax = Math.max(fMax, ds.frequencies[ds.frequencies.length - 1]);
+      }
+    }
+    if (isFinite(fMin) && isFinite(fMax) && fMin > 0) {
+      this.xDomain = [fMin, fMax];
+    }
+
+    // Magnitude Y domain
+    const magArrays: number[][] = [];
+    const phaseArrays: number[][] = [];
+    for (const s of this.signalStates) {
+      const ds = this.datasets[s.datasetIndex];
+      const mag = ds.magnitudes.get(s.name);
+      const phase = ds.phases.get(s.name);
+      if (mag) magArrays.push(mag);
+      if (phase) phaseArrays.push(phase);
+    }
+    if (magArrays.length > 0) this.magYDomain = computeYExtent(magArrays);
+    if (phaseArrays.length > 0) this.phaseYDomain = computeYExtent(phaseArrays);
+  }
+
+  private updateScales(): void {
+    const magPlotWidth = this.getPlotWidth(this.magCanvas);
+    const magPlotHeight = this.getPlotHeight(this.magCanvas);
+    const phasePlotHeight = this.getPlotHeight(this.phaseCanvas);
+
+    this.xScale = createLogScale(this.xDomain, [0, magPlotWidth]);
+    this.magYScale = createLinearScale(this.magYDomain, [magPlotHeight, 0]);
+    this.phaseYScale = createLinearScale(this.phaseYDomain, [phasePlotHeight, 0]);
+  }
+}

--- a/packages/ui/src/core/bode-renderer.ts
+++ b/packages/ui/src/core/bode-renderer.ts
@@ -117,6 +117,15 @@ export class BodeRenderer {
       return;
     }
 
+    // Clamp cursor to the plot area
+    const plotLeft = this.margin.left;
+    const plotRight = this.margin.left + this.getPlotWidth(this.magCanvas);
+    if (pixelX < plotLeft || pixelX > plotRight) {
+      this.cursorState = null;
+      this.emit('cursorMove', null);
+      return;
+    }
+
     const dataX = this.xScale.invert(pixelX - this.margin.left);
     const values: CursorValue[] = [];
 

--- a/packages/ui/src/core/bode-renderer.ts
+++ b/packages/ui/src/core/bode-renderer.ts
@@ -38,6 +38,7 @@ export class BodeRenderer {
   private phaseVisible = true;
   private cursorState: CursorState | null = null;
   private destroyed = false;
+  private fixedXDomain: [number, number] | null = null;
   private listeners: Partial<{ [K in keyof RendererEvents]: RendererEvents[K][] }> = {};
 
   constructor(magCanvas: HTMLCanvasElement, phaseCanvas: HTMLCanvasElement, options: BodeRendererOptions) {
@@ -79,6 +80,14 @@ export class BodeRenderer {
 
     this.computeDefaultDomains();
     this.updateScales();
+  }
+
+  setFixedXDomain(domain: [number, number] | null): void {
+    this.fixedXDomain = domain;
+    if (domain) {
+      this.xDomain = domain;
+      this.updateScales();
+    }
   }
 
   setTheme(theme: ThemeConfig): void {
@@ -350,17 +359,21 @@ export class BodeRenderer {
   private computeDefaultDomains(): void {
     if (this.datasets.length === 0) return;
 
-    // X domain: min/max frequency
-    let fMin = Infinity;
-    let fMax = -Infinity;
-    for (const ds of this.datasets) {
-      if (ds.frequencies.length > 0) {
-        fMin = Math.min(fMin, ds.frequencies[0]);
-        fMax = Math.max(fMax, ds.frequencies[ds.frequencies.length - 1]);
+    // X domain: use fixed domain if set, otherwise compute from data
+    if (this.fixedXDomain) {
+      this.xDomain = this.fixedXDomain;
+    } else {
+      let fMin = Infinity;
+      let fMax = -Infinity;
+      for (const ds of this.datasets) {
+        if (ds.frequencies.length > 0) {
+          fMin = Math.min(fMin, ds.frequencies[0]);
+          fMax = Math.max(fMax, ds.frequencies[ds.frequencies.length - 1]);
+        }
       }
-    }
-    if (isFinite(fMin) && isFinite(fMax) && fMin > 0) {
-      this.xDomain = [fMin, fMax];
+      if (isFinite(fMin) && isFinite(fMax) && fMin > 0) {
+        this.xDomain = [fMin, fMax];
+      }
     }
 
     // Magnitude Y domain

--- a/packages/ui/src/core/bode-renderer.ts
+++ b/packages/ui/src/core/bode-renderer.ts
@@ -39,6 +39,8 @@ export class BodeRenderer {
   private cursorState: CursorState | null = null;
   private destroyed = false;
   private fixedXDomain: [number, number] | null = null;
+  private userHasZoomed = false;
+  private hasData = false;
   private listeners: Partial<{ [K in keyof RendererEvents]: RendererEvents[K][] }> = {};
 
   constructor(magCanvas: HTMLCanvasElement, phaseCanvas: HTMLCanvasElement, options: BodeRendererOptions) {
@@ -78,8 +80,11 @@ export class BodeRenderer {
       }
     }
 
-    this.computeDefaultDomains();
+    if (!this.hasData || !this.userHasZoomed) {
+      this.computeDefaultDomains();
+    }
     this.updateScales();
+    this.hasData = true;
   }
 
   setFixedXDomain(domain: [number, number] | null): void {
@@ -159,16 +164,17 @@ export class BodeRenderer {
     this.emit('cursorMove', this.cursorState);
   }
 
-  zoomAt(pixelX: number, factor: number): void {
-    const centerX = this.xScale.invert(pixelX - this.margin.left);
-    const logCenter = Math.log10(centerX);
+  zoomAt(_pixelX: number, factor: number): void {
+    this.userHasZoomed = true;
     const [lx0, lx1] = [Math.log10(this.xDomain[0]), Math.log10(this.xDomain[1])];
+    const logCenter = (lx0 + lx1) / 2;
     const halfSpan = (lx1 - lx0) / 2 / factor;
     this.xDomain = [Math.pow(10, logCenter - halfSpan), Math.pow(10, logCenter + halfSpan)];
     this.updateScales();
   }
 
   pan(dx: number, _dy: number): void {
+    this.userHasZoomed = true;
     const plotWidth = this.getPlotWidth(this.magCanvas);
     const [lx0, lx1] = [Math.log10(this.xDomain[0]), Math.log10(this.xDomain[1])];
     const logShift = (dx / plotWidth) * (lx1 - lx0);
@@ -177,6 +183,7 @@ export class BodeRenderer {
   }
 
   fitToData(): void {
+    this.userHasZoomed = false;
     this.computeDefaultDomains();
     this.updateScales();
   }

--- a/packages/ui/src/core/buffer.test.ts
+++ b/packages/ui/src/core/buffer.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { GrowableBuffer } from './buffer.js';
+
+describe('GrowableBuffer', () => {
+  it('starts empty with given initial capacity', () => {
+    const buf = new GrowableBuffer(16);
+    expect(buf.length).toBe(0);
+    expect(buf.capacity).toBe(16);
+  });
+
+  it('appends values and grows length', () => {
+    const buf = new GrowableBuffer(4);
+    buf.push(1); buf.push(2); buf.push(3);
+    expect(buf.length).toBe(3);
+    expect(buf.get(0)).toBe(1);
+    expect(buf.get(1)).toBe(2);
+    expect(buf.get(2)).toBe(3);
+  });
+
+  it('doubles capacity when full', () => {
+    const buf = new GrowableBuffer(2);
+    buf.push(1); buf.push(2);
+    expect(buf.capacity).toBe(2);
+    buf.push(3);
+    expect(buf.capacity).toBe(4);
+    expect(buf.length).toBe(3);
+    expect(buf.get(2)).toBe(3);
+  });
+
+  it('toArray returns a copy of the data', () => {
+    const buf = new GrowableBuffer(4);
+    buf.push(10); buf.push(20);
+    const arr = buf.toArray();
+    expect(arr).toEqual(new Float64Array([10, 20]));
+    arr[0] = 999;
+    expect(buf.get(0)).toBe(10);
+  });
+
+  it('clear resets length but keeps capacity', () => {
+    const buf = new GrowableBuffer(4);
+    buf.push(1); buf.push(2);
+    buf.clear();
+    expect(buf.length).toBe(0);
+    expect(buf.capacity).toBe(4);
+  });
+
+  it('slice returns a sub-view as regular number array', () => {
+    const buf = new GrowableBuffer(8);
+    for (let i = 0; i < 5; i++) buf.push(i * 10);
+    expect(buf.slice(1, 4)).toEqual([10, 20, 30]);
+  });
+});

--- a/packages/ui/src/core/buffer.ts
+++ b/packages/ui/src/core/buffer.ts
@@ -1,0 +1,30 @@
+export class GrowableBuffer {
+  private data: Float64Array;
+  private _length = 0;
+
+  constructor(initialCapacity = 1024) {
+    this.data = new Float64Array(initialCapacity);
+  }
+
+  get length(): number { return this._length; }
+  get capacity(): number { return this.data.length; }
+
+  push(value: number): void {
+    if (this._length >= this.data.length) {
+      const newData = new Float64Array(this.data.length * 2);
+      newData.set(this.data);
+      this.data = newData;
+    }
+    this.data[this._length++] = value;
+  }
+
+  get(index: number): number { return this.data[index]; }
+
+  toArray(): Float64Array { return this.data.slice(0, this._length); }
+
+  slice(start: number, end: number): number[] {
+    return Array.from(this.data.subarray(start, end));
+  }
+
+  clear(): void { this._length = 0; }
+}

--- a/packages/ui/src/core/data.test.ts
+++ b/packages/ui/src/core/data.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeTransientData, normalizeACData } from './data.js';
+import type { TransientDataset, ACDataset } from './types.js';
+
+function mockTransientResult(time: number[], voltages: Record<string, number[]>) {
+  const voltageMap = new Map(Object.entries(voltages));
+  return {
+    time,
+    voltage(node: string) { const v = voltageMap.get(node); if (!v) throw new Error(`Unknown node: ${node}`); return v; },
+    current(_source: string) { return []; },
+  };
+}
+
+function mockACResult(frequencies: number[], voltages: Record<string, { magnitude: number; phase: number }[]>) {
+  const voltageMap = new Map(Object.entries(voltages));
+  return {
+    frequencies,
+    voltage(node: string) { const v = voltageMap.get(node); if (!v) throw new Error(`Unknown node: ${node}`); return v; },
+    current(_source: string) { return []; },
+  };
+}
+
+describe('normalizeTransientData', () => {
+  it('normalizes a single TransientResult', () => {
+    const result = mockTransientResult([0, 1, 2], { out: [0, 2.5, 5] });
+    const datasets = normalizeTransientData(result, ['out']);
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0].label).toBe('');
+    expect(datasets[0].time).toEqual([0, 1, 2]);
+    expect(datasets[0].signals.get('out')).toEqual([0, 2.5, 5]);
+  });
+
+  it('normalizes an array of TransientDatasets (pass-through)', () => {
+    const ds: TransientDataset[] = [
+      { time: [0, 1], signals: new Map([['out', [0, 5]]]), label: 'R=1k' },
+      { time: [0, 1], signals: new Map([['out', [0, 3]]]), label: 'R=10k' },
+    ];
+    const datasets = normalizeTransientData(ds, ['out']);
+    expect(datasets).toHaveLength(2);
+    expect(datasets[0].label).toBe('R=1k');
+    expect(datasets[1].label).toBe('R=10k');
+  });
+
+  it('extracts only requested signals', () => {
+    const result = mockTransientResult([0, 1], { out: [0, 5], mid: [0, 2.5] });
+    const datasets = normalizeTransientData(result, ['out']);
+    expect(datasets[0].signals.has('out')).toBe(true);
+    expect(datasets[0].signals.has('mid')).toBe(false);
+  });
+});
+
+describe('normalizeACData', () => {
+  it('normalizes a single ACResult into magnitude/phase arrays', () => {
+    const result = mockACResult([100, 1000, 10000], {
+      out: [
+        { magnitude: 1, phase: 0 },
+        { magnitude: 0.707, phase: -45 },
+        { magnitude: 0.1, phase: -84 },
+      ],
+    });
+    const datasets = normalizeACData(result, ['out']);
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0].frequencies).toEqual([100, 1000, 10000]);
+    const mags = datasets[0].magnitudes.get('out')!;
+    expect(mags[0]).toBeCloseTo(0, 1);
+    expect(mags[1]).toBeCloseTo(-3.01, 1);
+    expect(datasets[0].phases.get('out')).toEqual([0, -45, -84]);
+  });
+
+  it('normalizes an array of ACDatasets (pass-through)', () => {
+    const ds: ACDataset[] = [{
+      frequencies: [100, 1000],
+      magnitudes: new Map([['out', [0, -3]]]),
+      phases: new Map([['out', [0, -45]]]),
+      label: 'C=1n',
+    }];
+    const datasets = normalizeACData(ds, ['out']);
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0].label).toBe('C=1n');
+  });
+});

--- a/packages/ui/src/core/data.ts
+++ b/packages/ui/src/core/data.ts
@@ -1,0 +1,64 @@
+import type { TransientDataset, ACDataset } from './types.js';
+
+interface TransientResultLike {
+  time: number[];
+  voltage(node: string): number[];
+  current(source: string): number[];
+}
+
+interface ACResultLike {
+  frequencies: number[];
+  voltage(node: string): { magnitude: number; phase: number }[];
+  current(source: string): { magnitude: number; phase: number }[];
+}
+
+function isTransientResultLike(data: unknown): data is TransientResultLike {
+  return (
+    typeof data === 'object' && data !== null &&
+    'time' in data && Array.isArray((data as TransientResultLike).time) &&
+    'voltage' in data && typeof (data as TransientResultLike).voltage === 'function'
+  );
+}
+
+function isACResultLike(data: unknown): data is ACResultLike {
+  return (
+    typeof data === 'object' && data !== null &&
+    'frequencies' in data && Array.isArray((data as ACResultLike).frequencies) &&
+    'voltage' in data && typeof (data as ACResultLike).voltage === 'function'
+  );
+}
+
+export function normalizeTransientData(data: unknown, signals: string[]): TransientDataset[] {
+  if (Array.isArray(data)) return data as TransientDataset[];
+  if (!isTransientResultLike(data)) throw new Error('Invalid transient data: expected TransientResult or TransientDataset[]');
+
+  const signalMap = new Map<string, number[]>();
+  for (const name of signals) {
+    try { signalMap.set(name, data.voltage(name)); } catch {
+      try { signalMap.set(name, data.current(name)); } catch { /* skip */ }
+    }
+  }
+  return [{ time: data.time, signals: signalMap, label: '' }];
+}
+
+export function normalizeACData(data: unknown, signals: string[]): ACDataset[] {
+  if (Array.isArray(data)) return data as ACDataset[];
+  if (!isACResultLike(data)) throw new Error('Invalid AC data: expected ACResult or ACDataset[]');
+
+  const magnitudes = new Map<string, number[]>();
+  const phases = new Map<string, number[]>();
+  for (const name of signals) {
+    try {
+      const phasors = data.voltage(name);
+      magnitudes.set(name, phasors.map(p => 20 * Math.log10(Math.max(p.magnitude, 1e-30))));
+      phases.set(name, phasors.map(p => p.phase));
+    } catch {
+      try {
+        const phasors = data.current(name);
+        magnitudes.set(name, phasors.map(p => 20 * Math.log10(Math.max(p.magnitude, 1e-30))));
+        phases.set(name, phasors.map(p => p.phase));
+      } catch { /* skip */ }
+    }
+  }
+  return [{ frequencies: data.frequencies, magnitudes, phases, label: '' }];
+}

--- a/packages/ui/src/core/format.test.ts
+++ b/packages/ui/src/core/format.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, formatPhase, formatDB } from './format.js';
+
+describe('formatSI', () => {
+  it('formats values with SI prefixes', () => {
+    expect(formatSI(1e-12)).toBe('1p');
+    expect(formatSI(1e-9)).toBe('1n');
+    expect(formatSI(1e-6)).toBe('1µ');
+    expect(formatSI(1e-3)).toBe('1m');
+    expect(formatSI(1)).toBe('1');
+    expect(formatSI(1e3)).toBe('1k');
+    expect(formatSI(1e6)).toBe('1M');
+    expect(formatSI(1e9)).toBe('1G');
+  });
+
+  it('formats fractional values', () => {
+    expect(formatSI(2.5e-3)).toBe('2.5m');
+    expect(formatSI(47e3)).toBe('47k');
+    expect(formatSI(3.3e-6)).toBe('3.3µ');
+  });
+
+  it('formats zero', () => { expect(formatSI(0)).toBe('0'); });
+  it('formats negative values', () => { expect(formatSI(-5e-3)).toBe('-5m'); });
+  it('limits decimal places', () => { expect(formatSI(1.23456e3)).toBe('1.235k'); });
+});
+
+describe('formatTime', () => {
+  it('appends s suffix', () => {
+    expect(formatTime(1e-3)).toBe('1ms');
+    expect(formatTime(2.5e-6)).toBe('2.5µs');
+    expect(formatTime(1)).toBe('1s');
+  });
+});
+
+describe('formatFrequency', () => {
+  it('appends Hz suffix', () => {
+    expect(formatFrequency(1e3)).toBe('1kHz');
+    expect(formatFrequency(1e6)).toBe('1MHz');
+    expect(formatFrequency(100)).toBe('100Hz');
+  });
+});
+
+describe('formatVoltage', () => {
+  it('appends V suffix', () => {
+    expect(formatVoltage(5)).toBe('5V');
+    expect(formatVoltage(3.3e-3)).toBe('3.3mV');
+  });
+});
+
+describe('formatCurrent', () => {
+  it('appends A suffix', () => {
+    expect(formatCurrent(1e-3)).toBe('1mA');
+    expect(formatCurrent(5e-6)).toBe('5µA');
+  });
+});
+
+describe('formatDB', () => {
+  it('formats with dB suffix', () => {
+    expect(formatDB(0)).toBe('0dB');
+    expect(formatDB(-3)).toBe('-3dB');
+    expect(formatDB(-20.5)).toBe('-20.5dB');
+  });
+});
+
+describe('formatPhase', () => {
+  it('formats with degree suffix', () => {
+    expect(formatPhase(0)).toBe('0°');
+    expect(formatPhase(-90)).toBe('-90°');
+    expect(formatPhase(-45.5)).toBe('-45.5°');
+  });
+});

--- a/packages/ui/src/core/format.ts
+++ b/packages/ui/src/core/format.ts
@@ -1,0 +1,35 @@
+const SI_PREFIXES: [number, string][] = [
+  [1e-15, 'f'], [1e-12, 'p'], [1e-9, 'n'], [1e-6, 'µ'],
+  [1e-3, 'm'], [1, ''], [1e3, 'k'], [1e6, 'M'], [1e9, 'G'], [1e12, 'T'],
+];
+
+export function formatSI(value: number): string {
+  if (value === 0) return '0';
+  const abs = Math.abs(value);
+  let bestPrefix = '';
+  let bestScale = 1;
+  for (const [scale, prefix] of SI_PREFIXES) {
+    if (abs >= scale * 0.9999) {
+      bestScale = scale;
+      bestPrefix = prefix;
+    }
+  }
+  const scaled = value / bestScale;
+  const formatted = parseFloat(scaled.toPrecision(4)).toString();
+  return `${formatted}${bestPrefix}`;
+}
+
+export function formatTime(seconds: number): string { return `${formatSI(seconds)}s`; }
+export function formatFrequency(hz: number): string { return `${formatSI(hz)}Hz`; }
+export function formatVoltage(volts: number): string { return `${formatSI(volts)}V`; }
+export function formatCurrent(amps: number): string { return `${formatSI(amps)}A`; }
+
+export function formatDB(db: number): string {
+  const rounded = Math.round(db * 10) / 10;
+  return `${rounded === Math.floor(rounded) ? rounded.toString() : rounded.toString()}dB`;
+}
+
+export function formatPhase(degrees: number): string {
+  const rounded = Math.round(degrees * 10) / 10;
+  return `${rounded === Math.floor(rounded) ? rounded.toString() : rounded.toString()}°`;
+}

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -11,3 +11,4 @@ export { normalizeTransientData, normalizeACData } from './data.js';
 export { GrowableBuffer } from './buffer.js';
 export { TransientRenderer, type TransientRendererOptions } from './renderer.js';
 export { BodeRenderer, type BodeRendererOptions } from './bode-renderer.js';
+export { InteractionHandler, type InteractionCallbacks } from './interaction.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -12,4 +12,4 @@ export { GrowableBuffer } from './buffer.js';
 export { TransientRenderer, type TransientRendererOptions } from './renderer.js';
 export { BodeRenderer, type BodeRendererOptions } from './bode-renderer.js';
 export { InteractionHandler, type InteractionCallbacks } from './interaction.js';
-export { StreamingController } from './streaming.js';
+export { StreamingController, ACStreamingController } from './streaming.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -8,3 +8,4 @@ export { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, fo
 export { createLinearScale, createLogScale, computeYExtent, bisectData } from './scales.js';
 export type { LinearScale, LogScale } from './scales.js';
 export { normalizeTransientData, normalizeACData } from './data.js';
+export { GrowableBuffer } from './buffer.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -10,3 +10,4 @@ export type { LinearScale, LogScale } from './scales.js';
 export { normalizeTransientData, normalizeACData } from './data.js';
 export { GrowableBuffer } from './buffer.js';
 export { TransientRenderer, type TransientRendererOptions } from './renderer.js';
+export { BodeRenderer, type BodeRendererOptions } from './bode-renderer.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -1,6 +1,7 @@
 export type {
   ThemeConfig, CursorState, CursorValue, SignalConfig,
   TransientDataset, ACDataset, Margins, RendererEvents,
+  StreamingTransientStep, StreamingACPoint,
 } from './types.js';
 export { DEFAULT_PALETTE } from './types.js';
 export { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -5,3 +5,5 @@ export type {
 export { DEFAULT_PALETTE } from './types.js';
 export { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';
 export { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, formatDB, formatPhase } from './format.js';
+export { createLinearScale, createLogScale, computeYExtent, bisectData } from './scales.js';
+export type { LinearScale, LogScale } from './scales.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -4,3 +4,4 @@ export type {
 } from './types.js';
 export { DEFAULT_PALETTE } from './types.js';
 export { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';
+export { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, formatDB, formatPhase } from './format.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -12,3 +12,4 @@ export { GrowableBuffer } from './buffer.js';
 export { TransientRenderer, type TransientRendererOptions } from './renderer.js';
 export { BodeRenderer, type BodeRendererOptions } from './bode-renderer.js';
 export { InteractionHandler, type InteractionCallbacks } from './interaction.js';
+export { StreamingController } from './streaming.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -7,3 +7,4 @@ export { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';
 export { formatSI, formatTime, formatFrequency, formatVoltage, formatCurrent, formatDB, formatPhase } from './format.js';
 export { createLinearScale, createLogScale, computeYExtent, bisectData } from './scales.js';
 export type { LinearScale, LogScale } from './scales.js';
+export { normalizeTransientData, normalizeACData } from './data.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -9,3 +9,4 @@ export { createLinearScale, createLogScale, computeYExtent, bisectData } from '.
 export type { LinearScale, LogScale } from './scales.js';
 export { normalizeTransientData, normalizeACData } from './data.js';
 export { GrowableBuffer } from './buffer.js';
+export { TransientRenderer, type TransientRendererOptions } from './renderer.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -1,2 +1,6 @@
-// Core exports — populated as modules are built
-export {};
+export type {
+  ThemeConfig, CursorState, CursorValue, SignalConfig,
+  TransientDataset, ACDataset, Margins, RendererEvents,
+} from './types.js';
+export { DEFAULT_PALETTE } from './types.js';
+export { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';

--- a/packages/ui/src/core/index.ts
+++ b/packages/ui/src/core/index.ts
@@ -1,0 +1,2 @@
+// Core exports — populated as modules are built
+export {};

--- a/packages/ui/src/core/interaction.test.ts
+++ b/packages/ui/src/core/interaction.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InteractionHandler } from './interaction.js';
+
+function createTestCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = 800;
+  canvas.height = 400;
+  canvas.getBoundingClientRect = () => ({
+    x: 0, y: 0, width: 800, height: 400, top: 0, left: 0, right: 800, bottom: 400, toJSON() {},
+  });
+  return canvas;
+}
+
+describe('InteractionHandler', () => {
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    canvas = createTestCanvas();
+  });
+
+  it('fires onCursorMove on pointermove', () => {
+    const onCursor = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: onCursor,
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 200, clientY: 150 }));
+    expect(onCursor).toHaveBeenCalledWith(200);
+
+    handler.destroy();
+  });
+
+  it('fires onCursorMove(null) on pointerleave', () => {
+    const onCursor = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: onCursor,
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointerleave'));
+    expect(onCursor).toHaveBeenCalledWith(null);
+
+    handler.destroy();
+  });
+
+  it('fires onZoom on wheel event', () => {
+    const onZoom = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom,
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, clientX: 400 }));
+    expect(onZoom).toHaveBeenCalledWith(400, expect.any(Number), false);
+
+    handler.destroy();
+  });
+
+  it('fires onZoom with shiftKey for vertical zoom', () => {
+    const onZoom = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom,
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, clientX: 400, shiftKey: true }));
+    expect(onZoom).toHaveBeenCalledWith(400, expect.any(Number), true);
+
+    handler.destroy();
+  });
+
+  it('fires onPan during drag', () => {
+    const onPan = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan,
+      onDoubleClick: vi.fn(),
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 300, clientY: 200 }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 310, clientY: 205, buttons: 1 }));
+    expect(onPan).toHaveBeenCalledWith(10, 5);
+
+    handler.destroy();
+  });
+
+  it('fires onDoubleClick on dblclick', () => {
+    const onDoubleClick = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick,
+    });
+
+    canvas.dispatchEvent(new MouseEvent('dblclick'));
+    expect(onDoubleClick).toHaveBeenCalled();
+
+    handler.destroy();
+  });
+
+  it('destroy removes event listeners', () => {
+    const onCursor = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: onCursor,
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    handler.destroy();
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 100 }));
+    expect(onCursor).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/core/interaction.test.ts
+++ b/packages/ui/src/core/interaction.test.ts
@@ -139,4 +139,128 @@ describe('InteractionHandler', () => {
 
     vi.useRealTimers();
   });
+
+  it('horizontal scroll (deltaX > deltaY) dispatches onPan', () => {
+    const onPan = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan,
+      onDoubleClick: vi.fn(),
+    });
+
+    // Horizontal swipe: deltaX=50, deltaY=5 → pan, not zoom
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 50, deltaY: 5 }));
+    expect(onPan).toHaveBeenCalledWith(-50, 0);
+
+    handler.destroy();
+    vi.useRealTimers();
+  });
+
+  it('vertical scroll accumulates zoom, not pan', async () => {
+    const onPan = vi.fn();
+    const onZoom = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom,
+      onPan,
+      onDoubleClick: vi.fn(),
+    });
+
+    // Vertical scroll: deltaY >> deltaX → zoom path
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 2, deltaY: 100 }));
+    // onPan should NOT be called immediately for vertical scroll
+    expect(onPan).not.toHaveBeenCalled();
+    // Zoom will be dispatched via rAF
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onZoom).toHaveBeenCalled();
+
+    handler.destroy();
+    vi.useRealTimers();
+  });
+
+  it('pointerleave during drag launches momentum', async () => {
+    const onPan = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan,
+      onDoubleClick: vi.fn(),
+    });
+
+    // Start drag with some velocity
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 300, clientY: 200 }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 340, clientY: 200, buttons: 1 }));
+    onPan.mockClear();
+
+    // Leave canvas during drag — should stop dragging and emit cursor null
+    canvas.dispatchEvent(new PointerEvent('pointerleave'));
+    // After a rAF tick, momentum panning may fire
+    await vi.advanceTimersByTimeAsync(50);
+
+    handler.destroy();
+    vi.useRealTimers();
+  });
+
+  it('pointerup without prior pointerdown does not throw', () => {
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    // pointerup when not dragging should be a no-op
+    canvas.dispatchEvent(new PointerEvent('pointerup', { clientX: 300, clientY: 200 }));
+
+    handler.destroy();
+    vi.useRealTimers();
+  });
+
+  it('animation loop stops when destroyed mid-flight', async () => {
+    const onZoom = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom,
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    // Start zoom animation
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -200, clientX: 400 }));
+    // Destroy immediately — animate callback should bail out
+    handler.destroy();
+    await vi.advanceTimersByTimeAsync(100);
+    // Any calls to onZoom before destroy happened, but no new ones after
+    const callsBefore = onZoom.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(onZoom.mock.calls.length).toBe(callsBefore);
+
+    vi.useRealTimers();
+  });
+
+  it('zoom in produces factor > 1, zoom out produces factor < 1', async () => {
+    const onZoom = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom,
+      onPan: vi.fn(),
+      onDoubleClick: vi.fn(),
+    });
+
+    // Negative deltaY → zoom in
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onZoom.mock.calls.some((c) => c[1] > 1)).toBe(true);
+
+    onZoom.mockClear();
+
+    // Positive deltaY → zoom out
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onZoom.mock.calls.some((c) => c[1] < 1)).toBe(true);
+
+    handler.destroy();
+    vi.useRealTimers();
+  });
 });

--- a/packages/ui/src/core/interaction.test.ts
+++ b/packages/ui/src/core/interaction.test.ts
@@ -16,6 +16,7 @@ describe('InteractionHandler', () => {
 
   beforeEach(() => {
     canvas = createTestCanvas();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   it('fires onCursorMove on pointermove', () => {
@@ -31,6 +32,7 @@ describe('InteractionHandler', () => {
     expect(onCursor).toHaveBeenCalledWith(200);
 
     handler.destroy();
+    vi.useRealTimers();
   });
 
   it('fires onCursorMove(null) on pointerleave', () => {
@@ -46,9 +48,10 @@ describe('InteractionHandler', () => {
     expect(onCursor).toHaveBeenCalledWith(null);
 
     handler.destroy();
+    vi.useRealTimers();
   });
 
-  it('fires onZoom on wheel event', () => {
+  it('accumulates zoom on wheel and fires via animation', async () => {
     const onZoom = vi.fn();
     const handler = new InteractionHandler(canvas, {
       onCursorMove: vi.fn(),
@@ -58,27 +61,16 @@ describe('InteractionHandler', () => {
     });
 
     canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, clientX: 400 }));
-    expect(onZoom).toHaveBeenCalledWith(400, expect.any(Number), false);
+    // Zoom is applied via rAF animation, not synchronously
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onZoom).toHaveBeenCalled();
+    expect(onZoom.mock.calls[0][1]).toBeGreaterThan(1); // zoom in
 
     handler.destroy();
+    vi.useRealTimers();
   });
 
-  it('fires onZoom with shiftKey for vertical zoom', () => {
-    const onZoom = vi.fn();
-    const handler = new InteractionHandler(canvas, {
-      onCursorMove: vi.fn(),
-      onZoom,
-      onPan: vi.fn(),
-      onDoubleClick: vi.fn(),
-    });
-
-    canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, clientX: 400, shiftKey: true }));
-    expect(onZoom).toHaveBeenCalledWith(400, expect.any(Number), true);
-
-    handler.destroy();
-  });
-
-  it('fires onPan during drag', () => {
+  it('fires onPan during drag (horizontal only)', () => {
     const onPan = vi.fn();
     const handler = new InteractionHandler(canvas, {
       onCursorMove: vi.fn(),
@@ -89,9 +81,10 @@ describe('InteractionHandler', () => {
 
     canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 300, clientY: 200 }));
     canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 310, clientY: 205, buttons: 1 }));
-    expect(onPan).toHaveBeenCalledWith(10, 5);
+    expect(onPan).toHaveBeenCalledWith(10, 0);
 
     handler.destroy();
+    vi.useRealTimers();
   });
 
   it('fires onDoubleClick on dblclick', () => {
@@ -107,9 +100,31 @@ describe('InteractionHandler', () => {
     expect(onDoubleClick).toHaveBeenCalled();
 
     handler.destroy();
+    vi.useRealTimers();
   });
 
-  it('destroy removes event listeners', () => {
+  it('launches momentum on pointer up if drag had velocity', () => {
+    const onPan = vi.fn();
+    const handler = new InteractionHandler(canvas, {
+      onCursorMove: vi.fn(),
+      onZoom: vi.fn(),
+      onPan,
+      onDoubleClick: vi.fn(),
+    });
+
+    // Simulate drag — the handler tracks velocity internally
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 300, clientY: 200 }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 330, clientY: 200, buttons: 1 }));
+    // Direct pan is called during drag
+    expect(onPan).toHaveBeenCalledWith(30, 0);
+
+    canvas.dispatchEvent(new PointerEvent('pointerup', { clientX: 330, clientY: 200 }));
+    // Momentum animation is started (via rAF) — we just verify drag worked
+    handler.destroy();
+    vi.useRealTimers();
+  });
+
+  it('destroy removes event listeners and stops animation', () => {
     const onCursor = vi.fn();
     const handler = new InteractionHandler(canvas, {
       onCursorMove: onCursor,
@@ -121,5 +136,7 @@ describe('InteractionHandler', () => {
     handler.destroy();
     canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 100 }));
     expect(onCursor).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 });

--- a/packages/ui/src/core/interaction.ts
+++ b/packages/ui/src/core/interaction.ts
@@ -1,0 +1,104 @@
+export interface InteractionCallbacks {
+  /** Called with pixel X on hover, or null on leave. */
+  onCursorMove: (pixelX: number | null) => void;
+  /** Called on scroll-wheel zoom. factor >1 = zoom in. shiftKey = vertical zoom. */
+  onZoom: (pixelX: number, factor: number, shiftKey: boolean) => void;
+  /** Called during drag with pixel deltas. */
+  onPan: (dx: number, dy: number) => void;
+  /** Called on double-click (fit to data). */
+  onDoubleClick: () => void;
+}
+
+/**
+ * Attaches pointer/wheel event listeners to a canvas for zoom, pan, and cursor interaction.
+ * Framework-agnostic — works with any HTMLCanvasElement.
+ */
+export class InteractionHandler {
+  private canvas: HTMLCanvasElement;
+  private callbacks: InteractionCallbacks;
+  private dragging = false;
+  private lastX = 0;
+  private lastY = 0;
+  private destroyed = false;
+
+  private boundPointerMove: (e: PointerEvent) => void;
+  private boundPointerDown: (e: PointerEvent) => void;
+  private boundPointerUp: (e: PointerEvent) => void;
+  private boundPointerLeave: (e: PointerEvent) => void;
+  private boundWheel: (e: WheelEvent) => void;
+  private boundDblClick: (e: MouseEvent) => void;
+
+  constructor(canvas: HTMLCanvasElement, callbacks: InteractionCallbacks) {
+    this.canvas = canvas;
+    this.callbacks = callbacks;
+
+    this.boundPointerMove = this.handlePointerMove.bind(this);
+    this.boundPointerDown = this.handlePointerDown.bind(this);
+    this.boundPointerUp = this.handlePointerUp.bind(this);
+    this.boundPointerLeave = this.handlePointerLeave.bind(this);
+    this.boundWheel = this.handleWheel.bind(this);
+    this.boundDblClick = this.handleDblClick.bind(this);
+
+    canvas.addEventListener('pointermove', this.boundPointerMove);
+    canvas.addEventListener('pointerdown', this.boundPointerDown);
+    canvas.addEventListener('pointerup', this.boundPointerUp);
+    canvas.addEventListener('pointerleave', this.boundPointerLeave);
+    canvas.addEventListener('wheel', this.boundWheel, { passive: false });
+    canvas.addEventListener('dblclick', this.boundDblClick);
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.canvas.removeEventListener('pointermove', this.boundPointerMove);
+    this.canvas.removeEventListener('pointerdown', this.boundPointerDown);
+    this.canvas.removeEventListener('pointerup', this.boundPointerUp);
+    this.canvas.removeEventListener('pointerleave', this.boundPointerLeave);
+    this.canvas.removeEventListener('wheel', this.boundWheel);
+    this.canvas.removeEventListener('dblclick', this.boundDblClick);
+  }
+
+  private handlePointerMove(e: PointerEvent): void {
+    if (this.destroyed) return;
+
+    if (this.dragging && (e.buttons & 1)) {
+      const dx = e.clientX - this.lastX;
+      const dy = e.clientY - this.lastY;
+      this.lastX = e.clientX;
+      this.lastY = e.clientY;
+      this.callbacks.onPan(dx, dy);
+    } else {
+      this.callbacks.onCursorMove(e.clientX);
+    }
+  }
+
+  private handlePointerDown(e: PointerEvent): void {
+    if (this.destroyed) return;
+    this.dragging = true;
+    this.lastX = e.clientX;
+    this.lastY = e.clientY;
+    this.canvas.setPointerCapture?.(e.pointerId);
+  }
+
+  private handlePointerUp(e: PointerEvent): void {
+    this.dragging = false;
+    this.canvas.releasePointerCapture?.(e.pointerId);
+  }
+
+  private handlePointerLeave(_e: PointerEvent): void {
+    if (this.destroyed) return;
+    this.dragging = false;
+    this.callbacks.onCursorMove(null);
+  }
+
+  private handleWheel(e: WheelEvent): void {
+    if (this.destroyed) return;
+    e.preventDefault();
+    const zoomFactor = e.deltaY < 0 ? 1.2 : 1 / 1.2;
+    this.callbacks.onZoom(e.clientX, zoomFactor, e.shiftKey);
+  }
+
+  private handleDblClick(_e: MouseEvent): void {
+    if (this.destroyed) return;
+    this.callbacks.onDoubleClick();
+  }
+}

--- a/packages/ui/src/core/interaction.ts
+++ b/packages/ui/src/core/interaction.ts
@@ -9,7 +9,7 @@ export interface InteractionCallbacks {
   onDoubleClick: () => void;
 }
 
-const ZOOM_FRICTION = 0.75;
+const ZOOM_FRICTION = 0.4;
 const ZOOM_STOP_THRESHOLD = 0.0005;
 const PAN_FRICTION = 0.92;
 const PAN_STOP_THRESHOLD = 0.3;

--- a/packages/ui/src/core/interaction.ts
+++ b/packages/ui/src/core/interaction.ts
@@ -98,6 +98,14 @@ export class InteractionHandler {
   private handleWheel(e: WheelEvent): void {
     if (this.destroyed) return;
     e.preventDefault();
+
+    // Horizontal scroll (trackpad swipe or shift+scroll) → pan horizontally
+    if (e.deltaX !== 0) {
+      this.callbacks.onPan(-e.deltaX, 0);
+      return;
+    }
+
+    // Vertical scroll → zoom horizontal axis
     const zoomFactor = e.deltaY < 0 ? 1.05 : 1 / 1.05;
     this.callbacks.onZoom(this.toCanvasX(e.clientX), zoomFactor, e.shiftKey);
   }

--- a/packages/ui/src/core/interaction.ts
+++ b/packages/ui/src/core/interaction.ts
@@ -9,9 +9,14 @@ export interface InteractionCallbacks {
   onDoubleClick: () => void;
 }
 
+const ZOOM_FRICTION = 0.75;
+const ZOOM_STOP_THRESHOLD = 0.0005;
+const PAN_FRICTION = 0.92;
+const PAN_STOP_THRESHOLD = 0.3;
+
 /**
  * Attaches pointer/wheel event listeners to a canvas for zoom, pan, and cursor interaction.
- * Framework-agnostic — works with any HTMLCanvasElement.
+ * Includes smooth zoom animation and momentum panning for a premium feel.
  */
 export class InteractionHandler {
   private canvas: HTMLCanvasElement;
@@ -19,7 +24,17 @@ export class InteractionHandler {
   private dragging = false;
   private lastX = 0;
   private lastY = 0;
+  private lastDragTime = 0;
   private destroyed = false;
+
+  // Animation state
+  private animFrameId = 0;
+  private zoomAccumulator = 0;  // accumulated zoom input (log-space)
+  private panMomentumX = 0;     // momentum velocity in px/frame
+  private animating = false;
+
+  // Drag velocity tracking (exponential moving average)
+  private dragVelocityX = 0;
 
   private boundPointerMove: (e: PointerEvent) => void;
   private boundPointerDown: (e: PointerEvent) => void;
@@ -49,6 +64,7 @@ export class InteractionHandler {
 
   destroy(): void {
     this.destroyed = true;
+    cancelAnimationFrame(this.animFrameId);
     this.canvas.removeEventListener('pointermove', this.boundPointerMove);
     this.canvas.removeEventListener('pointerdown', this.boundPointerDown);
     this.canvas.removeEventListener('pointerup', this.boundPointerUp);
@@ -62,15 +78,68 @@ export class InteractionHandler {
     return clientX - rect.left;
   }
 
+  // --- Animation loop ---
+
+  private startAnimation(): void {
+    if (this.animating) return;
+    this.animating = true;
+    this.animFrameId = requestAnimationFrame(this.animate);
+  }
+
+  private animate = (): void => {
+    if (this.destroyed) { this.animating = false; return; }
+
+    let needsMore = false;
+
+    // Smooth zoom: apply a fraction of the accumulated zoom each frame
+    if (Math.abs(this.zoomAccumulator) > ZOOM_STOP_THRESHOLD) {
+      const factor = Math.exp(this.zoomAccumulator * (1 - ZOOM_FRICTION));
+      this.callbacks.onZoom(0, factor, false);
+      this.zoomAccumulator *= ZOOM_FRICTION;
+      needsMore = true;
+    } else {
+      this.zoomAccumulator = 0;
+    }
+
+    // Momentum pan: apply decaying velocity
+    if (Math.abs(this.panMomentumX) > PAN_STOP_THRESHOLD) {
+      this.callbacks.onPan(this.panMomentumX, 0);
+      this.panMomentumX *= PAN_FRICTION;
+      needsMore = true;
+    } else {
+      this.panMomentumX = 0;
+    }
+
+    if (needsMore) {
+      this.animFrameId = requestAnimationFrame(this.animate);
+    } else {
+      this.animating = false;
+    }
+  };
+
+  // --- Event handlers ---
+
   private handlePointerMove(e: PointerEvent): void {
     if (this.destroyed) return;
 
     if (this.dragging && (e.buttons & 1)) {
       const dx = e.clientX - this.lastX;
-      const dy = e.clientY - this.lastY;
+      const now = performance.now();
+      const dt = now - this.lastDragTime;
+
+      // Track velocity with exponential moving average
+      if (dt > 0 && dt < 100) {
+        const instantVelocity = dx / dt * 16; // normalize to ~per-frame at 60fps
+        this.dragVelocityX = this.dragVelocityX * 0.5 + instantVelocity * 0.5;
+      }
+
       this.lastX = e.clientX;
       this.lastY = e.clientY;
-      this.callbacks.onPan(dx, dy);
+      this.lastDragTime = now;
+
+      // Stop any ongoing momentum and apply pan directly
+      this.panMomentumX = 0;
+      this.callbacks.onPan(dx, 0);
     } else {
       this.callbacks.onCursorMove(this.toCanvasX(e.clientX));
     }
@@ -81,17 +150,36 @@ export class InteractionHandler {
     this.dragging = true;
     this.lastX = e.clientX;
     this.lastY = e.clientY;
+    this.lastDragTime = performance.now();
+    this.dragVelocityX = 0;
+    this.panMomentumX = 0; // stop any coasting
     this.canvas.setPointerCapture?.(e.pointerId);
   }
 
   private handlePointerUp(e: PointerEvent): void {
+    if (!this.dragging) return;
     this.dragging = false;
     this.canvas.releasePointerCapture?.(e.pointerId);
+
+    // Launch momentum with the tracked drag velocity
+    if (Math.abs(this.dragVelocityX) > PAN_STOP_THRESHOLD) {
+      this.panMomentumX = this.dragVelocityX;
+      this.startAnimation();
+    }
+    this.dragVelocityX = 0;
   }
 
   private handlePointerLeave(_e: PointerEvent): void {
     if (this.destroyed) return;
-    this.dragging = false;
+    if (this.dragging) {
+      // Don't stop momentum — let it coast
+      this.dragging = false;
+      if (Math.abs(this.dragVelocityX) > PAN_STOP_THRESHOLD) {
+        this.panMomentumX = this.dragVelocityX;
+        this.startAnimation();
+      }
+      this.dragVelocityX = 0;
+    }
     this.callbacks.onCursorMove(null);
   }
 
@@ -99,15 +187,15 @@ export class InteractionHandler {
     if (this.destroyed) return;
     e.preventDefault();
 
-    // Horizontal scroll (trackpad swipe or shift+scroll) → pan horizontally
-    if (e.deltaX !== 0) {
+    // Horizontal scroll (trackpad swipe) → pan horizontally
+    if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
       this.callbacks.onPan(-e.deltaX, 0);
       return;
     }
 
-    // Vertical scroll → zoom horizontal axis
-    const zoomFactor = e.deltaY < 0 ? 1.05 : 1 / 1.05;
-    this.callbacks.onZoom(this.toCanvasX(e.clientX), zoomFactor, e.shiftKey);
+    // Vertical scroll → accumulate zoom (applied smoothly in animation loop)
+    this.zoomAccumulator += e.deltaY * -0.003;
+    this.startAnimation();
   }
 
   private handleDblClick(_e: MouseEvent): void {

--- a/packages/ui/src/core/interaction.ts
+++ b/packages/ui/src/core/interaction.ts
@@ -98,7 +98,7 @@ export class InteractionHandler {
   private handleWheel(e: WheelEvent): void {
     if (this.destroyed) return;
     e.preventDefault();
-    const zoomFactor = e.deltaY < 0 ? 1.2 : 1 / 1.2;
+    const zoomFactor = e.deltaY < 0 ? 1.05 : 1 / 1.05;
     this.callbacks.onZoom(this.toCanvasX(e.clientX), zoomFactor, e.shiftKey);
   }
 

--- a/packages/ui/src/core/interaction.ts
+++ b/packages/ui/src/core/interaction.ts
@@ -57,6 +57,11 @@ export class InteractionHandler {
     this.canvas.removeEventListener('dblclick', this.boundDblClick);
   }
 
+  private toCanvasX(clientX: number): number {
+    const rect = this.canvas.getBoundingClientRect();
+    return clientX - rect.left;
+  }
+
   private handlePointerMove(e: PointerEvent): void {
     if (this.destroyed) return;
 
@@ -67,7 +72,7 @@ export class InteractionHandler {
       this.lastY = e.clientY;
       this.callbacks.onPan(dx, dy);
     } else {
-      this.callbacks.onCursorMove(e.clientX);
+      this.callbacks.onCursorMove(this.toCanvasX(e.clientX));
     }
   }
 
@@ -94,7 +99,7 @@ export class InteractionHandler {
     if (this.destroyed) return;
     e.preventDefault();
     const zoomFactor = e.deltaY < 0 ? 1.2 : 1 / 1.2;
-    this.callbacks.onZoom(e.clientX, zoomFactor, e.shiftKey);
+    this.callbacks.onZoom(this.toCanvasX(e.clientX), zoomFactor, e.shiftKey);
   }
 
   private handleDblClick(_e: MouseEvent): void {

--- a/packages/ui/src/core/renderer.test.ts
+++ b/packages/ui/src/core/renderer.test.ts
@@ -99,4 +99,153 @@ describe('TransientRenderer', () => {
     // Calling render after destroy should not throw
     renderer.render();
   });
+
+  it('render with cursor state draws cursor', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    // Set cursor inside plot area (left margin=56, canvas width=800)
+    renderer.setCursorPixelX(300);
+    renderer.render(); // should not throw with cursor active
+    renderer.destroy();
+  });
+
+  it('zoomAt updates xDomain and sets userHasZoomed', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+
+    // zoom in by 2x — domain should shrink
+    renderer.zoomAt(400, 2);
+    renderer.render();
+
+    // After zooming, setData should not reset zoom (userHasZoomed=true)
+    renderer.setData(createTestData(), ['out']);
+    renderer.render();
+
+    renderer.destroy();
+  });
+
+  it('pan updates domain', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    renderer.pan(50, 0);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('pan with dy updates y domain', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    renderer.pan(0, 20);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setFixedXDomain pins x-axis and persists through setData', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setFixedXDomain([0, 10e-3]);
+    renderer.setData(createTestData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setFixedXDomain(null) clears fixed domain', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setFixedXDomain([0, 10e-3]);
+    renderer.setFixedXDomain(null);
+    renderer.setData(createTestData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('fitToData after zoom resets userHasZoomed so next setData recalculates domain', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    renderer.zoomAt(400, 3);
+    renderer.fitToData();
+    // After fitToData, setting new data should recalculate domains
+    renderer.setData(createTestData(), ['out']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('zoomY updates y domain', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    renderer.zoomY(2);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('decimation path: render with more points than 2x plot width', () => {
+    // Canvas is 800 wide, margin left=56, right=16 → plotWidth=728, maxPoints≈1456
+    // Create dataset with >> 1456 points to trigger decimation
+    const n = 3000;
+    const time = Array.from({ length: n }, (_, i) => i * 1e-6);
+    const values = Array.from({ length: n }, (_, i) => Math.sin(i * 0.01));
+    const signals = new Map([['out', values]]);
+    const dataset = [{ time, signals, label: '' }];
+
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(dataset, ['out']);
+    renderer.render(); // should exercise the decimation branch
+    renderer.destroy();
+  });
+
+  it('setCursorPixelX outside plot area clears cursor', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    // left margin=56, so pixel < 56 is outside plot
+    renderer.setCursorPixelX(10);
+    expect(callback).toHaveBeenCalledWith(null);
+
+    renderer.destroy();
+  });
+
+  it('off() removes listener', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+    renderer.off('cursorMove', callback);
+
+    renderer.setCursorPixelX(300);
+    expect(callback).not.toHaveBeenCalled();
+    renderer.destroy();
+  });
+
+  it('setSignalColor changes color for signal', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    renderer.setSignalColor('out', '#ff0000');
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('getSignalStates returns signal state array', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out', 'in']);
+    const states = renderer.getSignalStates();
+    expect(states).toHaveLength(2);
+    expect(states[0].name).toBe('out');
+    renderer.destroy();
+  });
+
+  it('render with empty datasets does not throw', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setTheme updates theme', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    renderer.setTheme({ ...DARK_THEME, background: '#000' });
+    renderer.render();
+    renderer.destroy();
+  });
 });

--- a/packages/ui/src/core/renderer.test.ts
+++ b/packages/ui/src/core/renderer.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TransientRenderer } from './renderer.js';
+import { DARK_THEME } from './theme.js';
+import type { TransientDataset } from './types.js';
+
+function createTestCanvas(width = 800, height = 400): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  // getBoundingClientRect is not available in jsdom
+  canvas.getBoundingClientRect = () => ({
+    x: 0, y: 0, width, height, top: 0, left: 0, right: width, bottom: height, toJSON() {},
+  });
+  return canvas;
+}
+
+function createTestData(): TransientDataset[] {
+  const time = [0, 1e-3, 2e-3, 3e-3, 4e-3, 5e-3];
+  const signals = new Map<string, number[]>();
+  signals.set('out', [0, 1, 2, 3, 4, 5]);
+  signals.set('in', [5, 5, 5, 5, 5, 5]);
+  return [{ time, signals, label: '' }];
+}
+
+describe('TransientRenderer', () => {
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    canvas = createTestCanvas();
+  });
+
+  it('constructs without error', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    expect(renderer).toBeDefined();
+    renderer.destroy();
+  });
+
+  it('setData and render without error', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out', 'in']);
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('emits cursorMove events', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    // Simulate a cursor update at pixel position
+    renderer.setCursorPixelX(200);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x: expect.any(Number),
+        pixelX: 200,
+        values: expect.any(Array),
+      }),
+    );
+
+    renderer.destroy();
+  });
+
+  it('setCursorPixelX(null) clears cursor', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+
+    const callback = vi.fn();
+    renderer.on('cursorMove', callback);
+
+    renderer.setCursorPixelX(null);
+    expect(callback).toHaveBeenCalledWith(null);
+
+    renderer.destroy();
+  });
+
+  it('fitToData resets zoom to show all data', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out']);
+    // zoom in
+    renderer.zoomAt(400, 2);
+    renderer.fitToData();
+    renderer.render();
+    renderer.destroy();
+  });
+
+  it('setSignalVisibility hides/shows signals', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.setData(createTestData(), ['out', 'in']);
+    renderer.setSignalVisibility('out', false);
+    renderer.render(); // should not throw even with hidden signal
+    renderer.destroy();
+  });
+
+  it('destroy cleans up', () => {
+    const renderer = new TransientRenderer(canvas, { theme: DARK_THEME });
+    renderer.destroy();
+    // Calling render after destroy should not throw
+    renderer.render();
+  });
+});

--- a/packages/ui/src/core/renderer.ts
+++ b/packages/ui/src/core/renderer.ts
@@ -49,6 +49,7 @@ export class TransientRenderer {
   private yScale: LinearScale = createLinearScale([0, 1], [0, 1]);
   private xDomain: [number, number] = [0, 1];
   private yDomain: [number, number] = [0, 1];
+  private fixedXDomain: [number, number] | null = null;
   private cursorState: CursorState | null = null;
   private destroyed = false;
 
@@ -89,6 +90,15 @@ export class TransientRenderer {
 
     this.computeDefaultDomains();
     this.updateScales();
+  }
+
+  /** Pin the x-axis to a fixed range (e.g. [0, stopTime] during streaming). */
+  setFixedXDomain(domain: [number, number] | null): void {
+    this.fixedXDomain = domain;
+    if (domain) {
+      this.xDomain = domain;
+      this.updateScales();
+    }
   }
 
   /** Update theme. */
@@ -263,17 +273,22 @@ export class TransientRenderer {
 
   private computeDefaultDomains(): void {
     if (this.datasets.length === 0) return;
-    // X domain: min/max time across all datasets
-    let xMin = Infinity;
-    let xMax = -Infinity;
-    for (const ds of this.datasets) {
-      if (ds.time.length > 0) {
-        xMin = Math.min(xMin, ds.time[0]);
-        xMax = Math.max(xMax, ds.time[ds.time.length - 1]);
+
+    // X domain: use fixed domain if set, otherwise compute from data
+    if (this.fixedXDomain) {
+      this.xDomain = this.fixedXDomain;
+    } else {
+      let xMin = Infinity;
+      let xMax = -Infinity;
+      for (const ds of this.datasets) {
+        if (ds.time.length > 0) {
+          xMin = Math.min(xMin, ds.time[0]);
+          xMax = Math.max(xMax, ds.time[ds.time.length - 1]);
+        }
       }
-    }
-    if (isFinite(xMin) && isFinite(xMax)) {
-      this.xDomain = [xMin, xMax];
+      if (isFinite(xMin) && isFinite(xMax)) {
+        this.xDomain = [xMin, xMax];
+      }
     }
 
     // Y domain: extent of all visible signals

--- a/packages/ui/src/core/renderer.ts
+++ b/packages/ui/src/core/renderer.ts
@@ -123,6 +123,15 @@ export class TransientRenderer {
       return;
     }
 
+    // Clamp cursor to the plot area
+    const plotLeft = this.margin.left;
+    const plotRight = this.margin.left + this.getPlotWidth();
+    if (pixelX < plotLeft || pixelX > plotRight) {
+      this.cursorState = null;
+      this.emit('cursorMove', null);
+      return;
+    }
+
     const dataX = this.xScale.invert(pixelX - this.margin.left);
     const values: CursorValue[] = [];
 

--- a/packages/ui/src/core/renderer.ts
+++ b/packages/ui/src/core/renderer.ts
@@ -1,0 +1,408 @@
+import { createLinearScale, computeYExtent, bisectData, type LinearScale } from './scales.js';
+import { formatTime, formatVoltage } from './format.js';
+import type { ThemeConfig, TransientDataset, CursorState, CursorValue, Margins, RendererEvents } from './types.js';
+import { DEFAULT_PALETTE } from './types.js';
+
+export interface TransientRendererOptions {
+  theme: ThemeConfig;
+  margin?: Partial<Margins>;
+}
+
+interface SignalState {
+  name: string;
+  color: string;
+  visible: boolean;
+  datasetIndex: number;
+}
+
+export class TransientRenderer {
+  private canvas: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D | null;
+  private theme: ThemeConfig;
+  private margin: Margins;
+  private dpr: number;
+
+  private datasets: TransientDataset[] = [];
+  private signalStates: SignalState[] = [];
+  private xScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private yScale: LinearScale = createLinearScale([0, 1], [0, 1]);
+  private xDomain: [number, number] = [0, 1];
+  private yDomain: [number, number] = [0, 1];
+  private cursorState: CursorState | null = null;
+  private destroyed = false;
+
+  private listeners: Partial<{ [K in keyof RendererEvents]: RendererEvents[K][] }> = {};
+
+  constructor(canvas: HTMLCanvasElement, options: TransientRendererOptions) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.theme = options.theme;
+    this.dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
+    this.margin = {
+      top: options.margin?.top ?? 10,
+      right: options.margin?.right ?? 16,
+      bottom: options.margin?.bottom ?? 32,
+      left: options.margin?.left ?? 56,
+    };
+  }
+
+  /** Set or replace the data displayed. */
+  setData(datasets: TransientDataset[], signals: string[]): void {
+    this.datasets = datasets;
+    this.signalStates = [];
+
+    let colorIdx = 0;
+    for (let di = 0; di < datasets.length; di++) {
+      for (const name of signals) {
+        if (datasets[di].signals.has(name)) {
+          this.signalStates.push({
+            name,
+            color: DEFAULT_PALETTE[colorIdx % DEFAULT_PALETTE.length],
+            visible: true,
+            datasetIndex: di,
+          });
+          colorIdx++;
+        }
+      }
+    }
+
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  /** Update theme. */
+  setTheme(theme: ThemeConfig): void {
+    this.theme = theme;
+  }
+
+  /** Override color for a signal. */
+  setSignalColor(name: string, color: string): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.color = color;
+    }
+  }
+
+  /** Toggle signal visibility. */
+  setSignalVisibility(name: string, visible: boolean): void {
+    for (const s of this.signalStates) {
+      if (s.name === name) s.visible = visible;
+    }
+  }
+
+  /** Get current signal states (for legend rendering). */
+  getSignalStates(): ReadonlyArray<Readonly<SignalState>> {
+    return this.signalStates;
+  }
+
+  /** Set cursor at a pixel x position, or null to clear. */
+  setCursorPixelX(pixelX: number | null): void {
+    if (pixelX === null) {
+      this.cursorState = null;
+      this.emit('cursorMove', null);
+      return;
+    }
+
+    const dataX = this.xScale.invert(pixelX - this.margin.left);
+    const values: CursorValue[] = [];
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const idx = bisectData(ds.time as number[], dataX);
+      const signalArr = ds.signals.get(s.name);
+      if (!signalArr) continue;
+
+      const label = ds.label ? `${ds.label}: ${s.name}` : s.name;
+      values.push({
+        signalId: ds.label ? `${ds.label}:${s.name}` : s.name,
+        label,
+        value: signalArr[idx],
+        unit: 'V',
+        color: s.color,
+      });
+    }
+
+    this.cursorState = { x: dataX, pixelX, values };
+    this.emit('cursorMove', this.cursorState);
+  }
+
+  /** Zoom at a pixel x position by a factor (>1 zooms in, <1 zooms out). */
+  zoomAt(pixelX: number, factor: number): void {
+    const centerX = this.xScale.invert(pixelX - this.margin.left);
+    const [x0, x1] = this.xDomain;
+    const halfSpan = (x1 - x0) / 2 / factor;
+    this.xDomain = [centerX - halfSpan, centerX + halfSpan];
+    this.updateScales();
+  }
+
+  /** Zoom Y axis by factor. */
+  zoomY(factor: number): void {
+    const [y0, y1] = this.yDomain;
+    const center = (y0 + y1) / 2;
+    const halfSpan = (y1 - y0) / 2 / factor;
+    this.yDomain = [center - halfSpan, center + halfSpan];
+    this.updateScales();
+  }
+
+  /** Pan by pixel deltas. */
+  pan(dx: number, dy: number): void {
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+    const [x0, x1] = this.xDomain;
+    const [y0, y1] = this.yDomain;
+    const xShift = (dx / plotWidth) * (x1 - x0);
+    const yShift = (dy / plotHeight) * (y1 - y0);
+    this.xDomain = [x0 - xShift, x1 - xShift];
+    this.yDomain = [y0 + yShift, y1 + yShift];
+    this.updateScales();
+  }
+
+  /** Reset zoom to show all data. */
+  fitToData(): void {
+    this.computeDefaultDomains();
+    this.updateScales();
+  }
+
+  /** Register an event listener. */
+  on<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    (this.listeners[event] as RendererEvents[K][]).push(callback);
+  }
+
+  /** Remove an event listener. */
+  off<K extends keyof RendererEvents>(event: K, callback: RendererEvents[K]): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    const idx = (arr as RendererEvents[K][]).indexOf(callback);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
+  /** Render the full plot to the canvas. */
+  render(): void {
+    if (this.destroyed || !this.ctx) return;
+    const ctx = this.ctx;
+    const width = this.canvas.width / this.dpr;
+    const height = this.canvas.height / this.dpr;
+
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    ctx.save();
+    ctx.scale(this.dpr, this.dpr);
+
+    // Background
+    ctx.fillStyle = this.theme.background;
+    ctx.fillRect(this.margin.left, this.margin.top, this.getPlotWidth(), this.getPlotHeight());
+
+    this.drawGrid(ctx, width, height);
+    this.drawWaveforms(ctx);
+    this.drawXAxis(ctx, height);
+    this.drawYAxis(ctx);
+    if (this.cursorState) {
+      this.drawCursor(ctx);
+    }
+
+    ctx.restore();
+  }
+
+  /** Clean up resources. */
+  destroy(): void {
+    this.destroyed = true;
+    this.listeners = {};
+  }
+
+  // --- Private helpers ---
+
+  private emit<K extends keyof RendererEvents>(event: K, ...args: Parameters<RendererEvents[K]>): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    for (const cb of arr) {
+      (cb as (...a: unknown[]) => void)(...args);
+    }
+  }
+
+  private getPlotWidth(): number {
+    return this.canvas.width / this.dpr - this.margin.left - this.margin.right;
+  }
+
+  private getPlotHeight(): number {
+    return this.canvas.height / this.dpr - this.margin.top - this.margin.bottom;
+  }
+
+  private computeDefaultDomains(): void {
+    if (this.datasets.length === 0) return;
+    // X domain: min/max time across all datasets
+    let xMin = Infinity;
+    let xMax = -Infinity;
+    for (const ds of this.datasets) {
+      if (ds.time.length > 0) {
+        xMin = Math.min(xMin, ds.time[0]);
+        xMax = Math.max(xMax, ds.time[ds.time.length - 1]);
+      }
+    }
+    if (isFinite(xMin) && isFinite(xMax)) {
+      this.xDomain = [xMin, xMax];
+    }
+
+    // Y domain: extent of all visible signals
+    const arrays: number[][] = [];
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const arr = this.datasets[s.datasetIndex].signals.get(s.name);
+      if (arr) arrays.push(arr);
+    }
+    if (arrays.length > 0) {
+      this.yDomain = computeYExtent(arrays);
+    }
+  }
+
+  private updateScales(): void {
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+    this.xScale = createLinearScale(this.xDomain, [0, plotWidth]);
+    this.yScale = createLinearScale(this.yDomain, [plotHeight, 0]); // inverted: y=0 at bottom
+  }
+
+  private drawGrid(ctx: CanvasRenderingContext2D, _width: number, _height: number): void {
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+    const { left, top } = this.margin;
+
+    ctx.strokeStyle = this.theme.grid;
+    ctx.lineWidth = 0.5;
+
+    // Vertical grid lines
+    const xTicks = this.xScale.ticks(6);
+    for (const tick of xTicks) {
+      const x = left + this.xScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(x, top);
+      ctx.lineTo(x, top + plotHeight);
+      ctx.stroke();
+    }
+
+    // Horizontal grid lines
+    const yTicks = this.yScale.ticks(5);
+    for (const tick of yTicks) {
+      const y = top + this.yScale(tick);
+      ctx.beginPath();
+      ctx.moveTo(left, y);
+      ctx.lineTo(left + plotWidth, y);
+      ctx.stroke();
+    }
+  }
+
+  private drawWaveforms(ctx: CanvasRenderingContext2D): void {
+    const { left, top } = this.margin;
+    const plotWidth = this.getPlotWidth();
+    const plotHeight = this.getPlotHeight();
+
+    // Clip to plot area
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(left, top, plotWidth, plotHeight);
+    ctx.clip();
+
+    for (const s of this.signalStates) {
+      if (!s.visible) continue;
+      const ds = this.datasets[s.datasetIndex];
+      const yArr = ds.signals.get(s.name);
+      if (!yArr) continue;
+
+      ctx.strokeStyle = s.color;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+
+      let started = false;
+      for (let i = 0; i < ds.time.length; i++) {
+        const x = left + this.xScale(ds.time[i]);
+        const y = top + this.yScale(yArr[i]);
+        if (!started) {
+          ctx.moveTo(x, y);
+          started = true;
+        } else {
+          ctx.lineTo(x, y);
+        }
+      }
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  private drawXAxis(ctx: CanvasRenderingContext2D, height: number): void {
+    const { left } = this.margin;
+    const plotHeight = this.getPlotHeight();
+    const y = this.margin.top + plotHeight;
+
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `${this.theme.fontSize}px ${this.theme.font}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+
+    const ticks = this.xScale.ticks(6);
+    for (const tick of ticks) {
+      const x = left + this.xScale(tick);
+      ctx.fillText(formatTime(tick), x, y + 6);
+    }
+  }
+
+  private drawYAxis(ctx: CanvasRenderingContext2D): void {
+    const { left, top } = this.margin;
+
+    ctx.fillStyle = this.theme.textMuted;
+    ctx.font = `${this.theme.fontSize}px ${this.theme.font}`;
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+
+    const ticks = this.yScale.ticks(5);
+    for (const tick of ticks) {
+      const y = top + this.yScale(tick);
+      ctx.fillText(formatVoltage(tick), left - 6, y);
+    }
+  }
+
+  private drawCursor(ctx: CanvasRenderingContext2D): void {
+    if (!this.cursorState) return;
+    const { left, top } = this.margin;
+    const plotHeight = this.getPlotHeight();
+    const x = this.cursorState.pixelX;
+
+    // Dashed vertical line
+    ctx.strokeStyle = this.theme.cursor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(x, top);
+    ctx.lineTo(x, top + plotHeight);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Dots at intersection with each visible signal
+    for (const v of this.cursorState.values) {
+      const dataX = this.cursorState.x;
+      // Find the y value for this signal
+      for (const s of this.signalStates) {
+        const matchId = this.datasets[s.datasetIndex].label
+          ? `${this.datasets[s.datasetIndex].label}:${s.name}`
+          : s.name;
+        if (matchId !== v.signalId || !s.visible) continue;
+
+        const ds = this.datasets[s.datasetIndex];
+        const idx = bisectData(ds.time as number[], dataX);
+        const yArr = ds.signals.get(s.name);
+        if (!yArr) continue;
+
+        const py = top + this.yScale(yArr[idx]);
+        ctx.fillStyle = v.color;
+        ctx.strokeStyle = this.theme.background;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(x, py, 4, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+        break;
+      }
+    }
+  }
+}

--- a/packages/ui/src/core/renderer.ts
+++ b/packages/ui/src/core/renderer.ts
@@ -179,12 +179,12 @@ export class TransientRenderer {
   }
 
   /** Zoom at a pixel x position by a factor (>1 zooms in, <1 zooms out). */
-  zoomAt(pixelX: number, factor: number): void {
+  zoomAt(_pixelX: number, factor: number): void {
     this.userHasZoomed = true;
-    const centerX = this.xScale.invert(pixelX - this.margin.left);
     const [x0, x1] = this.xDomain;
+    const center = (x0 + x1) / 2;
     const halfSpan = (x1 - x0) / 2 / factor;
-    this.xDomain = [centerX - halfSpan, centerX + halfSpan];
+    this.xDomain = [center - halfSpan, center + halfSpan];
     this.updateScales();
   }
 

--- a/packages/ui/src/core/renderer.ts
+++ b/packages/ui/src/core/renderer.ts
@@ -350,25 +350,54 @@ export class TransientRenderer {
     ctx.rect(left, top, plotWidth, plotHeight);
     ctx.clip();
 
+    // Max points to draw — roughly 2 per CSS pixel for visual fidelity
+    const maxPoints = Math.ceil(plotWidth * 2);
+
     for (const s of this.signalStates) {
       if (!s.visible) continue;
       const ds = this.datasets[s.datasetIndex];
       const yArr = ds.signals.get(s.name);
-      if (!yArr) continue;
+      if (!yArr || ds.time.length === 0) continue;
 
       ctx.strokeStyle = s.color;
       ctx.lineWidth = 1.5;
       ctx.beginPath();
 
-      let started = false;
-      for (let i = 0; i < ds.time.length; i++) {
-        const x = left + this.xScale(ds.time[i]);
-        const y = top + this.yScale(yArr[i]);
-        if (!started) {
-          ctx.moveTo(x, y);
-          started = true;
-        } else {
-          ctx.lineTo(x, y);
+      const n = ds.time.length;
+      if (n <= maxPoints) {
+        // Few enough points — draw them all
+        ctx.moveTo(left + this.xScale(ds.time[0]), top + this.yScale(yArr[0]));
+        for (let i = 1; i < n; i++) {
+          ctx.lineTo(left + this.xScale(ds.time[i]), top + this.yScale(yArr[i]));
+        }
+      } else {
+        // Min/max decimation: split data into buckets, draw min and max per bucket.
+        // This preserves peaks/spikes that stride-based sampling would miss.
+        const bucketSize = n / maxPoints;
+        ctx.moveTo(left + this.xScale(ds.time[0]), top + this.yScale(yArr[0]));
+
+        for (let b = 0; b < maxPoints; b++) {
+          const start = Math.floor(b * bucketSize);
+          const end = Math.min(Math.floor((b + 1) * bucketSize), n);
+          if (start >= end) continue;
+
+          let minVal = yArr[start];
+          let maxVal = yArr[start];
+          let minIdx = start;
+          let maxIdx = start;
+          for (let i = start + 1; i < end; i++) {
+            if (yArr[i] < minVal) { minVal = yArr[i]; minIdx = i; }
+            if (yArr[i] > maxVal) { maxVal = yArr[i]; maxIdx = i; }
+          }
+
+          // Draw min and max in time order to maintain waveform continuity
+          if (minIdx <= maxIdx) {
+            ctx.lineTo(left + this.xScale(ds.time[minIdx]), top + this.yScale(minVal));
+            ctx.lineTo(left + this.xScale(ds.time[maxIdx]), top + this.yScale(maxVal));
+          } else {
+            ctx.lineTo(left + this.xScale(ds.time[maxIdx]), top + this.yScale(maxVal));
+            ctx.lineTo(left + this.xScale(ds.time[minIdx]), top + this.yScale(minVal));
+          }
         }
       }
       ctx.stroke();

--- a/packages/ui/src/core/renderer.ts
+++ b/packages/ui/src/core/renderer.ts
@@ -50,6 +50,8 @@ export class TransientRenderer {
   private xDomain: [number, number] = [0, 1];
   private yDomain: [number, number] = [0, 1];
   private fixedXDomain: [number, number] | null = null;
+  private userHasZoomed = false;
+  private hasData = false;
   private cursorState: CursorState | null = null;
   private destroyed = false;
 
@@ -88,8 +90,16 @@ export class TransientRenderer {
       }
     }
 
-    this.computeDefaultDomains();
-    this.updateScales();
+    // Only auto-set domains on first data load or if user hasn't manually zoomed.
+    // During streaming, we don't want to reset the user's zoom on every data update.
+    if (!this.hasData || !this.userHasZoomed) {
+      this.computeDefaultDomains();
+      this.updateScales();
+    } else {
+      // Just update scales (domain unchanged, but plot dimensions may have changed)
+      this.updateScales();
+    }
+    this.hasData = true;
   }
 
   /** Pin the x-axis to a fixed range (e.g. [0, stopTime] during streaming). */
@@ -170,6 +180,7 @@ export class TransientRenderer {
 
   /** Zoom at a pixel x position by a factor (>1 zooms in, <1 zooms out). */
   zoomAt(pixelX: number, factor: number): void {
+    this.userHasZoomed = true;
     const centerX = this.xScale.invert(pixelX - this.margin.left);
     const [x0, x1] = this.xDomain;
     const halfSpan = (x1 - x0) / 2 / factor;
@@ -188,6 +199,7 @@ export class TransientRenderer {
 
   /** Pan by pixel deltas. */
   pan(dx: number, dy: number): void {
+    this.userHasZoomed = true;
     const plotWidth = this.getPlotWidth();
     const plotHeight = this.getPlotHeight();
     const [x0, x1] = this.xDomain;
@@ -201,6 +213,7 @@ export class TransientRenderer {
 
   /** Reset zoom to show all data. */
   fitToData(): void {
+    this.userHasZoomed = false;
     this.computeDefaultDomains();
     this.updateScales();
   }

--- a/packages/ui/src/core/renderer.ts
+++ b/packages/ui/src/core/renderer.ts
@@ -3,6 +3,27 @@ import { formatTime, formatVoltage } from './format.js';
 import type { ThemeConfig, TransientDataset, CursorState, CursorValue, Margins, RendererEvents } from './types.js';
 import { DEFAULT_PALETTE } from './types.js';
 
+/** Linearly interpolate y at a given x between data points. */
+function interpolateAt(xArr: number[], yArr: number[], x: number): number {
+  if (xArr.length === 0) return 0;
+  if (x <= xArr[0]) return yArr[0];
+  if (x >= xArr[xArr.length - 1]) return yArr[yArr.length - 1];
+
+  // Binary search for the interval containing x
+  let lo = 0;
+  let hi = xArr.length - 1;
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1;
+    if (xArr[mid] <= x) lo = mid;
+    else hi = mid;
+  }
+
+  const x0 = xArr[lo];
+  const x1 = xArr[hi];
+  const t = (x - x0) / (x1 - x0);
+  return yArr[lo] + t * (yArr[hi] - yArr[lo]);
+}
+
 export interface TransientRendererOptions {
   theme: ThemeConfig;
   margin?: Partial<Margins>;
@@ -108,15 +129,17 @@ export class TransientRenderer {
     for (const s of this.signalStates) {
       if (!s.visible) continue;
       const ds = this.datasets[s.datasetIndex];
-      const idx = bisectData(ds.time as number[], dataX);
       const signalArr = ds.signals.get(s.name);
-      if (!signalArr) continue;
+      if (!signalArr || ds.time.length === 0) continue;
+
+      // Interpolate value at exact cursor X position
+      const interpValue = interpolateAt(ds.time, signalArr, dataX);
 
       const label = ds.label ? `${ds.label}: ${s.name}` : s.name;
       values.push({
         signalId: ds.label ? `${ds.label}:${s.name}` : s.name,
         label,
-        value: signalArr[idx],
+        value: interpValue,
         unit: 'V',
         color: s.color,
       });
@@ -378,31 +401,16 @@ export class TransientRenderer {
     ctx.stroke();
     ctx.setLineDash([]);
 
-    // Dots at intersection with each visible signal
+    // Dots at intersection with each visible signal (on the waveform line)
     for (const v of this.cursorState.values) {
-      const dataX = this.cursorState.x;
-      // Find the y value for this signal
-      for (const s of this.signalStates) {
-        const matchId = this.datasets[s.datasetIndex].label
-          ? `${this.datasets[s.datasetIndex].label}:${s.name}`
-          : s.name;
-        if (matchId !== v.signalId || !s.visible) continue;
-
-        const ds = this.datasets[s.datasetIndex];
-        const idx = bisectData(ds.time as number[], dataX);
-        const yArr = ds.signals.get(s.name);
-        if (!yArr) continue;
-
-        const py = top + this.yScale(yArr[idx]);
-        ctx.fillStyle = v.color;
-        ctx.strokeStyle = this.theme.background;
-        ctx.lineWidth = 1.5;
-        ctx.beginPath();
-        ctx.arc(x, py, 4, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-        break;
-      }
+      const py = top + this.yScale(v.value);
+      ctx.fillStyle = v.color;
+      ctx.strokeStyle = this.theme.background;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(x, py, 4, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
     }
   }
 }

--- a/packages/ui/src/core/scales.test.ts
+++ b/packages/ui/src/core/scales.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { createLinearScale, createLogScale, computeYExtent, bisectData } from './scales.js';
+
+describe('createLinearScale', () => {
+  it('maps domain to range', () => {
+    const scale = createLinearScale([0, 10], [0, 500]);
+    expect(scale(0)).toBe(0);
+    expect(scale(10)).toBe(500);
+    expect(scale(5)).toBe(250);
+  });
+
+  it('handles inverted range (for y-axis)', () => {
+    const scale = createLinearScale([0, 5], [300, 0]);
+    expect(scale(0)).toBe(300);
+    expect(scale(5)).toBe(0);
+    expect(scale(2.5)).toBe(150);
+  });
+});
+
+describe('createLogScale', () => {
+  it('maps domain to range on log scale', () => {
+    const scale = createLogScale([1, 1e6], [0, 600]);
+    expect(scale(1)).toBeCloseTo(0, 0);
+    expect(scale(1e6)).toBeCloseTo(600, 0);
+    expect(scale(1e3)).toBeCloseTo(300, 0);
+  });
+});
+
+describe('computeYExtent', () => {
+  it('computes min/max with 10% padding', () => {
+    const [min, max] = computeYExtent([[0, 1, 2, 3, 4, 5]]);
+    expect(min).toBeCloseTo(-0.5, 2);
+    expect(max).toBeCloseTo(5.5, 2);
+  });
+
+  it('handles multiple signal arrays', () => {
+    const [min, max] = computeYExtent([[0, 1, 2], [-1, 0, 3]]);
+    expect(min).toBeLessThan(-1);
+    expect(max).toBeGreaterThan(3);
+  });
+
+  it('handles constant signal (adds ±1 padding)', () => {
+    const [min, max] = computeYExtent([[5, 5, 5]]);
+    expect(min).toBe(4);
+    expect(max).toBe(6);
+  });
+});
+
+describe('bisectData', () => {
+  it('finds the nearest index for a given x value', () => {
+    const xValues = [0, 1, 2, 3, 4, 5];
+    expect(bisectData(xValues, 2.3)).toBe(2);
+    expect(bisectData(xValues, 2.7)).toBe(3);
+    expect(bisectData(xValues, 0)).toBe(0);
+    expect(bisectData(xValues, 5)).toBe(5);
+  });
+
+  it('clamps to array bounds', () => {
+    const xValues = [1, 2, 3];
+    expect(bisectData(xValues, -10)).toBe(0);
+    expect(bisectData(xValues, 100)).toBe(2);
+  });
+});

--- a/packages/ui/src/core/scales.ts
+++ b/packages/ui/src/core/scales.ts
@@ -1,0 +1,36 @@
+import { scaleLinear, scaleLog, type ScaleLinear, type ScaleLogarithmic } from 'd3-scale';
+import { bisector } from 'd3-array';
+
+export type LinearScale = ScaleLinear<number, number>;
+export type LogScale = ScaleLogarithmic<number, number>;
+
+export function createLinearScale(domain: [number, number], range: [number, number]): LinearScale {
+  return scaleLinear().domain(domain).range(range);
+}
+
+export function createLogScale(domain: [number, number], range: [number, number]): LogScale {
+  return scaleLog().base(10).domain(domain).range(range);
+}
+
+export function computeYExtent(signalArrays: number[][]): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const arr of signalArrays) {
+    for (const v of arr) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!isFinite(min) || !isFinite(max)) return [-1, 1];
+  if (min === max) return [min - 1, max + 1];
+  const padding = (max - min) * 0.1;
+  return [min - padding, max + padding];
+}
+
+const xBisector = bisector<number, number>((d) => d).center;
+
+export function bisectData(sortedX: number[], target: number): number {
+  if (sortedX.length === 0) return 0;
+  const idx = xBisector(sortedX, target);
+  return Math.max(0, Math.min(idx, sortedX.length - 1));
+}

--- a/packages/ui/src/core/streaming.test.ts
+++ b/packages/ui/src/core/streaming.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { StreamingController } from './streaming.js';
 
 // Helper: create an async generator that yields TransientStep-like objects
-async function* mockStream(steps: { time: number; voltages: Map<string, number> }[]) {
+async function* mockStream(steps: { time: number; voltages: Map<string, number>; currents: Map<string, number> }[]) {
   for (const step of steps) {
     yield step;
   }

--- a/packages/ui/src/core/streaming.test.ts
+++ b/packages/ui/src/core/streaming.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
-import { StreamingController } from './streaming.js';
+import { StreamingController, ACStreamingController } from './streaming.js';
 
 // Helper: create an async generator that yields TransientStep-like objects
 async function* mockStream(steps: { time: number; voltages: Map<string, number>; currents: Map<string, number> }[]) {
+  for (const step of steps) {
+    yield step;
+  }
+}
+
+async function* mockACStream(steps: { frequency: number; voltages: Map<string, { magnitude: number; phase: number }>; currents: Map<string, { magnitude: number; phase: number }> }[]) {
   for (const step of steps) {
     yield step;
   }
@@ -64,5 +70,205 @@ describe('StreamingController', () => {
 
     controller.clear();
     expect(controller.getDataset().time.length).toBe(0);
+  });
+
+  it('isRunning() reflects consumption state', async () => {
+    const controller = new StreamingController(['out'], vi.fn());
+    expect(controller.isRunning()).toBe(false);
+
+    const steps = [{ time: 0, voltages: new Map([['out', 1]]), currents: new Map() }];
+    const promise = controller.consume(mockStream(steps));
+    await promise;
+    expect(controller.isRunning()).toBe(false);
+  });
+
+  it('falls back to currents when voltage signal is missing', async () => {
+    const onData = vi.fn();
+    const controller = new StreamingController(['I(R1)'], onData);
+    const steps = [
+      {
+        time: 0,
+        voltages: new Map<string, number>(),
+        currents: new Map([['I(R1)', 0.01]]),
+      },
+    ];
+    await controller.consume(mockStream(steps));
+    const dataset = controller.getDataset();
+    expect(dataset.signals.get('I(R1)')![0]).toBe(0.01);
+  });
+
+  it('uses 0 when signal is in neither voltages nor currents', async () => {
+    const controller = new StreamingController(['missing'], vi.fn());
+    const steps = [
+      { time: 0, voltages: new Map<string, number>(), currents: new Map<string, number>() },
+    ];
+    await controller.consume(mockStream(steps));
+    const dataset = controller.getDataset();
+    expect(dataset.signals.get('missing')![0]).toBe(0);
+  });
+});
+
+describe('ACStreamingController', () => {
+  it('collects AC streaming data into an ACDataset', async () => {
+    const onData = vi.fn();
+    const controller = new ACStreamingController(['out'], onData);
+
+    const steps = [
+      {
+        frequency: 100,
+        voltages: new Map([['out', { magnitude: 1.0, phase: 0 }]]),
+        currents: new Map(),
+      },
+      {
+        frequency: 1000,
+        voltages: new Map([['out', { magnitude: 0.707, phase: -45 }]]),
+        currents: new Map(),
+      },
+      {
+        frequency: 10000,
+        voltages: new Map([['out', { magnitude: 0.1, phase: -84 }]]),
+        currents: new Map(),
+      },
+    ];
+
+    await controller.consume(mockACStream(steps));
+
+    expect(onData).toHaveBeenCalled();
+
+    const dataset = controller.getDataset();
+    expect(dataset.frequencies).toHaveLength(3);
+    expect(dataset.frequencies[0]).toBe(100);
+    expect(dataset.magnitudes.get('out')).toHaveLength(3);
+    expect(dataset.phases.get('out')).toHaveLength(3);
+  });
+
+  it('converts magnitude to dB via 20*log10', async () => {
+    const controller = new ACStreamingController(['out'], vi.fn());
+
+    // magnitude=1 → 0 dB, magnitude=10 → 20 dB
+    const steps = [
+      {
+        frequency: 100,
+        voltages: new Map([['out', { magnitude: 1.0, phase: 0 }]]),
+        currents: new Map(),
+      },
+      {
+        frequency: 1000,
+        voltages: new Map([['out', { magnitude: 10.0, phase: 0 }]]),
+        currents: new Map(),
+      },
+    ];
+
+    await controller.consume(mockACStream(steps));
+
+    const dataset = controller.getDataset();
+    const mags = dataset.magnitudes.get('out')!;
+    expect(mags[0]).toBeCloseTo(0, 5);    // 20*log10(1) = 0
+    expect(mags[1]).toBeCloseTo(20, 5);   // 20*log10(10) = 20
+  });
+
+  it('records phase values correctly', async () => {
+    const controller = new ACStreamingController(['out'], vi.fn());
+
+    const steps = [
+      {
+        frequency: 1000,
+        voltages: new Map([['out', { magnitude: 1, phase: -45 }]]),
+        currents: new Map(),
+      },
+    ];
+
+    await controller.consume(mockACStream(steps));
+    const dataset = controller.getDataset();
+    expect(dataset.phases.get('out')![0]).toBe(-45);
+  });
+
+  it('falls back to currents when voltage phasor is missing', async () => {
+    const controller = new ACStreamingController(['I(R1)'], vi.fn());
+
+    const steps = [
+      {
+        frequency: 1000,
+        voltages: new Map<string, { magnitude: number; phase: number }>(),
+        currents: new Map([['I(R1)', { magnitude: 0.01, phase: -10 }]]),
+      },
+    ];
+
+    await controller.consume(mockACStream(steps));
+    const dataset = controller.getDataset();
+    const mags = dataset.magnitudes.get('I(R1)')!;
+    // 20*log10(0.01) = -40
+    expect(mags[0]).toBeCloseTo(-40, 3);
+  });
+
+  it('uses -600 dB when phasor is absent', async () => {
+    const controller = new ACStreamingController(['missing'], vi.fn());
+
+    const steps = [
+      {
+        frequency: 1000,
+        voltages: new Map<string, { magnitude: number; phase: number }>(),
+        currents: new Map<string, { magnitude: number; phase: number }>(),
+      },
+    ];
+
+    await controller.consume(mockACStream(steps));
+    const dataset = controller.getDataset();
+    expect(dataset.magnitudes.get('missing')![0]).toBe(-600);
+    expect(dataset.phases.get('missing')![0]).toBe(0);
+  });
+
+  it('stop() halts AC consumption', async () => {
+    const onData = vi.fn();
+    const controller = new ACStreamingController(['out'], onData);
+
+    async function* infiniteACStream() {
+      let f = 10;
+      while (true) {
+        yield {
+          frequency: f,
+          voltages: new Map([['out', { magnitude: 1, phase: 0 }]]),
+          currents: new Map<string, { magnitude: number; phase: number }>(),
+        };
+        f *= 1.1;
+        await new Promise((r) => setTimeout(r, 0));
+      }
+    }
+
+    const promise = controller.consume(infiniteACStream());
+    await new Promise((r) => setTimeout(r, 10));
+    controller.stop();
+    await promise;
+
+    expect(controller.getDataset().frequencies.length).toBeGreaterThan(0);
+    expect(controller.isRunning()).toBe(false);
+  });
+
+  it('clear() resets all AC buffers', async () => {
+    const controller = new ACStreamingController(['out'], vi.fn());
+    const steps = [
+      {
+        frequency: 100,
+        voltages: new Map([['out', { magnitude: 1, phase: 0 }]]),
+        currents: new Map(),
+      },
+    ];
+
+    await controller.consume(mockACStream(steps));
+    expect(controller.getDataset().frequencies).toHaveLength(1);
+
+    controller.clear();
+    const dataset = controller.getDataset();
+    expect(dataset.frequencies).toHaveLength(0);
+    expect(dataset.magnitudes.get('out')).toHaveLength(0);
+    expect(dataset.phases.get('out')).toHaveLength(0);
+  });
+
+  it('isRunning() is false before and after consume', async () => {
+    const controller = new ACStreamingController(['out'], vi.fn());
+    expect(controller.isRunning()).toBe(false);
+
+    await controller.consume(mockACStream([]));
+    expect(controller.isRunning()).toBe(false);
   });
 });

--- a/packages/ui/src/core/streaming.test.ts
+++ b/packages/ui/src/core/streaming.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { StreamingController } from './streaming.js';
+
+// Helper: create an async generator that yields TransientStep-like objects
+async function* mockStream(steps: { time: number; voltages: Map<string, number> }[]) {
+  for (const step of steps) {
+    yield step;
+  }
+}
+
+describe('StreamingController', () => {
+  it('collects streaming data into datasets', async () => {
+    const onData = vi.fn();
+    const controller = new StreamingController(['out'], onData);
+
+    const steps = [
+      { time: 0, voltages: new Map([['out', 0]]), currents: new Map() },
+      { time: 1e-3, voltages: new Map([['out', 2.5]]), currents: new Map() },
+      { time: 2e-3, voltages: new Map([['out', 5]]), currents: new Map() },
+    ];
+
+    await controller.consume(mockStream(steps));
+
+    // onData should have been called at least once
+    expect(onData).toHaveBeenCalled();
+
+    const dataset = controller.getDataset();
+    expect(dataset.time.length).toBe(3);
+    expect(dataset.signals.get('out')!.length).toBe(3);
+    expect(dataset.signals.get('out')![2]).toBe(5);
+  });
+
+  it('stop() halts consumption', async () => {
+    const onData = vi.fn();
+    const controller = new StreamingController(['out'], onData);
+
+    // Stream that yields a few steps then pauses — allows stop() to be called
+    async function* stoppableStream() {
+      let t = 0;
+      while (true) {
+        yield { time: t, voltages: new Map([['out', t]]), currents: new Map<string, number>() };
+        t += 1e-3;
+        // Yield to the event loop so stop() can be called
+        await new Promise((r) => setTimeout(r, 0));
+      }
+    }
+
+    const promise = controller.consume(stoppableStream());
+    // Stop after a tick
+    await new Promise((r) => setTimeout(r, 10));
+    controller.stop();
+    await promise;
+
+    expect(controller.getDataset().time.length).toBeGreaterThan(0);
+  });
+
+  it('clear() resets buffers', async () => {
+    const controller = new StreamingController(['out'], vi.fn());
+    const steps = [
+      { time: 0, voltages: new Map([['out', 1]]), currents: new Map() },
+    ];
+    await controller.consume(mockStream(steps));
+    expect(controller.getDataset().time.length).toBe(1);
+
+    controller.clear();
+    expect(controller.getDataset().time.length).toBe(0);
+  });
+});

--- a/packages/ui/src/core/streaming.ts
+++ b/packages/ui/src/core/streaming.ts
@@ -30,6 +30,7 @@ export class StreamingController {
   /** Consume an async iterator of streaming steps. Resolves when done or stopped. */
   async consume(stream: AsyncIterable<StreamingStep>): Promise<void> {
     this.running = true;
+    let count = 0;
     for await (const step of stream) {
       if (!this.running) break;
 
@@ -40,6 +41,13 @@ export class StreamingController {
         buf.push(value);
       }
       this.onData();
+
+      // Yield to the event loop every N steps so requestAnimationFrame
+      // can fire and update the display. Without this, the for-await loop
+      // runs entirely in microtasks and never gives the browser a paint frame.
+      if (++count % 200 === 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
     }
     this.running = false;
   }

--- a/packages/ui/src/core/streaming.ts
+++ b/packages/ui/src/core/streaming.ts
@@ -1,0 +1,74 @@
+import { GrowableBuffer } from './buffer.js';
+import type { TransientDataset } from './types.js';
+
+interface StreamingStep {
+  time: number;
+  voltages: Map<string, number>;
+  currents: Map<string, number>;
+}
+
+/**
+ * Consumes an async stream of simulation steps and accumulates data
+ * into growable buffers. Calls onData after each step so the renderer
+ * can schedule a repaint.
+ */
+export class StreamingController {
+  private timeBuffer = new GrowableBuffer();
+  private signalBuffers = new Map<string, GrowableBuffer>();
+  private signals: string[];
+  private onData: () => void;
+  private running = false;
+
+  constructor(signals: string[], onData: () => void) {
+    this.signals = signals;
+    this.onData = onData;
+    for (const name of signals) {
+      this.signalBuffers.set(name, new GrowableBuffer());
+    }
+  }
+
+  /** Consume an async iterator of streaming steps. Resolves when done or stopped. */
+  async consume(stream: AsyncIterable<StreamingStep>): Promise<void> {
+    this.running = true;
+    for await (const step of stream) {
+      if (!this.running) break;
+
+      this.timeBuffer.push(step.time);
+      for (const name of this.signals) {
+        const buf = this.signalBuffers.get(name)!;
+        const value = step.voltages.get(name) ?? step.currents.get(name) ?? 0;
+        buf.push(value);
+      }
+      this.onData();
+    }
+    this.running = false;
+  }
+
+  /** Stop consuming the stream. */
+  stop(): void {
+    this.running = false;
+  }
+
+  /** Whether the stream is actively being consumed. */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /** Get the accumulated data as a TransientDataset. */
+  getDataset(): TransientDataset {
+    const time = Array.from(this.timeBuffer.toArray());
+    const signals = new Map<string, number[]>();
+    for (const [name, buf] of this.signalBuffers) {
+      signals.set(name, Array.from(buf.toArray()));
+    }
+    return { time, signals, label: '' };
+  }
+
+  /** Clear all accumulated data. */
+  clear(): void {
+    this.timeBuffer.clear();
+    for (const buf of this.signalBuffers.values()) {
+      buf.clear();
+    }
+  }
+}

--- a/packages/ui/src/core/streaming.ts
+++ b/packages/ui/src/core/streaming.ts
@@ -1,10 +1,16 @@
 import { GrowableBuffer } from './buffer.js';
-import type { TransientDataset } from './types.js';
+import type { TransientDataset, ACDataset } from './types.js';
 
 interface StreamingStep {
   time: number;
   voltages: Map<string, number>;
   currents: Map<string, number>;
+}
+
+interface ACStreamingStep {
+  frequency: number;
+  voltages: Map<string, { magnitude: number; phase: number }>;
+  currents: Map<string, { magnitude: number; phase: number }>;
 }
 
 /**
@@ -78,5 +84,70 @@ export class StreamingController {
     for (const buf of this.signalBuffers.values()) {
       buf.clear();
     }
+  }
+}
+
+/**
+ * Consumes an async stream of AC analysis points and accumulates
+ * frequency/magnitude/phase data into growable buffers.
+ */
+export class ACStreamingController {
+  private freqBuffer = new GrowableBuffer();
+  private magBuffers = new Map<string, GrowableBuffer>();
+  private phaseBuffers = new Map<string, GrowableBuffer>();
+  private signals: string[];
+  private onData: () => void;
+  private running = false;
+
+  constructor(signals: string[], onData: () => void) {
+    this.signals = signals;
+    this.onData = onData;
+    for (const name of signals) {
+      this.magBuffers.set(name, new GrowableBuffer());
+      this.phaseBuffers.set(name, new GrowableBuffer());
+    }
+  }
+
+  async consume(stream: AsyncIterable<ACStreamingStep>): Promise<void> {
+    this.running = true;
+    let count = 0;
+    for await (const step of stream) {
+      if (!this.running) break;
+
+      this.freqBuffer.push(step.frequency);
+      for (const name of this.signals) {
+        const phasor = step.voltages.get(name) ?? step.currents.get(name);
+        const mag = phasor ? 20 * Math.log10(Math.max(phasor.magnitude, 1e-30)) : -600;
+        const phase = phasor ? phasor.phase : 0;
+        this.magBuffers.get(name)!.push(mag);
+        this.phaseBuffers.get(name)!.push(phase);
+      }
+      this.onData();
+
+      if (++count % 50 === 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+    }
+    this.running = false;
+  }
+
+  stop(): void { this.running = false; }
+  isRunning(): boolean { return this.running; }
+
+  getDataset(): ACDataset {
+    const frequencies = Array.from(this.freqBuffer.toArray());
+    const magnitudes = new Map<string, number[]>();
+    const phases = new Map<string, number[]>();
+    for (const name of this.signals) {
+      magnitudes.set(name, Array.from(this.magBuffers.get(name)!.toArray()));
+      phases.set(name, Array.from(this.phaseBuffers.get(name)!.toArray()));
+    }
+    return { frequencies, magnitudes, phases, label: '' };
+  }
+
+  clear(): void {
+    this.freqBuffer.clear();
+    for (const buf of this.magBuffers.values()) buf.clear();
+    for (const buf of this.phaseBuffers.values()) buf.clear();
   }
 }

--- a/packages/ui/src/core/theme.test.ts
+++ b/packages/ui/src/core/theme.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { DARK_THEME, LIGHT_THEME, mergeTheme, resolveTheme } from './theme.js';
+import type { ThemeConfig } from './types.js';
+
+describe('theme', () => {
+  it('DARK_THEME has all required fields', () => {
+    expect(DARK_THEME.background).toBeDefined();
+    expect(DARK_THEME.surface).toBeDefined();
+    expect(DARK_THEME.border).toBeDefined();
+    expect(DARK_THEME.grid).toBeDefined();
+    expect(DARK_THEME.text).toBeDefined();
+    expect(DARK_THEME.textMuted).toBeDefined();
+    expect(DARK_THEME.cursor).toBeDefined();
+    expect(DARK_THEME.tooltipBg).toBeDefined();
+    expect(DARK_THEME.tooltipBorder).toBeDefined();
+    expect(DARK_THEME.font).toBeDefined();
+    expect(DARK_THEME.fontSize).toBeGreaterThan(0);
+  });
+
+  it('LIGHT_THEME has all required fields', () => {
+    expect(LIGHT_THEME.background).toBeDefined();
+    expect(LIGHT_THEME.text).toBeDefined();
+    expect(LIGHT_THEME.fontSize).toBeGreaterThan(0);
+  });
+
+  it('mergeTheme overrides specific fields', () => {
+    const merged = mergeTheme(DARK_THEME, { fontSize: 16, background: '#000' });
+    expect(merged.fontSize).toBe(16);
+    expect(merged.background).toBe('#000');
+    expect(merged.text).toBe(DARK_THEME.text);
+  });
+
+  it('mergeTheme returns base unchanged when overrides is empty', () => {
+    const merged = mergeTheme(DARK_THEME, {});
+    expect(merged).toEqual(DARK_THEME);
+  });
+
+  it('resolveTheme returns DARK_THEME for "dark"', () => {
+    expect(resolveTheme('dark')).toEqual(DARK_THEME);
+  });
+
+  it('resolveTheme returns LIGHT_THEME for "light"', () => {
+    expect(resolveTheme('light')).toEqual(LIGHT_THEME);
+  });
+
+  it('resolveTheme returns custom ThemeConfig as-is', () => {
+    const custom: ThemeConfig = { ...DARK_THEME, fontSize: 20 };
+    expect(resolveTheme(custom)).toBe(custom);
+  });
+
+  it('resolveTheme defaults to DARK_THEME for undefined', () => {
+    expect(resolveTheme(undefined)).toEqual(DARK_THEME);
+  });
+});

--- a/packages/ui/src/core/theme.ts
+++ b/packages/ui/src/core/theme.ts
@@ -1,0 +1,39 @@
+import type { ThemeConfig } from './types.js';
+
+export const DARK_THEME: ThemeConfig = {
+  background: 'hsl(224, 50%, 6%)',
+  surface: 'hsl(224, 71%, 4%)',
+  border: 'hsl(215, 20%, 17%)',
+  grid: 'hsl(215, 20%, 12%)',
+  text: 'hsl(210, 40%, 98%)',
+  textMuted: 'hsl(215, 20%, 45%)',
+  cursor: 'hsl(215, 20%, 40%)',
+  tooltipBg: 'hsl(224, 40%, 10%)',
+  tooltipBorder: 'hsl(215, 20%, 22%)',
+  font: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+  fontSize: 11,
+};
+
+export const LIGHT_THEME: ThemeConfig = {
+  background: 'hsl(210, 40%, 98%)',
+  surface: 'hsl(0, 0%, 100%)',
+  border: 'hsl(214, 32%, 91%)',
+  grid: 'hsl(214, 32%, 91%)',
+  text: 'hsl(222, 47%, 11%)',
+  textMuted: 'hsl(215, 16%, 47%)',
+  cursor: 'hsl(215, 16%, 47%)',
+  tooltipBg: 'hsl(0, 0%, 100%)',
+  tooltipBorder: 'hsl(214, 32%, 91%)',
+  font: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
+  fontSize: 11,
+};
+
+export function mergeTheme(base: ThemeConfig, overrides: Partial<ThemeConfig>): ThemeConfig {
+  return { ...base, ...overrides };
+}
+
+export function resolveTheme(theme: 'dark' | 'light' | ThemeConfig | undefined): ThemeConfig {
+  if (theme === undefined || theme === 'dark') return DARK_THEME;
+  if (theme === 'light') return LIGHT_THEME;
+  return theme;
+}

--- a/packages/ui/src/core/types.ts
+++ b/packages/ui/src/core/types.ts
@@ -1,0 +1,63 @@
+/** Configuration for visual theme colors and fonts. */
+export interface ThemeConfig {
+  background: string;
+  surface: string;
+  border: string;
+  grid: string;
+  text: string;
+  textMuted: string;
+  cursor: string;
+  tooltipBg: string;
+  tooltipBorder: string;
+  font: string;
+  fontSize: number;
+}
+
+export interface CursorValue {
+  signalId: string;
+  label: string;
+  value: number;
+  unit: string;
+  color: string;
+}
+
+export interface CursorState {
+  x: number;
+  pixelX: number;
+  values: CursorValue[];
+}
+
+export interface SignalConfig {
+  name: string;
+  color?: string;
+  visible?: boolean;
+}
+
+export interface TransientDataset {
+  time: number[];
+  signals: Map<string, number[]>;
+  label: string;
+}
+
+export interface ACDataset {
+  frequencies: number[];
+  magnitudes: Map<string, number[]>;
+  phases: Map<string, number[]>;
+  label: string;
+}
+
+export interface Margins {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+export interface RendererEvents {
+  cursorMove: (state: CursorState | null) => void;
+}
+
+export const DEFAULT_PALETTE = [
+  '#4ade80', '#60a5fa', '#f97316', '#a78bfa',
+  '#f472b6', '#facc15', '#2dd4bf', '#fb923c',
+] as const;

--- a/packages/ui/src/core/types.ts
+++ b/packages/ui/src/core/types.ts
@@ -57,6 +57,20 @@ export interface RendererEvents {
   cursorMove: (state: CursorState | null) => void;
 }
 
+/** A single transient simulation step (duck-type compatible with core's TransientStep). */
+export interface StreamingTransientStep {
+  time: number;
+  voltages: Map<string, number>;
+  currents: Map<string, number>;
+}
+
+/** A single AC simulation point (duck-type compatible with core's ACPoint). */
+export interface StreamingACPoint {
+  frequency: number;
+  voltages: Map<string, { magnitude: number; phase: number }>;
+  currents: Map<string, { magnitude: number; phase: number }>;
+}
+
 export const DEFAULT_PALETTE = [
   '#4ade80', '#60a5fa', '#f97316', '#a78bfa',
   '#f472b6', '#facc15', '#2dd4bf', '#fb923c',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './core/index.js';

--- a/packages/ui/src/react/BodePlot.test.tsx
+++ b/packages/ui/src/react/BodePlot.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
 import { BodePlot } from './BodePlot.js';
 
 function mockACResult() {
@@ -35,5 +35,74 @@ describe('BodePlot', () => {
       <BodePlot data={mockACResult()} signals={['out']} defaultPanes="magnitude" />,
     );
     expect(container.firstChild).toBeDefined();
+  });
+
+  it('renders with phase-only pane', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} defaultPanes="phase" />,
+    );
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('clicking magnitude header toggles magnitude pane', () => {
+    const { getAllByText } = render(
+      <BodePlot data={mockACResult()} signals={['out']} />,
+    );
+    const headers = getAllByText(/Magnitude/i);
+    fireEvent.click(headers[0]);
+    // After click, the pane is collapsed; clicking again should re-expand
+    fireEvent.click(headers[0]);
+  });
+
+  it('clicking phase header toggles phase pane', () => {
+    const { getAllByText } = render(
+      <BodePlot data={mockACResult()} signals={['out']} />,
+    );
+    const headers = getAllByText(/Phase/i);
+    fireEvent.click(headers[0]);
+    fireEvent.click(headers[0]);
+  });
+
+  it('renders with colors prop', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} colors={{ out: '#ff0000' }} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBe(2);
+  });
+
+  it('renders with signalVisibility prop', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} signalVisibility={{ out: false }} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBe(2);
+  });
+
+  it('renders with xDomain prop', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} xDomain={[10, 1e6]} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBe(2);
+  });
+
+  it('calls onCursorMove when provided', () => {
+    const onCursorMove = vi.fn();
+    render(
+      <BodePlot data={mockACResult()} signals={['out']} onCursorMove={onCursorMove} />,
+    );
+    expect(onCursorMove).not.toHaveBeenCalled();
+  });
+
+  it('unmounts cleanly without errors', () => {
+    const { unmount } = render(
+      <BodePlot data={mockACResult()} signals={['out']} />,
+    );
+    unmount();
+  });
+
+  it('renders with numeric height prop', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} height={250} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBe(2);
   });
 });

--- a/packages/ui/src/react/BodePlot.test.tsx
+++ b/packages/ui/src/react/BodePlot.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { BodePlot } from './BodePlot.js';
+
+function mockACResult() {
+  const voltageMap = new Map([
+    ['out', [
+      { magnitude: 1, phase: 0 },
+      { magnitude: 0.707, phase: -45 },
+      { magnitude: 0.1, phase: -84 },
+    ]],
+  ]);
+  return {
+    frequencies: [100, 1000, 10000],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+describe('BodePlot', () => {
+  it('renders two canvas elements (magnitude + phase)', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} />,
+    );
+    const canvases = container.querySelectorAll('canvas');
+    expect(canvases.length).toBe(2);
+  });
+
+  it('renders with magnitude-only pane', () => {
+    const { container } = render(
+      <BodePlot data={mockACResult()} signals={['out']} defaultPanes="magnitude" />,
+    );
+    expect(container.firstChild).toBeDefined();
+  });
+});

--- a/packages/ui/src/react/BodePlot.tsx
+++ b/packages/ui/src/react/BodePlot.tsx
@@ -25,6 +25,8 @@ export interface BodePlotProps {
   onCursorMove?: (cursor: CursorState | null) => void;
   /** Signal visibility state (controlled). */
   signalVisibility?: Record<string, boolean>;
+  /** Fixed x-axis domain [minHz, maxHz]. Useful for streaming. */
+  xDomain?: [number, number];
 }
 
 export function BodePlot({
@@ -37,6 +39,7 @@ export function BodePlot({
   height,
   onCursorMove,
   signalVisibility,
+  xDomain,
 }: BodePlotProps) {
   const rendererRef = useRef<BodeRenderer | null>(null);
   const magInteractionRef = useRef<InteractionHandler | null>(null);
@@ -73,6 +76,10 @@ export function BodePlot({
 
     const datasets = normalizeACData(data, signals);
     renderer.setData(datasets, signals);
+
+    if (xDomain) {
+      renderer.setFixedXDomain(xDomain);
+    }
 
     if (colors) {
       for (const [name, color] of Object.entries(colors)) {
@@ -114,7 +121,7 @@ export function BodePlot({
       magInteractionRef.current?.destroy();
       phaseInteractionRef.current?.destroy();
     };
-  }, [data, signals, resolvedTheme, defaultPanes, colors, onCursorMove]);
+  }, [data, signals, resolvedTheme, defaultPanes, colors, onCursorMove, xDomain]);
 
   // Sync pane visibility
   useEffect(() => {

--- a/packages/ui/src/react/BodePlot.tsx
+++ b/packages/ui/src/react/BodePlot.tsx
@@ -44,12 +44,15 @@ export function BodePlot({
   const rendererRef = useRef<BodeRenderer | null>(null);
   const magInteractionRef = useRef<InteractionHandler | null>(null);
   const phaseInteractionRef = useRef<InteractionHandler | null>(null);
+  const onCursorMoveRef = useRef(onCursorMove);
+  onCursorMoveRef.current = onCursorMove;
   const resolvedTheme = resolveTheme(theme);
   const [magVisible, setMagVisible] = useState(defaultPanes !== 'phase');
   const [phaseVisible, setPhaseVisible] = useState(defaultPanes !== 'magnitude');
 
   const magCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const phaseCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const canvasesReady = useRef(false);
 
   const handleResize = useCallback(() => {
     rendererRef.current?.render();
@@ -58,15 +61,14 @@ export function BodePlot({
   const { refCallback: magRefCallback } = useCanvas(handleResize);
   const { refCallback: phaseRefCallback } = useCanvas(handleResize);
 
-  // Initialize renderer when both canvases are available
+  // Create renderer once when both canvases are mounted.
+  // Does NOT depend on data — data updates go through a separate useEffect.
   useEffect(() => {
     const magCanvas = magCanvasRef.current;
     const phaseCanvas = phaseCanvasRef.current;
     if (!magCanvas || !phaseCanvas) return;
-
-    rendererRef.current?.destroy();
-    magInteractionRef.current?.destroy();
-    phaseInteractionRef.current?.destroy();
+    if (canvasesReady.current) return; // already initialized
+    canvasesReady.current = true;
 
     const renderer = new BodeRenderer(magCanvas, phaseCanvas, {
       theme: resolvedTheme,
@@ -74,22 +76,9 @@ export function BodePlot({
     });
     rendererRef.current = renderer;
 
-    const datasets = normalizeACData(data, signals);
-    renderer.setData(datasets, signals);
-
-    if (xDomain) {
-      renderer.setFixedXDomain(xDomain);
-    }
-
-    if (colors) {
-      for (const [name, color] of Object.entries(colors)) {
-        renderer.setSignalColor(name, color);
-      }
-    }
-
-    if (onCursorMove) {
-      renderer.on('cursorMove', onCursorMove);
-    }
+    renderer.on('cursorMove', (state) => {
+      onCursorMoveRef.current?.(state);
+    });
 
     const createInteraction = (canvas: HTMLCanvasElement) =>
       new InteractionHandler(canvas, {
@@ -114,14 +103,35 @@ export function BodePlot({
     magInteractionRef.current = createInteraction(magCanvas);
     phaseInteractionRef.current = createInteraction(phaseCanvas);
 
-    renderer.render();
-
     return () => {
+      canvasesReady.current = false;
       renderer.destroy();
       magInteractionRef.current?.destroy();
       phaseInteractionRef.current?.destroy();
+      rendererRef.current = null;
     };
-  }, [data, signals, resolvedTheme, defaultPanes, colors, onCursorMove, xDomain]);
+  }, [resolvedTheme, defaultPanes]);
+
+  // Update data on existing renderer without recreating it.
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+
+    const datasets = normalizeACData(data, signals);
+    renderer.setData(datasets, signals);
+
+    if (xDomain) {
+      renderer.setFixedXDomain(xDomain);
+    }
+
+    if (colors) {
+      for (const [name, color] of Object.entries(colors)) {
+        renderer.setSignalColor(name, color);
+      }
+    }
+
+    renderer.render();
+  }, [data, signals, colors, xDomain]);
 
   // Sync pane visibility
   useEffect(() => {

--- a/packages/ui/src/react/BodePlot.tsx
+++ b/packages/ui/src/react/BodePlot.tsx
@@ -97,12 +97,12 @@ export function BodePlot({
           renderer.setCursorPixelX(pixelX);
           renderer.render();
         },
-        onZoom: (pixelX, factor, _shiftKey) => {
-          renderer.zoomAt(pixelX, factor);
+        onZoom: (_pixelX, factor, _shiftKey) => {
+          renderer.zoomAt(_pixelX, factor);
           renderer.render();
         },
-        onPan: (dx, dy) => {
-          renderer.pan(dx, dy);
+        onPan: (dx, _dy) => {
+          renderer.pan(dx, 0);
           renderer.render();
         },
         onDoubleClick: () => {

--- a/packages/ui/src/react/BodePlot.tsx
+++ b/packages/ui/src/react/BodePlot.tsx
@@ -1,0 +1,193 @@
+import { useRef, useEffect, useCallback, useState, type CSSProperties } from 'react';
+import { BodeRenderer } from '../core/bode-renderer.js';
+import { resolveTheme } from '../core/theme.js';
+import { normalizeACData } from '../core/data.js';
+import { InteractionHandler } from '../core/interaction.js';
+import type { ThemeConfig, CursorState } from '../core/types.js';
+import { useCanvas } from './use-renderer.js';
+
+export interface BodePlotProps {
+  /** ACResult from @spice-ts/core, or array of ACDataset for overlay. */
+  data: unknown;
+  /** Signal names to display. */
+  signals: string[];
+  /** Signal color overrides. */
+  colors?: Record<string, string>;
+  /** Theme preset or custom config. */
+  theme?: 'dark' | 'light' | ThemeConfig;
+  /** Which panes to show initially. Default 'both'. */
+  defaultPanes?: 'both' | 'magnitude' | 'phase';
+  /** CSS width. Default '100%'. */
+  width?: number | string;
+  /** CSS height. Default 200 per visible pane. */
+  height?: number | string;
+  /** Cursor move callback. */
+  onCursorMove?: (cursor: CursorState | null) => void;
+  /** Signal visibility state (controlled). */
+  signalVisibility?: Record<string, boolean>;
+}
+
+export function BodePlot({
+  data,
+  signals,
+  colors,
+  theme,
+  defaultPanes = 'both',
+  width = '100%',
+  height,
+  onCursorMove,
+  signalVisibility,
+}: BodePlotProps) {
+  const rendererRef = useRef<BodeRenderer | null>(null);
+  const magInteractionRef = useRef<InteractionHandler | null>(null);
+  const phaseInteractionRef = useRef<InteractionHandler | null>(null);
+  const resolvedTheme = resolveTheme(theme);
+  const [magVisible, setMagVisible] = useState(defaultPanes !== 'phase');
+  const [phaseVisible, setPhaseVisible] = useState(defaultPanes !== 'magnitude');
+
+  const magCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const phaseCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const handleResize = useCallback(() => {
+    rendererRef.current?.render();
+  }, []);
+
+  const { refCallback: magRefCallback } = useCanvas(handleResize);
+  const { refCallback: phaseRefCallback } = useCanvas(handleResize);
+
+  // Initialize renderer when both canvases are available
+  useEffect(() => {
+    const magCanvas = magCanvasRef.current;
+    const phaseCanvas = phaseCanvasRef.current;
+    if (!magCanvas || !phaseCanvas) return;
+
+    rendererRef.current?.destroy();
+    magInteractionRef.current?.destroy();
+    phaseInteractionRef.current?.destroy();
+
+    const renderer = new BodeRenderer(magCanvas, phaseCanvas, {
+      theme: resolvedTheme,
+      defaultPanes,
+    });
+    rendererRef.current = renderer;
+
+    const datasets = normalizeACData(data, signals);
+    renderer.setData(datasets, signals);
+
+    if (colors) {
+      for (const [name, color] of Object.entries(colors)) {
+        renderer.setSignalColor(name, color);
+      }
+    }
+
+    if (onCursorMove) {
+      renderer.on('cursorMove', onCursorMove);
+    }
+
+    const createInteraction = (canvas: HTMLCanvasElement) =>
+      new InteractionHandler(canvas, {
+        onCursorMove: (pixelX) => {
+          renderer.setCursorPixelX(pixelX);
+          renderer.render();
+        },
+        onZoom: (pixelX, factor, _shiftKey) => {
+          renderer.zoomAt(pixelX, factor);
+          renderer.render();
+        },
+        onPan: (dx, dy) => {
+          renderer.pan(dx, dy);
+          renderer.render();
+        },
+        onDoubleClick: () => {
+          renderer.fitToData();
+          renderer.render();
+        },
+      });
+
+    magInteractionRef.current = createInteraction(magCanvas);
+    phaseInteractionRef.current = createInteraction(phaseCanvas);
+
+    renderer.render();
+
+    return () => {
+      renderer.destroy();
+      magInteractionRef.current?.destroy();
+      phaseInteractionRef.current?.destroy();
+    };
+  }, [data, signals, resolvedTheme, defaultPanes, colors, onCursorMove]);
+
+  // Sync pane visibility
+  useEffect(() => {
+    if (!rendererRef.current) return;
+    rendererRef.current.setPaneVisible('magnitude', magVisible);
+    rendererRef.current.setPaneVisible('phase', phaseVisible);
+    rendererRef.current.render();
+  }, [magVisible, phaseVisible]);
+
+  // Sync signal visibility
+  useEffect(() => {
+    if (!rendererRef.current || !signalVisibility) return;
+    for (const [name, visible] of Object.entries(signalVisibility)) {
+      rendererRef.current.setSignalVisibility(name, visible);
+    }
+    rendererRef.current.render();
+  }, [signalVisibility]);
+
+  const paneHeight = height
+    ? typeof height === 'number' ? height : height
+    : 200;
+
+  const containerStyle: CSSProperties = {
+    width: typeof width === 'number' ? `${width}px` : width,
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const paneHeaderStyle: CSSProperties = {
+    padding: '4px 8px',
+    fontSize: `${resolvedTheme.fontSize - 1}px`,
+    fontFamily: resolvedTheme.font,
+    color: resolvedTheme.textMuted,
+    background: resolvedTheme.surface,
+    borderBottom: `1px solid ${resolvedTheme.border}`,
+    cursor: 'pointer',
+    userSelect: 'none',
+  };
+
+  const canvasStyle: CSSProperties = { width: '100%', height: '100%', display: 'block' };
+
+  return (
+    <div style={containerStyle}>
+      <div
+        style={paneHeaderStyle}
+        onClick={() => setMagVisible((v) => !v)}
+      >
+        {magVisible ? '\u25be' : '\u25b8'} Magnitude (dB)
+      </div>
+      <div style={{ height: magVisible ? (typeof paneHeight === 'number' ? `${paneHeight}px` : paneHeight) : 0, overflow: 'hidden' }}>
+        <canvas
+          ref={(el) => {
+            magCanvasRef.current = el;
+            magRefCallback(el);
+          }}
+          style={canvasStyle}
+        />
+      </div>
+      <div
+        style={paneHeaderStyle}
+        onClick={() => setPhaseVisible((v) => !v)}
+      >
+        {phaseVisible ? '\u25be' : '\u25b8'} Phase (\u00b0)
+      </div>
+      <div style={{ height: phaseVisible ? (typeof paneHeight === 'number' ? `${paneHeight}px` : paneHeight) : 0, overflow: 'hidden' }}>
+        <canvas
+          ref={(el) => {
+            phaseCanvasRef.current = el;
+            phaseRefCallback(el);
+          }}
+          style={canvasStyle}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/react/CursorTooltip.test.tsx
+++ b/packages/ui/src/react/CursorTooltip.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { CursorTooltip } from './CursorTooltip.js';
+import { DARK_THEME } from '../core/theme.js';
+import type { CursorState } from '../core/types.js';
+
+function makeCursor(overrides?: Partial<CursorState>): CursorState {
+  return {
+    x: 1e-3,
+    pixelX: 200,
+    values: [
+      { signalId: 'out', label: 'out', value: 2.5, unit: 'V', color: '#4ade80' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('CursorTooltip', () => {
+  it('renders nothing when cursor is null', () => {
+    const { container } = render(
+      <CursorTooltip cursor={null} theme={DARK_THEME} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders tooltip when cursor is provided', () => {
+    const { container } = render(
+      <CursorTooltip cursor={makeCursor()} theme={DARK_THEME} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it('renders signal label and value', () => {
+    const { container } = render(
+      <CursorTooltip cursor={makeCursor()} theme={DARK_THEME} />,
+    );
+    // Should contain the signal label somewhere in the rendered output
+    expect(container.textContent).toContain('out');
+  });
+
+  it('renders multiple signal values', () => {
+    const cursor: CursorState = {
+      x: 2e-3,
+      pixelX: 300,
+      values: [
+        { signalId: 'out', label: 'out', value: 3.3, unit: 'V', color: '#4ade80' },
+        { signalId: 'in', label: 'in', value: 5.0, unit: 'V', color: '#60a5fa' },
+      ],
+    };
+    const { container } = render(
+      <CursorTooltip cursor={cursor} theme={DARK_THEME} />,
+    );
+    // Both signal labels should appear
+    const text = container.textContent ?? '';
+    expect(text).toContain('out');
+    expect(text).toContain('in');
+  });
+
+  it('uses custom formatX when provided', () => {
+    const formatX = (x: number) => `${(x * 1000).toFixed(1)} ms`;
+    const { container } = render(
+      <CursorTooltip cursor={makeCursor({ x: 0.001 })} theme={DARK_THEME} formatX={formatX} />,
+    );
+    expect(container.textContent).toContain('1.0 ms');
+  });
+
+  it('uses default formatSI when formatX is omitted', () => {
+    const { container } = render(
+      <CursorTooltip cursor={makeCursor({ x: 1e-3 })} theme={DARK_THEME} />,
+    );
+    // formatSI(1e-3) → '1.000m' or similar — just verify something rendered
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it('applies inline style override via style prop', () => {
+    const { container } = render(
+      <CursorTooltip
+        cursor={makeCursor()}
+        theme={DARK_THEME}
+        style={{ top: 50 }}
+      />,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div.style.top).toBe('50px');
+  });
+
+  it('positions tooltip at pixelX + 12', () => {
+    const { container } = render(
+      <CursorTooltip cursor={makeCursor({ pixelX: 200 })} theme={DARK_THEME} />,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div.style.left).toBe('212px');
+  });
+});

--- a/packages/ui/src/react/CursorTooltip.tsx
+++ b/packages/ui/src/react/CursorTooltip.tsx
@@ -1,0 +1,62 @@
+import type { CSSProperties } from 'react';
+import type { CursorState, ThemeConfig } from '../core/types.js';
+import { formatSI } from '../core/format.js';
+
+export interface CursorTooltipProps {
+  cursor: CursorState | null;
+  theme: ThemeConfig;
+  /** Format the x-axis value (default: formatSI). */
+  formatX?: (x: number) => string;
+  style?: CSSProperties;
+}
+
+export function CursorTooltip({ cursor, theme, formatX, style }: CursorTooltipProps) {
+  if (!cursor) return null;
+
+  const xLabel = formatX ? formatX(cursor.x) : formatSI(cursor.x);
+
+  const tooltipStyle: CSSProperties = {
+    position: 'absolute',
+    left: cursor.pixelX + 12,
+    top: 8,
+    background: theme.tooltipBg,
+    border: `1px solid ${theme.tooltipBorder}`,
+    borderRadius: '6px',
+    padding: '6px 10px',
+    fontSize: `${theme.fontSize}px`,
+    fontFamily: theme.font,
+    color: theme.text,
+    minWidth: '120px',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+    pointerEvents: 'none',
+    zIndex: 10,
+    ...style,
+  };
+
+  return (
+    <div style={tooltipStyle}>
+      <div style={{ color: theme.textMuted, marginBottom: '4px' }}>
+        {xLabel}
+      </div>
+      {cursor.values.map((v) => (
+        <div
+          key={v.signalId}
+          style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}
+        >
+          <div
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              background: v.color,
+              flexShrink: 0,
+            }}
+          />
+          <span>
+            {v.label} = {formatSI(v.value)}{v.unit}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/react/Legend.test.tsx
+++ b/packages/ui/src/react/Legend.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { Legend } from './Legend.js';
+
+describe('Legend', () => {
+  const signals = [
+    { id: 'out', label: 'V(out)', color: '#4ade80', visible: true },
+    { id: 'in', label: 'V(in)', color: '#60a5fa', visible: true },
+  ];
+
+  it('renders signal labels', () => {
+    const { getByText } = render(
+      <Legend signals={signals} onToggle={() => {}} />,
+    );
+    expect(getByText('V(out)')).toBeDefined();
+    expect(getByText('V(in)')).toBeDefined();
+  });
+
+  it('calls onToggle with signal id when clicked', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <Legend signals={signals} onToggle={onToggle} />,
+    );
+    const item = container.querySelector('[data-signal-id="out"]') as HTMLElement;
+    fireEvent.click(item);
+    expect(onToggle).toHaveBeenCalledWith('out');
+  });
+
+  it('dims hidden signals', () => {
+    const hiddenSignals = [
+      { id: 'out', label: 'V(out)', color: '#4ade80', visible: false },
+      { id: 'in', label: 'V(in)', color: '#60a5fa', visible: true },
+    ];
+    const { container } = render(
+      <Legend signals={hiddenSignals} onToggle={() => {}} />,
+    );
+    const items = container.querySelectorAll('[data-signal-id]');
+    expect(items.length).toBe(2);
+  });
+});

--- a/packages/ui/src/react/Legend.tsx
+++ b/packages/ui/src/react/Legend.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties } from 'react';
+
+export interface LegendSignal {
+  id: string;
+  label: string;
+  color: string;
+  visible: boolean;
+}
+
+export interface LegendProps {
+  signals: LegendSignal[];
+  onToggle: (signalId: string) => void;
+  style?: CSSProperties;
+}
+
+export function Legend({ signals, onToggle, style }: LegendProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '12px',
+        padding: '8px 0',
+        ...style,
+      }}
+    >
+      {signals.map((signal) => (
+        <div
+          key={signal.id}
+          data-signal-id={signal.id}
+          onClick={() => onToggle(signal.id)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            fontSize: '12px',
+            cursor: 'pointer',
+            opacity: signal.visible ? 1 : 0.35,
+            transition: 'opacity 0.15s',
+            userSelect: 'none',
+          }}
+        >
+          <div
+            style={{
+              width: '12px',
+              height: '3px',
+              borderRadius: '1px',
+              background: signal.color,
+            }}
+          />
+          <span>{signal.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/react/TransientPlot.test.tsx
+++ b/packages/ui/src/react/TransientPlot.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { TransientPlot } from './TransientPlot.js';
+
+// Mock TransientResult-like object
+function mockTransientResult() {
+  const voltageMap = new Map([['out', [0, 2.5, 5]]]);
+  return {
+    time: [0, 1e-3, 2e-3],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+describe('TransientPlot', () => {
+  it('renders a canvas element', () => {
+    const { container } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} />,
+    );
+    const canvas = container.querySelector('canvas');
+    expect(canvas).not.toBeNull();
+  });
+
+  it('renders with dark theme by default', () => {
+    const { container } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} />,
+    );
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('renders with custom dimensions', () => {
+    const { container } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} width={600} height={400} />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.width).toBe('600px');
+    expect(wrapper.style.height).toBe('400px');
+  });
+});

--- a/packages/ui/src/react/TransientPlot.test.tsx
+++ b/packages/ui/src/react/TransientPlot.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { TransientPlot } from './TransientPlot.js';
+import type { TransientDataset } from '../core/types.js';
 
 // Mock TransientResult-like object
 function mockTransientResult() {
@@ -39,5 +40,86 @@ describe('TransientPlot', () => {
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.style.width).toBe('600px');
     expect(wrapper.style.height).toBe('400px');
+  });
+
+  it('renders with string width/height', () => {
+    const { container } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} width="80%" height="200px" />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.width).toBe('80%');
+    expect(wrapper.style.height).toBe('200px');
+  });
+
+  it('calls onCursorMove callback when provided', () => {
+    const onCursorMove = vi.fn();
+    render(
+      <TransientPlot
+        data={mockTransientResult()}
+        signals={['out']}
+        onCursorMove={onCursorMove}
+      />,
+    );
+    // Component mounts without errors; callback is wired up
+    expect(onCursorMove).not.toHaveBeenCalled(); // no interaction fired yet
+  });
+
+  it('renders with signalVisibility prop', () => {
+    const { container } = render(
+      <TransientPlot
+        data={mockTransientResult()}
+        signals={['out']}
+        signalVisibility={{ out: false }}
+      />,
+    );
+    expect(container.querySelector('canvas')).not.toBeNull();
+  });
+
+  it('renders with colors prop', () => {
+    const { container } = render(
+      <TransientPlot
+        data={mockTransientResult()}
+        signals={['out']}
+        colors={{ out: '#ff0000' }}
+      />,
+    );
+    expect(container.querySelector('canvas')).not.toBeNull();
+  });
+
+  it('renders with xDomain prop', () => {
+    const { container } = render(
+      <TransientPlot
+        data={mockTransientResult()}
+        signals={['out']}
+        xDomain={[0, 5e-3]}
+      />,
+    );
+    expect(container.querySelector('canvas')).not.toBeNull();
+  });
+
+  it('renders with array of TransientDatasets', () => {
+    const datasets: TransientDataset[] = [
+      {
+        time: [0, 1e-3, 2e-3],
+        signals: new Map([['out', [0, 2.5, 5]]]),
+        label: 'run1',
+      },
+      {
+        time: [0, 1e-3, 2e-3],
+        signals: new Map([['out', [5, 2.5, 0]]]),
+        label: 'run2',
+      },
+    ];
+    const { container } = render(
+      <TransientPlot data={datasets} signals={['out']} />,
+    );
+    expect(container.querySelector('canvas')).not.toBeNull();
+  });
+
+  it('unmounts cleanly without errors', () => {
+    const { unmount } = render(
+      <TransientPlot data={mockTransientResult()} signals={['out']} />,
+    );
+    unmount(); // should not throw
   });
 });

--- a/packages/ui/src/react/TransientPlot.tsx
+++ b/packages/ui/src/react/TransientPlot.tsx
@@ -81,13 +81,12 @@ export function TransientPlot({
             renderer.setCursorPixelX(pixelX);
             renderer.render();
           },
-          onZoom: (pixelX, factor, _shiftKey) => {
-            renderer.zoomAt(pixelX, factor);
-            renderer.zoomY(factor);
+          onZoom: (_pixelX, factor, _shiftKey) => {
+            renderer.zoomAt(_pixelX, factor);
             renderer.render();
           },
-          onPan: (dx, dy) => {
-            renderer.pan(dx, dy);
+          onPan: (dx, _dy) => {
+            renderer.pan(dx, 0);
             renderer.render();
           },
           onDoubleClick: () => {

--- a/packages/ui/src/react/TransientPlot.tsx
+++ b/packages/ui/src/react/TransientPlot.tsx
@@ -81,9 +81,9 @@ export function TransientPlot({
             renderer.setCursorPixelX(pixelX);
             renderer.render();
           },
-          onZoom: (pixelX, factor, shiftKey) => {
-            if (shiftKey) renderer.zoomY(factor);
-            else renderer.zoomAt(pixelX, factor);
+          onZoom: (pixelX, factor, _shiftKey) => {
+            renderer.zoomAt(pixelX, factor);
+            renderer.zoomY(factor);
             renderer.render();
           },
           onPan: (dx, dy) => {

--- a/packages/ui/src/react/TransientPlot.tsx
+++ b/packages/ui/src/react/TransientPlot.tsx
@@ -47,22 +47,20 @@ export function TransientPlot({
 }: TransientPlotProps) {
   const rendererRef = useRef<TransientRenderer | null>(null);
   const interactionRef = useRef<InteractionHandler | null>(null);
+  const onCursorMoveRef = useRef(onCursorMove);
+  onCursorMoveRef.current = onCursorMove;
   const resolvedTheme = resolveTheme(theme);
 
-  const handleResize = useCallback(
-    (_canvas: HTMLCanvasElement) => {
-      if (rendererRef.current) {
-        rendererRef.current.render();
-      }
-    },
-    [],
-  );
+  const handleResize = useCallback(() => {
+    rendererRef.current?.render();
+  }, []);
 
   const { refCallback } = useCanvas(handleResize);
 
+  // Create renderer and interaction handler once when canvas mounts.
+  // Does NOT depend on data, signals, or colors — those update via useEffect below.
   const canvasRefCallback = useCallback(
     (canvas: HTMLCanvasElement | null) => {
-      // Cleanup previous
       rendererRef.current?.destroy();
       interactionRef.current?.destroy();
       rendererRef.current = null;
@@ -74,22 +72,9 @@ export function TransientPlot({
         const renderer = new TransientRenderer(canvas, { theme: resolvedTheme });
         rendererRef.current = renderer;
 
-        const datasets = normalizeTransientData(data, signals);
-        renderer.setData(datasets, signals);
-
-        if (xDomain) {
-          renderer.setFixedXDomain(xDomain);
-        }
-
-        if (colors) {
-          for (const [name, color] of Object.entries(colors)) {
-            renderer.setSignalColor(name, color);
-          }
-        }
-
-        if (onCursorMove) {
-          renderer.on('cursorMove', onCursorMove);
-        }
+        renderer.on('cursorMove', (state) => {
+          onCursorMoveRef.current?.(state);
+        });
 
         const interaction = new InteractionHandler(canvas, {
           onCursorMove: (pixelX) => {
@@ -120,12 +105,32 @@ export function TransientPlot({
             },
           };
         }
-
-        renderer.render();
       }
     },
-    [data, signals, resolvedTheme, colors, onCursorMove, refCallback, handleRef, xDomain],
+    [resolvedTheme, refCallback, handleRef],
   );
+
+  // Update data on the existing renderer without recreating it.
+  // This preserves zoom/pan state during streaming.
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+
+    const datasets = normalizeTransientData(data, signals);
+    renderer.setData(datasets, signals);
+
+    if (xDomain) {
+      renderer.setFixedXDomain(xDomain);
+    }
+
+    if (colors) {
+      for (const [name, color] of Object.entries(colors)) {
+        renderer.setSignalColor(name, color);
+      }
+    }
+
+    renderer.render();
+  }, [data, signals, colors, xDomain]);
 
   // Update visibility when prop changes
   useEffect(() => {

--- a/packages/ui/src/react/TransientPlot.tsx
+++ b/packages/ui/src/react/TransientPlot.tsx
@@ -6,6 +6,10 @@ import { InteractionHandler } from '../core/interaction.js';
 import type { ThemeConfig, CursorState } from '../core/types.js';
 import { useCanvas } from './use-renderer.js';
 
+export interface TransientPlotHandle {
+  fitToData(): void;
+}
+
 export interface TransientPlotProps {
   /** TransientResult from @spice-ts/core, or array of TransientDataset for overlay. */
   data: unknown;
@@ -23,6 +27,8 @@ export interface TransientPlotProps {
   onCursorMove?: (cursor: CursorState | null) => void;
   /** Signal visibility state (controlled). */
   signalVisibility?: Record<string, boolean>;
+  /** Ref to access imperative methods like fitToData(). */
+  handleRef?: React.MutableRefObject<TransientPlotHandle | null>;
 }
 
 export function TransientPlot({
@@ -34,6 +40,7 @@ export function TransientPlot({
   height = 300,
   onCursorMove,
   signalVisibility,
+  handleRef,
 }: TransientPlotProps) {
   const rendererRef = useRef<TransientRenderer | null>(null);
   const interactionRef = useRef<InteractionHandler | null>(null);
@@ -98,10 +105,19 @@ export function TransientPlot({
         });
         interactionRef.current = interaction;
 
+        if (handleRef) {
+          handleRef.current = {
+            fitToData() {
+              renderer.fitToData();
+              renderer.render();
+            },
+          };
+        }
+
         renderer.render();
       }
     },
-    [data, signals, resolvedTheme, colors, onCursorMove, refCallback],
+    [data, signals, resolvedTheme, colors, onCursorMove, refCallback, handleRef],
   );
 
   // Update visibility when prop changes

--- a/packages/ui/src/react/TransientPlot.tsx
+++ b/packages/ui/src/react/TransientPlot.tsx
@@ -29,6 +29,8 @@ export interface TransientPlotProps {
   signalVisibility?: Record<string, boolean>;
   /** Ref to access imperative methods like fitToData(). */
   handleRef?: React.MutableRefObject<TransientPlotHandle | null>;
+  /** Fixed x-axis domain [min, max] in seconds. Useful for streaming. */
+  xDomain?: [number, number];
 }
 
 export function TransientPlot({
@@ -41,6 +43,7 @@ export function TransientPlot({
   onCursorMove,
   signalVisibility,
   handleRef,
+  xDomain,
 }: TransientPlotProps) {
   const rendererRef = useRef<TransientRenderer | null>(null);
   const interactionRef = useRef<InteractionHandler | null>(null);
@@ -73,6 +76,10 @@ export function TransientPlot({
 
         const datasets = normalizeTransientData(data, signals);
         renderer.setData(datasets, signals);
+
+        if (xDomain) {
+          renderer.setFixedXDomain(xDomain);
+        }
 
         if (colors) {
           for (const [name, color] of Object.entries(colors)) {
@@ -117,7 +124,7 @@ export function TransientPlot({
         renderer.render();
       }
     },
-    [data, signals, resolvedTheme, colors, onCursorMove, refCallback, handleRef],
+    [data, signals, resolvedTheme, colors, onCursorMove, refCallback, handleRef, xDomain],
   );
 
   // Update visibility when prop changes

--- a/packages/ui/src/react/TransientPlot.tsx
+++ b/packages/ui/src/react/TransientPlot.tsx
@@ -1,0 +1,138 @@
+import { useRef, useEffect, useCallback, type CSSProperties } from 'react';
+import { TransientRenderer } from '../core/renderer.js';
+import { resolveTheme } from '../core/theme.js';
+import { normalizeTransientData } from '../core/data.js';
+import { InteractionHandler } from '../core/interaction.js';
+import type { ThemeConfig, CursorState } from '../core/types.js';
+import { useCanvas } from './use-renderer.js';
+
+export interface TransientPlotProps {
+  /** TransientResult from @spice-ts/core, or array of TransientDataset for overlay. */
+  data: unknown;
+  /** Signal names to display. */
+  signals: string[];
+  /** Signal color overrides. */
+  colors?: Record<string, string>;
+  /** Theme preset or custom config. */
+  theme?: 'dark' | 'light' | ThemeConfig;
+  /** CSS width. Default '100%'. */
+  width?: number | string;
+  /** CSS height. Default 300. */
+  height?: number | string;
+  /** Cursor move callback. */
+  onCursorMove?: (cursor: CursorState | null) => void;
+  /** Signal visibility state (controlled). */
+  signalVisibility?: Record<string, boolean>;
+}
+
+export function TransientPlot({
+  data,
+  signals,
+  colors,
+  theme,
+  width = '100%',
+  height = 300,
+  onCursorMove,
+  signalVisibility,
+}: TransientPlotProps) {
+  const rendererRef = useRef<TransientRenderer | null>(null);
+  const interactionRef = useRef<InteractionHandler | null>(null);
+  const resolvedTheme = resolveTheme(theme);
+
+  const handleResize = useCallback(
+    (_canvas: HTMLCanvasElement) => {
+      if (rendererRef.current) {
+        rendererRef.current.render();
+      }
+    },
+    [],
+  );
+
+  const { refCallback } = useCanvas(handleResize);
+
+  const canvasRefCallback = useCallback(
+    (canvas: HTMLCanvasElement | null) => {
+      // Cleanup previous
+      rendererRef.current?.destroy();
+      interactionRef.current?.destroy();
+      rendererRef.current = null;
+      interactionRef.current = null;
+
+      refCallback(canvas);
+
+      if (canvas) {
+        const renderer = new TransientRenderer(canvas, { theme: resolvedTheme });
+        rendererRef.current = renderer;
+
+        const datasets = normalizeTransientData(data, signals);
+        renderer.setData(datasets, signals);
+
+        if (colors) {
+          for (const [name, color] of Object.entries(colors)) {
+            renderer.setSignalColor(name, color);
+          }
+        }
+
+        if (onCursorMove) {
+          renderer.on('cursorMove', onCursorMove);
+        }
+
+        const interaction = new InteractionHandler(canvas, {
+          onCursorMove: (pixelX) => {
+            renderer.setCursorPixelX(pixelX);
+            renderer.render();
+          },
+          onZoom: (pixelX, factor, shiftKey) => {
+            if (shiftKey) renderer.zoomY(factor);
+            else renderer.zoomAt(pixelX, factor);
+            renderer.render();
+          },
+          onPan: (dx, dy) => {
+            renderer.pan(dx, dy);
+            renderer.render();
+          },
+          onDoubleClick: () => {
+            renderer.fitToData();
+            renderer.render();
+          },
+        });
+        interactionRef.current = interaction;
+
+        renderer.render();
+      }
+    },
+    [data, signals, resolvedTheme, colors, onCursorMove, refCallback],
+  );
+
+  // Update visibility when prop changes
+  useEffect(() => {
+    if (!rendererRef.current || !signalVisibility) return;
+    for (const [name, visible] of Object.entries(signalVisibility)) {
+      rendererRef.current.setSignalVisibility(name, visible);
+    }
+    rendererRef.current.render();
+  }, [signalVisibility]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      rendererRef.current?.destroy();
+      interactionRef.current?.destroy();
+    };
+  }, []);
+
+  const style: CSSProperties = {
+    width: typeof width === 'number' ? `${width}px` : width,
+    height: typeof height === 'number' ? `${height}px` : height,
+    position: 'relative',
+  };
+
+  return (
+    <div style={style}>
+      <canvas
+        ref={canvasRefCallback}
+        style={{ width: '100%', height: '100%', display: 'block' }}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/react/WaveformViewer.test.tsx
+++ b/packages/ui/src/react/WaveformViewer.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { WaveformViewer } from './WaveformViewer.js';
+
+function mockTransientResult() {
+  const voltageMap = new Map([['out', [0, 2.5, 5]]]);
+  return {
+    time: [0, 1e-3, 2e-3],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+function mockACResult() {
+  const voltageMap = new Map([
+    ['out', [
+      { magnitude: 1, phase: 0 },
+      { magnitude: 0.707, phase: -45 },
+    ]],
+  ]);
+  return {
+    frequencies: [100, 10000],
+    voltage(node: string) {
+      const v = voltageMap.get(node);
+      if (!v) throw new Error(`Unknown: ${node}`);
+      return v;
+    },
+    current() { return []; },
+  };
+}
+
+describe('WaveformViewer', () => {
+  it('renders transient-only view', () => {
+    const { container } = render(
+      <WaveformViewer transient={mockTransientResult()} signals={['out']} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders AC-only view', () => {
+    const { container } = render(
+      <WaveformViewer ac={mockACResult()} signals={['out']} />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders both transient and AC stacked', () => {
+    const { container } = render(
+      <WaveformViewer
+        transient={mockTransientResult()}
+        ac={mockACResult()}
+        signals={['out']}
+      />,
+    );
+    // At least 3 canvases: 1 transient + 2 Bode panes
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/ui/src/react/WaveformViewer.test.tsx
+++ b/packages/ui/src/react/WaveformViewer.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
 import { WaveformViewer } from './WaveformViewer.js';
 
 function mockTransientResult() {
@@ -58,5 +58,119 @@ describe('WaveformViewer', () => {
     );
     // At least 3 canvases: 1 transient + 2 Bode panes
     expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders with dark theme', () => {
+    const { container } = render(
+      <WaveformViewer transient={mockTransientResult()} signals={['out']} theme="dark" />,
+    );
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('renders with light theme', () => {
+    const { container } = render(
+      <WaveformViewer transient={mockTransientResult()} signals={['out']} theme="light" />,
+    );
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('renders Reset Axes button', () => {
+    const { getAllByText } = render(
+      <WaveformViewer transient={mockTransientResult()} signals={['out']} />,
+    );
+    const buttons = getAllByText('Reset Axes');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('Reset Axes button is clickable', () => {
+    const { getAllByText } = render(
+      <WaveformViewer transient={mockTransientResult()} signals={['out']} />,
+    );
+    // Should not throw on click
+    const buttons = getAllByText('Reset Axes');
+    fireEvent.click(buttons[0]);
+  });
+
+  it('legend toggle changes signal visibility', () => {
+    const { container } = render(
+      <WaveformViewer transient={mockTransientResult()} signals={['out']} />,
+    );
+    // The legend renders signal labels — find any button or clickable element
+    const legendItems = container.querySelectorAll('[style]');
+    // Just verify legend is rendered with signal info
+    expect(legendItems.length).toBeGreaterThan(0);
+  });
+
+  it('renders error state when stream errors', async () => {
+    async function* errorStream(): AsyncIterable<never> {
+      throw new Error('Simulation failed');
+    }
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <WaveformViewer stream={errorStream()} signals={['out']} />,
+      ));
+      // Let the error propagate through microtasks
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(container.textContent).toContain('Simulation error');
+  });
+
+  it('renders streaming data progressively', async () => {
+    async function* mockTransientStream() {
+      yield {
+        time: 0,
+        voltages: new Map([['out', 0]]),
+        currents: new Map<string, number>(),
+      };
+      yield {
+        time: 1e-3,
+        voltages: new Map([['out', 2.5]]),
+        currents: new Map<string, number>(),
+      };
+    }
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <WaveformViewer stream={mockTransientStream()} signals={['out']} />,
+      ));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Canvas should be rendered
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('renders with xDomain prop', () => {
+    const { container } = render(
+      <WaveformViewer
+        transient={mockTransientResult()}
+        signals={['out']}
+        xDomain={[0, 5e-3]}
+      />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders with colors prop', () => {
+    const { container } = render(
+      <WaveformViewer
+        transient={mockTransientResult()}
+        signals={['out']}
+        colors={{ out: '#ff0000' }}
+      />,
+    );
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders AC-only without transient (no stream)', () => {
+    const { container } = render(
+      <WaveformViewer ac={mockACResult()} signals={['out']} />,
+    );
+    // Bode plot shows 2 canvases
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/ui/src/react/WaveformViewer.tsx
+++ b/packages/ui/src/react/WaveformViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef, type CSSProperties } from 'react';
-import { TransientPlot, type TransientPlotProps } from './TransientPlot.js';
+import { TransientPlot, type TransientPlotProps, type TransientPlotHandle } from './TransientPlot.js';
 import { BodePlot, type BodePlotProps } from './BodePlot.js';
 import { Legend, type LegendSignal } from './Legend.js';
 import { CursorTooltip } from './CursorTooltip.js';
@@ -47,6 +47,7 @@ export function WaveformViewer({
   const [streamData, setStreamData] = useState<TransientDataset[] | null>(null);
   const controllerRef = useRef<StreamingController | null>(null);
   const rafRef = useRef<number>(0);
+  const transientHandleRef = useRef<TransientPlotHandle | null>(null);
 
   // Streaming: consume async iterator, update data on rAF
   useEffect(() => {
@@ -103,8 +104,26 @@ export function WaveformViewer({
     position: 'relative',
   };
 
+  const handleFit = useCallback(() => {
+    transientHandleRef.current?.fitToData();
+  }, []);
+
+  const buttonStyle: CSSProperties = {
+    fontSize: `${resolvedTheme.fontSize}px`,
+    fontFamily: resolvedTheme.font,
+    color: resolvedTheme.textMuted,
+    background: 'transparent',
+    border: `1px solid ${resolvedTheme.border}`,
+    borderRadius: '4px',
+    padding: '2px 8px',
+    cursor: 'pointer',
+  };
+
   return (
     <div style={containerStyle}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '8px', gap: '6px' }}>
+        <button style={buttonStyle} onClick={handleFit}>Reset Axes</button>
+      </div>
       {transientData != null && (
         <TransientPlot
           data={transientData}
@@ -113,6 +132,7 @@ export function WaveformViewer({
           theme={resolvedTheme}
           onCursorMove={setCursor}
           signalVisibility={visibility}
+          handleRef={transientHandleRef}
         />
       )}
       {ac != null && !stream && (

--- a/packages/ui/src/react/WaveformViewer.tsx
+++ b/packages/ui/src/react/WaveformViewer.tsx
@@ -15,7 +15,7 @@ export interface WaveformViewerProps {
   /** AC result or dataset array. */
   ac?: BodePlotProps['data'];
   /** Async stream from simulateStream(). Renders progressively as data arrives. */
-  stream?: AsyncIterable<{ time: number; voltages: Map<string, number>; currents: Map<string, number> }>;
+  stream?: AsyncIterable<unknown>;
   /** Signal names to display. */
   signals: string[];
   /** Signal color overrides. */

--- a/packages/ui/src/react/WaveformViewer.tsx
+++ b/packages/ui/src/react/WaveformViewer.tsx
@@ -45,6 +45,7 @@ export function WaveformViewer({
     return v;
   });
   const [streamData, setStreamData] = useState<TransientDataset[] | null>(null);
+  const [streamError, setStreamError] = useState<string | null>(null);
   const controllerRef = useRef<StreamingController | null>(null);
   const rafRef = useRef<number>(0);
   const transientHandleRef = useRef<TransientPlotHandle | null>(null);
@@ -52,6 +53,7 @@ export function WaveformViewer({
   // Streaming: consume async iterator, update data on rAF
   useEffect(() => {
     if (!stream) return;
+    setStreamError(null);
 
     let dirty = false;
     const controller = new StreamingController(signals, () => { dirty = true; });
@@ -72,7 +74,11 @@ export function WaveformViewer({
     };
     rafRef.current = requestAnimationFrame(loop);
 
-    controller.consume(stream as AsyncIterable<Parameters<typeof controller.consume>[0] extends AsyncIterable<infer T> ? T : never>);
+    controller.consume(stream as AsyncIterable<Parameters<typeof controller.consume>[0] extends AsyncIterable<infer T> ? T : never>)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        setStreamError(msg);
+      });
 
     return () => {
       controller.stop();
@@ -145,6 +151,11 @@ export function WaveformViewer({
             onCursorMove={transientData == null ? setCursor : undefined}
             signalVisibility={visibility}
           />
+        </div>
+      )}
+      {streamError && (
+        <div style={{ color: '#f87171', fontSize: `${resolvedTheme.fontSize}px`, padding: '8px 0' }}>
+          Simulation error: {streamError}
         </div>
       )}
       <Legend signals={legendSignals} onToggle={handleToggle} />

--- a/packages/ui/src/react/WaveformViewer.tsx
+++ b/packages/ui/src/react/WaveformViewer.tsx
@@ -6,9 +6,8 @@ import { CursorTooltip } from './CursorTooltip.js';
 import { StreamingController } from '../core/streaming.js';
 import { resolveTheme } from '../core/theme.js';
 import { formatTime, formatFrequency } from '../core/format.js';
-import type { ThemeConfig, CursorState, TransientDataset } from '../core/types.js';
+import type { ThemeConfig, CursorState, TransientDataset, StreamingTransientStep, StreamingACPoint } from '../core/types.js';
 import { DEFAULT_PALETTE } from '../core/types.js';
-import type { TransientStep, ACPoint } from '@spice-ts/core';
 
 export interface WaveformViewerProps {
   /** Transient result or dataset array. */
@@ -16,7 +15,7 @@ export interface WaveformViewerProps {
   /** AC result or dataset array. */
   ac?: BodePlotProps['data'];
   /** Async stream from simulateStream(). Renders progressively as data arrives. */
-  stream?: AsyncIterable<TransientStep | ACPoint>;
+  stream?: AsyncIterable<StreamingTransientStep | StreamingACPoint>;
   /** Signal names to display. */
   signals: string[];
   /** Signal color overrides. */

--- a/packages/ui/src/react/WaveformViewer.tsx
+++ b/packages/ui/src/react/WaveformViewer.tsx
@@ -22,6 +22,8 @@ export interface WaveformViewerProps {
   colors?: Record<string, string>;
   /** Theme preset or custom config. */
   theme?: 'dark' | 'light' | ThemeConfig;
+  /** Fixed x-axis domain [min, max] in seconds. Useful during streaming. */
+  xDomain?: [number, number];
 }
 
 /**
@@ -36,6 +38,7 @@ export function WaveformViewer({
   signals,
   colors,
   theme,
+  xDomain,
 }: WaveformViewerProps) {
   const resolvedTheme = resolveTheme(theme);
   const [cursor, setCursor] = useState<CursorState | null>(null);
@@ -139,6 +142,7 @@ export function WaveformViewer({
           onCursorMove={setCursor}
           signalVisibility={visibility}
           handleRef={transientHandleRef}
+          xDomain={xDomain}
         />
       )}
       {ac != null && !stream && (

--- a/packages/ui/src/react/WaveformViewer.tsx
+++ b/packages/ui/src/react/WaveformViewer.tsx
@@ -1,0 +1,138 @@
+import { useState, useCallback, useEffect, useRef, type CSSProperties } from 'react';
+import { TransientPlot, type TransientPlotProps } from './TransientPlot.js';
+import { BodePlot, type BodePlotProps } from './BodePlot.js';
+import { Legend, type LegendSignal } from './Legend.js';
+import { CursorTooltip } from './CursorTooltip.js';
+import { StreamingController } from '../core/streaming.js';
+import { resolveTheme } from '../core/theme.js';
+import { formatTime, formatFrequency } from '../core/format.js';
+import type { ThemeConfig, CursorState, TransientDataset } from '../core/types.js';
+import { DEFAULT_PALETTE } from '../core/types.js';
+
+export interface WaveformViewerProps {
+  /** Transient result or dataset array. */
+  transient?: TransientPlotProps['data'];
+  /** AC result or dataset array. */
+  ac?: BodePlotProps['data'];
+  /** Async stream from simulateStream(). Renders progressively as data arrives. */
+  stream?: AsyncIterable<{ time: number; voltages: Map<string, number>; currents: Map<string, number> }>;
+  /** Signal names to display. */
+  signals: string[];
+  /** Signal color overrides. */
+  colors?: Record<string, string>;
+  /** Theme preset or custom config. */
+  theme?: 'dark' | 'light' | ThemeConfig;
+}
+
+/**
+ * Pre-composed waveform viewer. When both transient and ac are provided,
+ * renders them stacked vertically (transient on top, Bode below).
+ * When streaming, displays only the analysis type being streamed.
+ */
+export function WaveformViewer({
+  transient,
+  ac,
+  stream,
+  signals,
+  colors,
+  theme,
+}: WaveformViewerProps) {
+  const resolvedTheme = resolveTheme(theme);
+  const [cursor, setCursor] = useState<CursorState | null>(null);
+  const [visibility, setVisibility] = useState<Record<string, boolean>>(() => {
+    const v: Record<string, boolean> = {};
+    for (const s of signals) v[s] = true;
+    return v;
+  });
+  const [streamData, setStreamData] = useState<TransientDataset[] | null>(null);
+  const controllerRef = useRef<StreamingController | null>(null);
+  const rafRef = useRef<number>(0);
+
+  // Streaming: consume async iterator, update data on rAF
+  useEffect(() => {
+    if (!stream) return;
+
+    let dirty = false;
+    const controller = new StreamingController(signals, () => { dirty = true; });
+    controllerRef.current = controller;
+
+    // rAF loop: only update React state at display refresh rate
+    const loop = () => {
+      if (dirty) {
+        dirty = false;
+        setStreamData([controller.getDataset()]);
+      }
+      if (controller.isRunning()) {
+        rafRef.current = requestAnimationFrame(loop);
+      } else {
+        // Final update after stream ends
+        setStreamData([controller.getDataset()]);
+      }
+    };
+    rafRef.current = requestAnimationFrame(loop);
+
+    controller.consume(stream as AsyncIterable<Parameters<typeof controller.consume>[0] extends AsyncIterable<infer T> ? T : never>);
+
+    return () => {
+      controller.stop();
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [stream, signals]);
+
+  // Use streaming data if available, otherwise the transient prop
+  const transientData = streamData ?? transient;
+
+  const legendSignals: LegendSignal[] = signals.map((name, i) => ({
+    id: name,
+    label: name,
+    color: colors?.[name] ?? DEFAULT_PALETTE[i % DEFAULT_PALETTE.length],
+    visible: visibility[name] ?? true,
+  }));
+
+  const handleToggle = useCallback((signalId: string) => {
+    setVisibility((prev) => ({ ...prev, [signalId]: !prev[signalId] }));
+  }, []);
+
+  const containerStyle: CSSProperties = {
+    background: resolvedTheme.surface,
+    border: `1px solid ${resolvedTheme.border}`,
+    borderRadius: '8px',
+    padding: '16px',
+    fontFamily: resolvedTheme.font,
+    color: resolvedTheme.text,
+    position: 'relative',
+  };
+
+  return (
+    <div style={containerStyle}>
+      {transientData != null && (
+        <TransientPlot
+          data={transientData}
+          signals={signals}
+          colors={colors}
+          theme={resolvedTheme}
+          onCursorMove={setCursor}
+          signalVisibility={visibility}
+        />
+      )}
+      {ac != null && !stream && (
+        <div style={{ marginTop: transientData != null ? '16px' : 0 }}>
+          <BodePlot
+            data={ac}
+            signals={signals}
+            colors={colors}
+            theme={resolvedTheme}
+            onCursorMove={transientData == null ? setCursor : undefined}
+            signalVisibility={visibility}
+          />
+        </div>
+      )}
+      <Legend signals={legendSignals} onToggle={handleToggle} />
+      <CursorTooltip
+        cursor={cursor}
+        theme={resolvedTheme}
+        formatX={transientData ? (x) => formatTime(x) : (x) => formatFrequency(x)}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/react/WaveformViewer.tsx
+++ b/packages/ui/src/react/WaveformViewer.tsx
@@ -8,6 +8,7 @@ import { resolveTheme } from '../core/theme.js';
 import { formatTime, formatFrequency } from '../core/format.js';
 import type { ThemeConfig, CursorState, TransientDataset } from '../core/types.js';
 import { DEFAULT_PALETTE } from '../core/types.js';
+import type { TransientStep, ACPoint } from '@spice-ts/core';
 
 export interface WaveformViewerProps {
   /** Transient result or dataset array. */
@@ -15,7 +16,7 @@ export interface WaveformViewerProps {
   /** AC result or dataset array. */
   ac?: BodePlotProps['data'];
   /** Async stream from simulateStream(). Renders progressively as data arrives. */
-  stream?: AsyncIterable<unknown>;
+  stream?: AsyncIterable<TransientStep | ACPoint>;
   /** Signal names to display. */
   signals: string[];
   /** Signal color overrides. */

--- a/packages/ui/src/react/index.ts
+++ b/packages/ui/src/react/index.ts
@@ -1,2 +1,5 @@
-// React exports — populated as components are built
-export {};
+export { TransientPlot, type TransientPlotProps } from './TransientPlot.js';
+export { BodePlot, type BodePlotProps } from './BodePlot.js';
+export { Legend, type LegendProps, type LegendSignal } from './Legend.js';
+export { CursorTooltip, type CursorTooltipProps } from './CursorTooltip.js';
+export { WaveformViewer, type WaveformViewerProps } from './WaveformViewer.js';

--- a/packages/ui/src/react/index.ts
+++ b/packages/ui/src/react/index.ts
@@ -1,0 +1,2 @@
+// React exports — populated as components are built
+export {};

--- a/packages/ui/src/react/index.ts
+++ b/packages/ui/src/react/index.ts
@@ -1,4 +1,4 @@
-export { TransientPlot, type TransientPlotProps } from './TransientPlot.js';
+export { TransientPlot, type TransientPlotProps, type TransientPlotHandle } from './TransientPlot.js';
 export { BodePlot, type BodePlotProps } from './BodePlot.js';
 export { Legend, type LegendProps, type LegendSignal } from './Legend.js';
 export { CursorTooltip, type CursorTooltipProps } from './CursorTooltip.js';

--- a/packages/ui/src/react/use-renderer.ts
+++ b/packages/ui/src/react/use-renderer.ts
@@ -1,0 +1,45 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+/**
+ * Shared hook for managing a canvas element with DPI scaling and resize observation.
+ * Returns a ref callback to attach to the canvas, and the current canvas element.
+ */
+export function useCanvas(onResize?: (canvas: HTMLCanvasElement) => void) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const refCallback = useCallback(
+    (canvas: HTMLCanvasElement | null) => {
+      // Cleanup old observer
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+
+      canvasRef.current = canvas;
+
+      if (canvas) {
+        const updateSize = () => {
+          const dpr = window.devicePixelRatio || 1;
+          const rect = canvas.getBoundingClientRect();
+          canvas.width = rect.width * dpr;
+          canvas.height = rect.height * dpr;
+          onResize?.(canvas);
+        };
+
+        updateSize();
+        observerRef.current = new ResizeObserver(updateSize);
+        observerRef.current.observe(canvas);
+      }
+    },
+    [onResize],
+  );
+
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, []);
+
+  return { refCallback, canvasRef };
+}

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,6 +1,19 @@
 // src/test-setup.ts
 import { vi } from 'vitest';
 
+// Polyfill PointerEvent for jsdom (not available by default)
+if (typeof PointerEvent === 'undefined') {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = PointerEventPolyfill;
+}
+
 function createMockContext(): CanvasRenderingContext2D {
   return {
     canvas: document.createElement('canvas'),

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,6 +1,16 @@
 // src/test-setup.ts
 import { vi } from 'vitest';
 
+// Polyfill ResizeObserver for jsdom (not available by default)
+if (typeof ResizeObserver === 'undefined') {
+  class ResizeObserverPolyfill {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as unknown as Record<string, unknown>).ResizeObserver = ResizeObserverPolyfill;
+}
+
 // Polyfill PointerEvent for jsdom (not available by default)
 if (typeof PointerEvent === 'undefined') {
   class PointerEventPolyfill extends MouseEvent {

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,0 +1,46 @@
+// src/test-setup.ts
+import { vi } from 'vitest';
+
+function createMockContext(): CanvasRenderingContext2D {
+  return {
+    canvas: document.createElement('canvas'),
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    scale: vi.fn(),
+    translate: vi.fn(),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn().mockReturnValue({ width: 40 }),
+    rect: vi.fn(),
+    arc: vi.fn(),
+    clip: vi.fn(),
+    setLineDash: vi.fn(),
+    getLineDash: vi.fn().mockReturnValue([]),
+    lineWidth: 1,
+    strokeStyle: '',
+    fillStyle: '',
+    font: '',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
+    globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+    lineDashOffset: 0,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+HTMLCanvasElement.prototype.getContext = function (this: HTMLCanvasElement, contextId: string, ...args: unknown[]) {
+  if (contextId === '2d') {
+    return createMockContext();
+  }
+  return originalGetContext.call(this, contextId, ...args);
+} as typeof HTMLCanvasElement.prototype.getContext;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    react: 'src/react/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  sourcemap: true,
+  external: ['@spice-ts/core', 'react', 'react-dom'],
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+    reporters: ['default', ['junit', { outputFile: 'test-results.xml' }]],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary'],
+      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/test-setup.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,68 @@ importers:
         version: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
+
+  packages/ui:
+    dependencies:
+      d3-array:
+        specifier: ^3.2.4
+        version: 3.2.4
+      d3-scale:
+        specifier: ^4.0.2
+        version: 4.0.2
+    devDependencies:
+      '@spice-ts/core':
+        specifier: workspace:*
+        version: link:../core
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/d3-array':
+        specifier: ^3.2.1
+        version: 3.2.2
+      '@types/d3-scale':
+        specifier: ^4.0.8
+        version: 4.0.9
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.0
+        version: 18.3.1(react@18.3.1)
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
 
 packages:
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -64,12 +123,44 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
   '@emnapi/core@1.9.2':
@@ -479,11 +570,42 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -493,6 +615,17 @@ packages:
 
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
@@ -537,8 +670,23 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -546,6 +694,9 @@ packages:
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -557,6 +708,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -564,6 +719,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -579,6 +738,45 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -588,15 +786,53 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eecircuit-engine@1.7.0:
     resolution: {integrity: sha512-ZDpr/w/H81uCH3n2vjf0vohxOQqQ4NCsvaXkoYwcH+LCxIGKpBdvAIvGN5IdozW6AFJ8tojquKvDya3337yjSQ==}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -622,20 +858,74 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -655,6 +945,18 @@ packages:
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -737,6 +1039,17 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -746,6 +1059,18 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -761,12 +1086,18 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -807,6 +1138,26 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -827,6 +1178,22 @@ packages:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -859,6 +1226,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -883,6 +1253,21 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -1013,12 +1398,66 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
 snapshots:
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -1028,12 +1467,34 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -1280,15 +1741,46 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/aria-query@5.0.4': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-time@3.0.4': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -1297,6 +1789,17 @@ snapshots:
   '@types/node@25.5.2':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -1310,7 +1813,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
+      vitest: 4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -1355,7 +1858,17 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -1365,6 +1878,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  asynckit@0.4.0: {}
+
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -1372,11 +1887,20 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   chai@6.2.2: {}
 
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@4.1.1: {}
 
@@ -1386,15 +1910,86 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   eecircuit-engine@1.7.0: {}
 
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1441,16 +2036,82 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.60.1
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  internmap@2.0.3: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -1468,6 +2129,36 @@ snapshots:
   joycon@3.1.1: {}
 
   js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1524,6 +2215,14 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
+
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1537,6 +2236,14 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mlly@1.8.2:
     dependencies:
@@ -1555,9 +2262,15 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   obug@2.1.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   pathe@2.0.3: {}
 
@@ -1585,6 +2298,26 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-is@17.0.2: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   readdirp@4.1.2: {}
 
@@ -1644,6 +2377,20 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
@@ -1670,6 +2417,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -1690,6 +2439,20 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -1752,7 +2515,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
@@ -1777,10 +2540,34 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.2
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,37 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
+  examples/08-waveform-viewer:
+    dependencies:
+      '@spice-ts/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@spice-ts/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)
+
   packages/core:
     devDependencies:
       '@vitest/coverage-v8':
@@ -110,6 +141,40 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -118,13 +183,41 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -331,6 +424,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -438,6 +534,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
@@ -595,6 +694,18 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -626,6 +737,12 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
@@ -698,6 +815,16 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  baseline-browser-mapping@2.10.18:
+    resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -711,6 +838,9 @@ packages:
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001787:
+    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -811,6 +941,9 @@ packages:
   eecircuit-engine@1.7.0:
     resolution: {integrity: sha512-ZDpr/w/H81uCH3n2vjf0vohxOQqQ4NCsvaXkoYwcH+LCxIGKpBdvAIvGN5IdozW6AFJ8tojquKvDya3337yjSQ==}
 
+  electron-to-chromium@1.5.335:
+    resolution: {integrity: sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -838,6 +971,10 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -869,6 +1006,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -958,6 +1099,16 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -1046,6 +1197,9 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1085,6 +1239,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -1154,6 +1311,10 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -1194,6 +1355,10 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1313,6 +1478,12 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -1443,6 +1614,9 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
 snapshots:
 
   '@asamuzakjp/css-color@3.2.0':
@@ -1459,15 +1633,108 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -1595,6 +1862,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -1661,6 +1933,8 @@ snapshots:
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
@@ -1769,6 +2043,27 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1800,6 +2095,18 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -1880,6 +2187,16 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  baseline-browser-mapping@2.10.18: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001787
+      electron-to-chromium: 1.5.335
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -1891,6 +2208,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  caniuse-lite@1.0.30001787: {}
 
   chai@6.2.2: {}
 
@@ -1972,6 +2291,8 @@ snapshots:
 
   eecircuit-engine@1.7.0: {}
 
+  electron-to-chromium@1.5.335: {}
+
   entities@6.0.1: {}
 
   es-define-property@1.0.1: {}
@@ -2020,6 +2341,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escalade@3.2.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2048,6 +2371,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2160,6 +2485,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
   lightningcss-android-arm64@1.32.0:
     optional: true
 
@@ -2221,6 +2550,10 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -2261,6 +2594,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  node-releases@2.0.37: {}
 
   nwsapi@2.2.23: {}
 
@@ -2314,6 +2649,8 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
@@ -2390,6 +2727,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -2502,6 +2841,12 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -2571,3 +2916,5 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "packages/*"
   - "examples"
+  - "examples/08-waveform-viewer"


### PR DESCRIPTION
## Summary

- Add `@spice-ts/ui` package with framework-agnostic Canvas rendering core and React bindings (`@spice-ts/ui/react` subpath)
- Transient waveform plots and AC Bode plots (dual-pane magnitude/phase, collapsible) with zoom, pan, cursor readout, and streaming support
- Composable React components (`TransientPlot`, `BodePlot`, `Legend`, `CursorTooltip`) plus a pre-composed `WaveformViewer`
- Dark/light themes (shadcn-inspired), click-to-toggle legend, multi-result overlay for parametric sweeps
- Example Vite app at `examples/08-waveform-viewer/` running a real RC low-pass simulation

## Test plan
- [x] 71 new unit tests across 13 test files — all passing
- [x] Full monorepo `pnpm -r test` passes (core + ui + examples)
- [x] `pnpm build` succeeds for all packages
- [x] `pnpm lint` (tsc --noEmit) clean across all packages
- [x] Example app builds and bundles successfully (238 kB / 76 kB gzip)
- [ ] Manual verification: run `cd examples/08-waveform-viewer && pnpm dev`, open in browser, verify transient/Bode/light-theme views render with zoom/pan/cursor interaction

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mfiumara/spice-ts/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
