### PR TITLE
fix(core): resolve transient convergence failures (#24, #25)

### DIFF
--- a/packages/core/src/analysis/transient-convergence.test.ts
+++ b/packages/core/src/analysis/transient-convergence.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { simulate } from '../simulate.js';
+
+describe('Transient convergence (issues #24 and #25)', () => {
+  it('#25: half-wave rectifier with SIN source should not throw TimestepTooSmallError', { timeout: 30000 }, async () => {
+    // Diode rectifier: SIN source drives a diode into a RC load.
+    // The diode turn-on at ~0.57V previously caused TimestepTooSmallError
+    // because the adaptive timestep cascaded to near-zero.
+    const netlist = `
+      V1 in 0 SIN(0 10 500)
+      D1 in rect DMOD
+      .model DMOD D (IS=1e-14 N=1.05 RS=0.5)
+      R1 rect out 100
+      C1 out 0 100u
+      R2 out 0 1k
+      .tran 0.1u 20m
+    `;
+
+    // Should complete without throwing
+    const result = await simulate(netlist);
+
+    expect(result.transient).toBeDefined();
+    const time = result.transient!.time;
+    const vout = result.transient!.voltage('out');
+
+    // Basic sanity: simulation ran to completion
+    expect(time.length).toBeGreaterThan(10);
+    expect(time[time.length - 1]).toBeCloseTo(20e-3, 4);
+
+    // Output voltage should be non-negative (rectified)
+    // and bounded by supply amplitude
+    for (let i = 0; i < vout.length; i++) {
+      expect(vout[i]).toBeGreaterThanOrEqual(-1); // small undershoot ok
+      expect(vout[i]).toBeLessThanOrEqual(12);    // bounded by 10V supply + margin
+    }
+  });
+
+  it('#24: CMOS inverter should not produce voltage spikes beyond supply rails', async () => {
+    // CMOS inverter with PULSE input. Previously produced 20V+ voltage spikes
+    // on a 5V supply during switching transitions.
+    const netlist = `
+      .model NMOS NMOS (VTO=0.7 KP=110e-6 LAMBDA=0.04 CBD=5p CBS=5p)
+      .model PMOS PMOS (VTO=-0.7 KP=50e-6 LAMBDA=0.05 CBD=5p CBS=5p)
+      V1 vdd 0 DC 5
+      V2 in 0 PULSE(0 5 0 0.1n 0.1n 50n 100n)
+      M1 out in vdd vdd PMOS W=10u L=1u
+      M2 out in 0 0 NMOS W=5u L=1u
+      C1 out 0 1p
+      .tran 0.05n 500n
+    `;
+
+    const result = await simulate(netlist);
+
+    expect(result.transient).toBeDefined();
+    const vout = result.transient!.voltage('out');
+
+    // Output should stay within supply rails (0V to 5V) with small tolerance
+    // for numerical overshoot. 20V+ spikes are definitely wrong.
+    const maxV = Math.max(...vout);
+    const minV = Math.min(...vout);
+
+    expect(maxV).toBeLessThan(6.5);  // <30% overshoot of VDD
+    expect(minV).toBeGreaterThan(-1.5); // <30% undershoot of VSS
+  });
+});

--- a/packages/core/src/analysis/transient.ts
+++ b/packages/core/src/analysis/transient.ts
@@ -6,7 +6,8 @@ import { createSparseSolver } from '../solver/sparse-solver.js';
 import { TimestepTooSmallError } from '../errors.js';
 import { TransientResult } from '../results.js';
 
-const MIN_TIMESTEP = 1e-18;
+const MIN_TIMESTEP = 1e-15;
+const NR_VOLTAGE_LIMIT = 3.5; // Max node-voltage change per NR iteration
 
 export function solveTransient(
   compiled: CompiledCircuit,
@@ -45,6 +46,11 @@ export function solveTransient(
   const solver = createSparseSolver();
   let patternAnalyzed = false;
 
+  // LTE history tracking
+  let secondPrevSol: Float64Array | undefined;
+  let prevDt = dt;
+  let lteRejectCount = 0;
+
   // Compute initial b(0) for trapezoidal history on the first step
   let prevB: Float64Array | undefined;
   if (options.integrationMethod === 'trapezoidal') {
@@ -75,7 +81,16 @@ export function solveTransient(
       solver.factorize(assembler.getCscMatrix());
       const x = solver.solve(new Float64Array(assembler.b));
 
+      // NR damping: limit node-voltage change per iteration to aid convergence
+      // through device switching transitions (MOSFETs, diodes)
       const prev = new Float64Array(assembler.solution);
+      for (let i = 0; i < nodeCount; i++) {
+        const delta = x[i] - prev[i];
+        if (Math.abs(delta) > NR_VOLTAGE_LIMIT) {
+          x[i] = prev[i] + Math.sign(delta) * NR_VOLTAGE_LIMIT;
+        }
+      }
+
       assembler.solution.set(x);
 
       if (isConvergedTransient(x, prev, nodeCount, options)) {
@@ -85,12 +100,32 @@ export function solveTransient(
     }
 
     if (!converged) {
-      dt = dt / 4;
+      // Less aggressive than /4 — gives more attempts before hitting the floor
+      dt = dt / 2;
       if (dt < MIN_TIMESTEP) {
         throw new TimestepTooSmallError(time, dt);
       }
       assembler.solution.set(prevSol);
       continue;
+    }
+
+    // LTE-based timestep control: reject if local truncation error is too large.
+    // This catches inaccurate solutions that NR accepted (convergence != accuracy).
+    let lteRatio = 0;
+    if (secondPrevSol && lteRejectCount < 10) {
+      lteRatio = estimateLTE(
+        assembler.solution, prevSol, secondPrevSol,
+        actualDt, prevDt, nodeCount, options,
+      );
+      if (lteRatio > 1) {
+        // Reduce dt proportionally to the error ratio
+        const factor = Math.max(0.25, 0.9 / Math.sqrt(lteRatio));
+        dt = Math.max(actualDt * factor, MIN_TIMESTEP);
+        assembler.solution.set(prevSol);
+        lteRejectCount++;
+        continue;
+      }
+      lteRejectCount = 0;
     }
 
     // Save the DC-stamped b for trapezoidal history on next step
@@ -113,12 +148,59 @@ export function solveTransient(
       currentArrays.get(branchNames[i])!.push(assembler.solution[nodeCount + i]);
     }
 
-    // Adaptive: grow timestep if converged
-    dt = Math.min(dt * 1.5, maxDt, analysis.stopTime - time);
+    // Update LTE history
+    secondPrevSol = prevSol;
+    prevDt = actualDt;
+
+    // Adaptive: grow timestep based on LTE margin
+    const growFactor = lteRatio > 0.001
+      ? Math.min(2.0, 0.9 / Math.sqrt(lteRatio))
+      : 2.0;
+    dt = Math.min(actualDt * growFactor, maxDt, analysis.stopTime - time);
     if (dt < MIN_TIMESTEP && time < analysis.stopTime - MIN_TIMESTEP) break;
   }
 
   return new TransientResult(timePoints, voltageArrays, currentArrays);
+}
+
+/**
+ * Estimate the Local Truncation Error ratio for the current step.
+ *
+ * Uses a forward-Euler predictor compared against the actual solution:
+ *   predicted = x(n) + dt * (x(n) - x(n-1)) / prevDt
+ *   error = |actual - predicted| / 3   (for trapezoidal, order-2 corrector)
+ *   ratio = error / (trtol * tolerance)
+ *
+ * A ratio > 1 means the step should be rejected.
+ */
+function estimateLTE(
+  current: Float64Array,
+  previous: Float64Array,
+  secondPrev: Float64Array,
+  dt: number,
+  prevDt: number,
+  nodeCount: number,
+  options: ResolvedOptions,
+): number {
+  let maxRatio = 0;
+  const divider = options.integrationMethod === 'trapezoidal' ? 3 : 2;
+
+  for (let i = 0; i < nodeCount; i++) {
+    // Forward Euler prediction from the rate of change at the previous step
+    const slope = (previous[i] - secondPrev[i]) / prevDt;
+    const predicted = previous[i] + dt * slope;
+
+    // Error between corrector (actual NR result) and predictor
+    const error = Math.abs(current[i] - predicted) / divider;
+    const tol = options.trtol * (options.vntol + options.reltol * Math.abs(current[i]));
+
+    if (tol > 0) {
+      const ratio = error / tol;
+      if (ratio > maxRatio) maxRatio = ratio;
+    }
+  }
+
+  return maxRatio;
 }
 
 function isConvergedTransient(

--- a/packages/core/src/devices/mosfet.ts
+++ b/packages/core/src/devices/mosfet.ts
@@ -34,16 +34,30 @@ export class MOSFET implements DeviceModel {
   stamp(ctx: StampContext): void {
     const { VTO, KP, LAMBDA, W, L, polarity } = this.params;
     const WL = W / L;
-    const [nD, nG, nS] = this.nodes;
 
-    // Get node voltages
+    // Get node voltages — may swap drain/source below
+    let nD = this.nodes[0];
+    const nG = this.nodes[1];
+    let nS = this.nodes[2];
+
     const vD = nD >= 0 ? ctx.getVoltage(nD) : 0;
     const vG = nG >= 0 ? ctx.getVoltage(nG) : 0;
     const vS = nS >= 0 ? ctx.getVoltage(nS) : 0;
 
     // Internal voltages adjusted for polarity (PMOS flips)
-    const vGS = polarity * (vG - vS);
-    const vDS = polarity * (vD - vS);
+    let vGS = polarity * (vG - vS);
+    let vDS = polarity * (vD - vS);
+
+    // Source-drain swap: if vDS < 0, the device operates in reverse mode.
+    // Standard SPICE Level 1 handles this by swapping drain and source
+    // internally so that vDS >= 0 for the model equations.
+    if (vDS < 0) {
+      const tmp = nD;
+      nD = nS;
+      nS = tmp;
+      vGS = vGS - vDS; // vG - vD (gate to new effective source)
+      vDS = -vDS;       // |vDS|
+    }
 
     // Threshold in polarity-adjusted domain: for PMOS, VTO from model card is
     // negative (e.g. -0.5V). After the polarity flip vGS is positive, so we
@@ -80,23 +94,14 @@ export class MOSFET implements DeviceModel {
     // Equivalent current: Ieq = ID0 - gm*VGS0 - gds*VDS0
     const Ieq = ID - gm * vGS - gds * vDS;
 
-    // Physical current into drain = polarity * ID
-    // VGS = polarity*(vG - vS), VDS = polarity*(vD - vS)
-    // dVGS/dvG = polarity, dVGS/dvS = -polarity
-    // dVDS/dvD = polarity, dVDS/dvS = -polarity
+    // Physical current into effective drain = polarity * ID
+    // The stamps below use the (possibly swapped) nD, nG, nS.
     //
-    // ID_node = polarity * (gm*VGS + gds*VDS + Ieq)
-    //
-    // dID_node/dvG = polarity * gm * polarity = gm
-    // dID_node/dvD = polarity * gds * polarity = gds
-    // dID_node/dvS = polarity * (-gm*polarity - gds*polarity) = -(gm + gds)
-    //
-    // IS_node = -ID_node (KCL, gate draws no current)
-    // dIS_node/dvG = -gm
-    // dIS_node/dvD = -gds
-    // dIS_node/dvS = gm + gds
+    // dID_node/dvG = gm
+    // dID_node/dvD = gds
+    // dID_node/dvS = -(gm + gds)
 
-    // Stamp drain row (current into drain)
+    // Stamp drain row (current into effective drain)
     if (nD >= 0) {
       if (nG >= 0) ctx.stampG(nD, nG, gm);
       if (nD >= 0) ctx.stampG(nD, nD, gds);
@@ -104,7 +109,7 @@ export class MOSFET implements DeviceModel {
       ctx.stampB(nD, -polarity * Ieq);
     }
 
-    // Stamp source row (current into source = -current into drain)
+    // Stamp source row (current into effective source = -current into effective drain)
     if (nS >= 0) {
       if (nG >= 0) ctx.stampG(nS, nG, -gm);
       if (nD >= 0) ctx.stampG(nS, nD, -gds);
@@ -130,18 +135,28 @@ export class MOSFET implements DeviceModel {
       const mosfet = mosfets[m];
       const { VTO, KP, LAMBDA, W, L, polarity } = mosfet.params;
       const WL = W / L;
-      const nD = mosfet.nodes[0];
-      const nG = mosfet.nodes[1];
-      const nS = mosfet.nodes[2];
 
-      // Get node voltages
+      // Get node voltages — may swap drain/source below
+      let nD = mosfet.nodes[0];
+      const nG = mosfet.nodes[1];
+      let nS = mosfet.nodes[2];
+
       const vD = nD >= 0 ? solution[nD] : 0;
       const vG = nG >= 0 ? solution[nG] : 0;
       const vS = nS >= 0 ? solution[nS] : 0;
 
       // Internal voltages adjusted for polarity (PMOS flips)
-      const vGS = polarity * (vG - vS);
-      const vDS = polarity * (vD - vS);
+      let vGS = polarity * (vG - vS);
+      let vDS = polarity * (vD - vS);
+
+      // Source-drain swap for negative vDS
+      if (vDS < 0) {
+        const tmp = nD;
+        nD = nS;
+        nS = tmp;
+        vGS = vGS - vDS;
+        vDS = -vDS;
+      }
 
       const Vth = Math.abs(VTO);
 
@@ -174,7 +189,7 @@ export class MOSFET implements DeviceModel {
       // NR companion: Ieq = ID0 - gm*VGS0 - gds*VDS0
       const Ieq = ID - gm * vGS - gds * vDS;
 
-      // Stamp drain row (current into drain) — direct array writes
+      // Stamp drain row — direct array writes using (possibly swapped) nD, nS
       if (nD >= 0) {
         if (nG >= 0) gValues[posMap[nD * n + nG]] += gm;
         if (nD >= 0) gValues[posMap[nD * n + nD]] += gds;
@@ -182,7 +197,7 @@ export class MOSFET implements DeviceModel {
         b[nD] -= polarity * Ieq;
       }
 
-      // Stamp source row (current into source = -current into drain)
+      // Stamp source row
       if (nS >= 0) {
         if (nG >= 0) gValues[posMap[nS * n + nG]] -= gm;
         if (nD >= 0) gValues[posMap[nS * n + nD]] -= gds;

--- a/packages/core/src/mna/companion.ts
+++ b/packages/core/src/mna/companion.ts
@@ -8,6 +8,12 @@ import { MOSFET } from '../devices/mosfet.js';
  *
  * Backward Euler: (G + C/dt) * x(n+1) = b(n+1) + (C/dt) * x(n)
  * Trapezoidal:    (G + 2C/dt) * x(n+1) = b(n+1) + b(n) + (2C/dt - G) * x(n)
+ *
+ * IMPORTANT: For the trapezoidal method, the history terms (b(n) - G*x(n))
+ * are only applied to DYNAMIC rows (rows with non-zero C entries). Algebraic
+ * rows (C=0) are solved as G*x(n+1) = b(n+1) without history coupling. This
+ * prevents NR oscillation on nonlinear algebraic equations (e.g., diode KCL
+ * at nodes without capacitors).
  */
 export function buildCompanionSystem(
   assembler: MNAAssembler,
@@ -22,7 +28,7 @@ export function buildCompanionSystem(
   assembler.clear();
   const ctx = assembler.getStampContext();
 
-  if (assembler.isFastPath) {
+  if (assembler.isFastPath && assembler.posMap.length > 0) {
     // Batch-stamp MOSFETs with direct array writes, fall back for others
     let hasMosfets = false;
     const mosfets: MOSFET[] = [];
@@ -79,14 +85,23 @@ export function buildCompanionSystem(
       }
     } else {
       // Trapezoidal: G_eff = G + 2C/dt
-      // b_eff = b(n+1) + b(n) + (2C/dt)*x(n) - G*x(n)
+      // b_eff depends on whether a row is dynamic (C≠0) or algebraic (C=0):
+      //   Dynamic: b(n+1) + (2C/dt)*x(n) - G*x(n) + b(n)
+      //   Algebraic: b(n+1) only
       const factor = 2 / dt;
       const nnz = colPtr[n];
+
+      // Determine which rows have dynamic (C≠0) entries
+      const isDynamic = new Uint8Array(n);
+      for (let p = 0; p < nnz; p++) {
+        if (cv[p] !== 0) isDynamic[rowIdx[p]] = 1;
+      }
 
       // Save b(n+1) before modification
       const bCurrent = new Float64Array(b);
 
       // Compute G*x(n) before modifying G — CSC SpMV
+      // Only needed for dynamic rows, but computing for all is simpler
       const Gx = new Float64Array(n);
       for (let j = 0; j < n; j++) {
         const xj = prevSolution[j];
@@ -99,13 +114,13 @@ export function buildCompanionSystem(
       // G_eff = G + 2C/dt (one tight loop)
       for (let i = 0; i < nnz; i++) gv[i] += factor * cv[i];
 
-      // Build b_eff = b(n+1) + (2C/dt)*x(n) - G*x(n) + b(n)
+      // Build b_eff
       b.fill(0);
 
-      // Start with b(n+1)
+      // Start with b(n+1) for all rows
       for (let i = 0; i < n; i++) b[i] = bCurrent[i];
 
-      // Add (2C/dt)*x(n) — CSC SpMV
+      // Add (2C/dt)*x(n) — CSC SpMV (only affects dynamic rows via cv)
       for (let j = 0; j < n; j++) {
         const xj = prevSolution[j];
         if (xj === 0) continue;
@@ -114,10 +129,12 @@ export function buildCompanionSystem(
         }
       }
 
-      // Subtract G*x(n) and add b(n)
+      // Subtract G*x(n) and add b(n) ONLY for dynamic rows
       for (let i = 0; i < n; i++) {
-        b[i] -= Gx[i];
-        if (prevB) b[i] += prevB[i];
+        if (isDynamic[i]) {
+          b[i] -= Gx[i];
+          if (prevB) b[i] += prevB[i];
+        }
       }
     }
   } else {
@@ -141,8 +158,7 @@ export function buildCompanionSystem(
       }
     } else {
       // Trapezoidal: G_eff = G + 2C/dt
-      // b_eff = b(n+1) + b(n) + (2C/dt - G)*x(n)
-      //       = b(n+1) + b(n) + (2C/dt)*x(n) - G*x(n)
+      // History terms only for dynamic rows (C≠0)
       const factor = 2 / dt;
 
       // Save b(n+1) and G before modification
@@ -160,23 +176,25 @@ export function buildCompanionSystem(
       // Modify G: G_eff = G + 2C/dt
       assembler.G.addMatrix(assembler.C, factor);
 
-      // Build b_eff = b(n+1) + (2C/dt)*x(n) - G*x(n) + b(n)
+      // Build b_eff
       assembler.b.fill(0);
       for (let i = 0; i < assembler.systemSize; i++) {
         assembler.b[i] = bCurrent[i]; // b(n+1)
 
-        // Add (2C/dt)*x(n)
-        const row = assembler.C.getRow(i);
-        for (const [j, cval] of row) {
+        const cRow = assembler.C.getRow(i);
+        const hasDynamic = cRow.size > 0;
+
+        // Add (2C/dt)*x(n) for dynamic rows
+        for (const [j, cval] of cRow) {
           assembler.b[i] += factor * cval * prevSolution[j];
         }
 
-        // Subtract G*x(n)
-        assembler.b[i] -= Gx[i];
-
-        // Add b(n)
-        if (prevB) {
-          assembler.b[i] += prevB[i];
+        // Subtract G*x(n) and add b(n) ONLY for dynamic rows
+        if (hasDynamic) {
+          assembler.b[i] -= Gx[i];
+          if (prevB) {
+            assembler.b[i] += prevB[i];
+          }
         }
       }
     }

--- a/packages/core/src/simulate.ts
+++ b/packages/core/src/simulate.ts
@@ -157,7 +157,8 @@ function validateCircuit(compiled: CompiledCircuit, warnings: SimulationWarning[
   }
 }
 
-const MIN_TIMESTEP = 1e-18;
+const MIN_TIMESTEP = 1e-15;
+const NR_VOLTAGE_LIMIT = 3.5;
 
 function* streamTransient(
   compiled: CompiledCircuit,
@@ -179,6 +180,11 @@ function* streamTransient(
 
   const solver = createSparseSolver();
   let patternAnalyzed = false;
+
+  // LTE history tracking
+  let secondPrevSol: Float64Array | undefined;
+  let prevDt = dt;
+  let lteRejectCount = 0;
 
   // Compute initial b(0) for trapezoidal history on the first step
   let prevB: Float64Array | undefined;
@@ -210,7 +216,15 @@ function* streamTransient(
       solver.factorize(assembler.getCscMatrix());
       const x = solver.solve(new Float64Array(assembler.b));
 
+      // NR damping: limit node-voltage change per iteration
       const prev = new Float64Array(assembler.solution);
+      for (let i = 0; i < nodeCount; i++) {
+        const delta = x[i] - prev[i];
+        if (Math.abs(delta) > NR_VOLTAGE_LIMIT) {
+          x[i] = prev[i] + Math.sign(delta) * NR_VOLTAGE_LIMIT;
+        }
+      }
+
       assembler.solution.set(x);
 
       if (isStreamConverged(x, prev, nodeCount, options)) {
@@ -220,12 +234,29 @@ function* streamTransient(
     }
 
     if (!converged) {
-      dt = dt / 4;
+      dt = dt / 2;
       if (dt < MIN_TIMESTEP) {
         throw new TimestepTooSmallError(time, dt);
       }
       assembler.solution.set(prevSol);
       continue;
+    }
+
+    // LTE-based timestep control
+    let lteRatio = 0;
+    if (secondPrevSol && lteRejectCount < 10) {
+      lteRatio = streamEstimateLTE(
+        assembler.solution, prevSol, secondPrevSol,
+        actualDt, prevDt, nodeCount, options,
+      );
+      if (lteRatio > 1) {
+        const factor = Math.max(0.25, 0.9 / Math.sqrt(lteRatio));
+        dt = Math.max(actualDt * factor, MIN_TIMESTEP);
+        assembler.solution.set(prevSol);
+        lteRejectCount++;
+        continue;
+      }
+      lteRejectCount = 0;
     }
 
     // Save the DC-stamped b for trapezoidal history on next step
@@ -239,10 +270,43 @@ function* streamTransient(
     time = nextTime;
     yield buildTransientStep(time, assembler.solution, nodeNames, branchNames, nodeCount, nodeIndexMap);
 
-    // Adaptive: grow timestep if converged
-    dt = Math.min(dt * 1.5, maxDt, analysis.stopTime - time);
+    // Update LTE history
+    secondPrevSol = prevSol;
+    prevDt = actualDt;
+
+    // Adaptive: grow timestep based on LTE margin
+    const growFactor = lteRatio > 0.001
+      ? Math.min(2.0, 0.9 / Math.sqrt(lteRatio))
+      : 2.0;
+    dt = Math.min(actualDt * growFactor, maxDt, analysis.stopTime - time);
     if (dt < MIN_TIMESTEP && time < analysis.stopTime - MIN_TIMESTEP) break;
   }
+}
+
+function streamEstimateLTE(
+  current: Float64Array,
+  previous: Float64Array,
+  secondPrev: Float64Array,
+  dt: number,
+  prevDt: number,
+  nodeCount: number,
+  options: ResolvedOptions,
+): number {
+  let maxRatio = 0;
+  const divider = options.integrationMethod === 'trapezoidal' ? 3 : 2;
+
+  for (let i = 0; i < nodeCount; i++) {
+    const slope = (previous[i] - secondPrev[i]) / prevDt;
+    const predicted = previous[i] + dt * slope;
+    const error = Math.abs(current[i] - predicted) / divider;
+    const tol = options.trtol * (options.vntol + options.reltol * Math.abs(current[i]));
+    if (tol > 0) {
+      const ratio = error / tol;
+      if (ratio > maxRatio) maxRatio = ratio;
+    }
+  }
+
+  return maxRatio;
 }
 
 function buildTransientStep(


### PR DESCRIPTION
## Summary

- **MOSFET source-drain reversal** (root cause of #24): Level 1 model now swaps drain/source internally when `vDS < 0`, fixing wrong DC operating points (25V on a 5V supply) caused by `(1 + LAMBDA*vDS)` going to zero
- **Trapezoidal companion fix** (root cause of #25): History terms are now applied only to dynamic rows (non-zero C entries), eliminating NR oscillation on nonlinear algebraic equations at nodes without capacitors
- **Timestep control hardening**: Raised `MIN_TIMESTEP` to 1e-15, added NR voltage damping, added LTE-based step rejection, reduced dt shrink factor from /4 to /2

Closes #24, closes #25

## Test plan

- [x] New regression test: half-wave rectifier with SIN source completes without `TimestepTooSmallError`
- [x] New regression test: CMOS inverter output stays within supply rails (< 6.5V on 5V supply)
- [x] All 303 existing tests pass (34 test files)
- [x] Build succeeds (ESM, CJS, DTS)
- [x] CMOS inverter example (`04-cmos-inverter.ts`) runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mfiumara/spice-ts/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
