### PR TITLE
feat(ui): node-ranking schematic layout with intermediate-node fix

### DIFF
--- a/examples/showcase/package.json
+++ b/examples/showcase/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "typescript": "^5.4.0",
     "vite": "^8.0.8"
   }

--- a/examples/showcase/vite.config.ts
+++ b/examples/showcase/vite.config.ts
@@ -1,7 +1,19 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+
+const r = (p: string) => fileURLToPath(new URL(p, import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_PATH || '/spice-ts/',
+  // Alias workspace packages to their TS source so `vite dev` hot-reloads on
+  // edits in packages/*/src instead of serving the stale dist/ output.
+  resolve: {
+    alias: [
+      { find: '@spice-ts/ui/react', replacement: r('../../packages/ui/src/react/index.ts') },
+      { find: /^@spice-ts\/ui$/,    replacement: r('../../packages/ui/src/index.ts') },
+      { find: '@spice-ts/core',     replacement: r('../../packages/core/src/index.ts') },
+    ],
+  },
 });

--- a/packages/ui/src/react/SchematicView.tsx
+++ b/packages/ui/src/react/SchematicView.tsx
@@ -112,7 +112,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
 
         {/* Components */}
         {layout.components.map((pc, ci) => {
-          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '');
+          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal);
           return (
             <g key={ci} transform={`translate(${pc.x},${pc.y})`}
               style={{ cursor: 'pointer' }}
@@ -150,7 +150,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
           pc.pins.flatMap((p, pi) => {
             if (p.net !== '0') return [];
             const gnd = groundSymbol();
-            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '');
+            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal);
             const symPin = pi < compSym.pins.length ? compSym.pins[pi] : null;
             const isSidePin = symPin !== null && (symPin.dx <= 1 || symPin.dx >= compSym.width - 1);
             const stubLen = GRID * 1.5;

--- a/packages/ui/src/react/SchematicView.tsx
+++ b/packages/ui/src/react/SchematicView.tsx
@@ -112,7 +112,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
 
         {/* Components */}
         {layout.components.map((pc, ci) => {
-          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH);
+          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW);
           return (
             <g key={ci} transform={`translate(${pc.x},${pc.y})`}
               style={{ cursor: 'pointer' }}
@@ -150,7 +150,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
           pc.pins.flatMap((p, pi) => {
             if (p.net !== '0') return [];
             const gnd = groundSymbol();
-            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH);
+            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW);
             const symPin = pi < compSym.pins.length ? compSym.pins[pi] : null;
             const isSidePin = symPin !== null && (symPin.dx <= 1 || symPin.dx >= compSym.width - 1);
             const stubLen = GRID * 1.5;

--- a/packages/ui/src/react/SchematicView.tsx
+++ b/packages/ui/src/react/SchematicView.tsx
@@ -112,7 +112,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
 
         {/* Components */}
         {layout.components.map((pc, ci) => {
-          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW);
+          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW, pc.flipped);
           return (
             <g key={ci} transform={`translate(${pc.x},${pc.y})`}
               style={{ cursor: 'pointer' }}
@@ -150,7 +150,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
           pc.pins.flatMap((p, pi) => {
             if (p.net !== '0') return [];
             const gnd = groundSymbol();
-            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW);
+            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW, pc.flipped);
             const symPin = pi < compSym.pins.length ? compSym.pins[pi] : null;
             const isSidePin = symPin !== null && (symPin.dx <= 1 || symPin.dx >= compSym.width - 1);
             const stubLen = GRID * 1.5;

--- a/packages/ui/src/react/SchematicView.tsx
+++ b/packages/ui/src/react/SchematicView.tsx
@@ -112,7 +112,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
 
         {/* Components */}
         {layout.components.map((pc, ci) => {
-          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal);
+          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH);
           return (
             <g key={ci} transform={`translate(${pc.x},${pc.y})`}
               style={{ cursor: 'pointer' }}
@@ -150,7 +150,7 @@ export function SchematicView({ circuit, theme, width = '100%', height = 400, on
           pc.pins.flatMap((p, pi) => {
             if (p.net !== '0') return [];
             const gnd = groundSymbol();
-            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal);
+            const compSym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH);
             const symPin = pi < compSym.pins.length ? compSym.pins[pi] : null;
             const isSidePin = symPin !== null && (symPin.dx <= 1 || symPin.dx >= compSym.width - 1);
             const stubLen = GRID * 1.5;

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -14,7 +14,7 @@ function makeCircuit(...components: CircuitIR['components']): CircuitIR {
 }
 
 describe('layoutSchematic', () => {
-  it('lays out voltage divider left-to-right', () => {
+  it('places all components and produces valid bounds', () => {
     const circuit = makeCircuit(
       { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
       { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'out' }], params: { resistance: 1000 }, displayValue: '1k' },
@@ -25,12 +25,6 @@ describe('layoutSchematic', () => {
     expect(layout.components).toHaveLength(3);
     expect(layout.bounds.width).toBeGreaterThan(0);
     expect(layout.bounds.height).toBeGreaterThan(0);
-
-    const v1 = layout.components.find(c => c.component.name === 'V1')!;
-    const r1 = layout.components.find(c => c.component.name === 'R1')!;
-    const r2 = layout.components.find(c => c.component.name === 'R2')!;
-    expect(v1.x).toBeLessThan(r1.x);
-    expect(r1.x).toBeLessThanOrEqual(r2.x);
   });
 
   it('produces wires connecting components on the same net', () => {
@@ -45,7 +39,7 @@ describe('layoutSchematic', () => {
     expect(inWire).toBeDefined();
   });
 
-  it('places ground symbols at bottom', () => {
+  it('ranks ground lower than source positive terminal (higher Y)', () => {
     const circuit = makeCircuit(
       { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: '1' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
       { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: '1' }, { name: 'n', net: '0' }], params: { resistance: 1000 }, displayValue: '1k' },
@@ -72,30 +66,23 @@ describe('layoutSchematic', () => {
     const layout = layoutSchematic(circuit);
     const m1 = layout.components.find(c => c.component.id === 'M1')!;
 
-    // drain pin (port 0) should be at right upper (higher x than gate)
-    // gate pin (port 1) should be at left center (lower x)
-    const drainPin = m1.pins[0]; // drain
-    const gatePin = m1.pins[1];  // gate
+    // drain pin (port 0) should be at higher x than gate (port 1)
+    const drainPin = m1.pins[0];
+    const gatePin = m1.pins[1];
     expect(drainPin.x).toBeGreaterThan(gatePin.x);
   });
 
-  it('aligns MOSFET by gate pin (input), not drain', () => {
+  it('places components spanning same ranks side by side', () => {
     const circuit = makeCircuit(
       { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
-      { type: 'M', id: 'M1', name: 'M1', ports: [
-        { name: 'drain', net: 'vdd' },
-        { name: 'gate', net: 'in' },
-        { name: 'source', net: '0' },
-      ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+      { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { resistance: 1000 }, displayValue: '1k' },
     );
     const layout = layoutSchematic(circuit);
-    const v1 = layout.components.find(c => c.component.id === 'V1')!;
-    const m1 = layout.components.find(c => c.component.id === 'M1')!;
 
-    // V1's positive pin and M1's gate pin should be on the same signal rail (same Y)
-    const v1Signal = v1.pins.find(p => p.net === 'in')!;
-    const m1Gate = m1.pins.find(p => p.net === 'in')!;
-    expect(m1Gate.y).toBe(v1Signal.y);
+    const v1 = layout.components.find(c => c.component.id === 'V1')!;
+    const r1 = layout.components.find(c => c.component.id === 'R1')!;
+    // Different X (side by side), similar Y (same rank span)
+    expect(v1.x).not.toBe(r1.x);
   });
 
   it('handles empty circuit', () => {

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -119,17 +119,25 @@ describe('layoutSchematic', () => {
       return hSeg?.y1;
     }
 
-    it('assigns distinct vertical positions to in, gate, sw nets', () => {
+    it('keeps in, gate, and sw buses visually separated (different Y or disjoint x)', () => {
       const layout = layoutSchematic(makeBuckBoost());
-      const inY = horizontalBusY(layout, 'in');
-      const gateY = horizontalBusY(layout, 'gate');
-      const swY = horizontalBusY(layout, 'sw');
-
-      expect(inY).toBeDefined();
-      expect(gateY).toBeDefined();
-      expect(swY).toBeDefined();
-      const ys = new Set([inY, gateY, swY]);
-      expect(ys.size).toBe(3);
+      type H = { net: string; y: number; x1: number; x2: number };
+      const segs: H[] = [];
+      for (const w of layout.wires) {
+        for (const s of w.segments) {
+          if (s.y1 === s.y2 && (w.net === 'in' || w.net === 'gate' || w.net === 'sw')) {
+            segs.push({ net: w.net, y: s.y1, x1: Math.min(s.x1, s.x2), x2: Math.max(s.x1, s.x2) });
+          }
+        }
+      }
+      for (let i = 0; i < segs.length; i++) {
+        for (let j = i + 1; j < segs.length; j++) {
+          const a = segs[i], b = segs[j];
+          if (a.net === b.net || a.y !== b.y) continue;
+          const overlap = Math.min(a.x2, b.x2) - Math.max(a.x1, b.x1);
+          expect(overlap, `${a.net}/${b.net} overlap at y=${a.y}`).toBeLessThanOrEqual(0);
+        }
+      }
     });
 
     it('orders nets by potential: in above the sw/n1 rail (lower Y = higher on screen)', () => {

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -305,6 +305,29 @@ describe('layoutSchematic', () => {
       expect(xs[2]).toBeLessThan(xs[3]);
     });
 
+    it('Sallen-Key: feedback cap C1 stretches across the opamp feedback span', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 1 }, displayValue: 'AC 1' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'n1' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'R', id: 'R2', name: 'R2', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'n2' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'out' }], params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'C', id: 'C2', name: 'C2', ports: [{ name: 'p', net: 'n2' }, { name: 'n', net: '0' }],  params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'E', id: 'E1', name: 'E1', ports: [
+          { name: 'ctrlP', net: 'n2' },
+          { name: 'ctrlN', net: 'out' },
+          { name: 'outP',  net: 'out' },
+          { name: 'outN',  net: '0' },
+        ], params: { gain: 1e6 }, displayValue: '1e6' },
+      );
+      const layout = layoutSchematic(circuit);
+      const c1 = layout.components.find(c => c.component.id === 'C1')!;
+      // The feedback cap's two pins span from the leftmost n1 pin on the
+      // chain to the rightmost out pin at the opamp, so the loop visibly
+      // brackets the signal chain instead of sitting in one narrow column.
+      const capWidth = Math.abs(c1.pins[0].x - c1.pins[1].x);
+      expect(capWidth).toBeGreaterThan(GRID * 10);
+    });
+
     it('Sallen-Key: feedback cap C1 is elevated above the main signal rail', () => {
       // C1 connects n1 to out, both on the signal rail. Conventional
       // schematics draw it as a loop above the chain rather than in-line,

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -305,6 +305,29 @@ describe('layoutSchematic', () => {
       expect(xs[2]).toBeLessThan(xs[3]);
     });
 
+    it('Sallen-Key: feedback cap C1 is elevated above the main signal rail', () => {
+      // C1 connects n1 to out, both on the signal rail. Conventional
+      // schematics draw it as a loop above the chain rather than in-line,
+      // so C1's pins must sit at a smaller Y than R1/R2's pins.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 1 }, displayValue: 'AC 1' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'n1' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'R', id: 'R2', name: 'R2', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'n2' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'out' }], params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'C', id: 'C2', name: 'C2', ports: [{ name: 'p', net: 'n2' }, { name: 'n', net: '0' }],  params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'E', id: 'E1', name: 'E1', ports: [
+          { name: 'ctrlP', net: 'n2' },
+          { name: 'ctrlN', net: 'out' },
+          { name: 'outP',  net: 'out' },
+          { name: 'outN',  net: '0' },
+        ], params: { gain: 1e6 }, displayValue: '1e6' },
+      );
+      const layout = layoutSchematic(circuit);
+      const c1 = layout.components.find(c => c.component.id === 'C1')!;
+      const r1 = layout.components.find(c => c.component.id === 'R1')!;
+      expect(c1.pins[0].y).toBeLessThan(r1.pins[0].y - GRID * 2);
+    });
+
     it('Sallen-Key: in, n1, n2, and out all sit on one signal rail', () => {
       // Unity-gain VCVS: E1 pins outN=0 and ctrlN=out, so out is electrically
       // at the opamp's output — same DC potential as the input via feedback.

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -305,6 +305,31 @@ describe('layoutSchematic', () => {
       expect(xs[2]).toBeLessThan(xs[3]);
     });
 
+    it('Sallen-Key: in, n1, n2, and out all sit on one signal rail', () => {
+      // Unity-gain VCVS: E1 pins outN=0 and ctrlN=out, so out is electrically
+      // at the opamp's output — same DC potential as the input via feedback.
+      // Expect a single signal rail, not a second rank above it.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 1 }, displayValue: 'AC 1' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'n1' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'R', id: 'R2', name: 'R2', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'n2' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'out' }], params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'C', id: 'C2', name: 'C2', ports: [{ name: 'p', net: 'n2' }, { name: 'n', net: '0' }],  params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'E', id: 'E1', name: 'E1', ports: [
+          { name: 'ctrlP', net: 'n2' },
+          { name: 'ctrlN', net: 'out' },
+          { name: 'outP',  net: 'out' },
+          { name: 'outN',  net: '0' },
+        ], params: { gain: 1e6 }, displayValue: '1e6' },
+      );
+      const layout = layoutSchematic(circuit);
+      const y = (net: string) => horizontalBusY(layout, net);
+      const inY = y('in')!, n1Y = y('n1')!, n2Y = y('n2')!, outY = y('out')!;
+      for (const [a, b, name] of [[inY, n1Y, 'in/n1'], [n1Y, n2Y, 'n1/n2'], [n2Y, outY, 'n2/out']] as const) {
+        expect(Math.abs(a - b), `${name} not on same rail`).toBeLessThanOrEqual(GRID * 2);
+      }
+    });
+
     it('CMOS inverter: MP and MN stack in the same column', () => {
       const circuit = makeCircuit(
         { type: 'V', id: 'VDD', name: 'VDD', ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: '0' }], params: { dc: 1.8 }, displayValue: 'DC 1.8' },

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { layoutSchematic } from './layout.js';
-import { GRID } from './symbols.js';
+import { GRID, getSymbol } from './symbols.js';
 import type { CircuitIR } from './types.js';
 
 /** Helper to build a simple CircuitIR for testing. */
@@ -704,6 +704,38 @@ describe('layoutSchematic', () => {
         const yInBody = s.y1 >= vgBodyYMin && s.y1 <= vgBodyYMax;
         expect(xCrosses && yInBody, `in bus at y=${s.y1} x=[${xMin},${xMax}] crosses Vg body at x=${vgCenterX} y=[${vgBodyYMin},${vgBodyYMax}]`).toBe(false);
       }
+    });
+
+    it('diode with anode at lower rank flips its triangle so it points from anode to cathode', () => {
+      // A freewheel-style diode with anode=gnd (rank 0) and cathode=sw
+      // (higher rank) must render with the triangle apex at the TOP (cathode
+      // side) and the anode lead coming from the BOTTOM. Without flipping
+      // the symbol, the triangle points from cathode to anode — backwards.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'out' }], params: { resistance: 1 }, displayValue: '1' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: '0' }, { name: 'n', net: 'out' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+      );
+      const layout = layoutSchematic(circuit);
+      const d1 = layout.components.find(c => c.component.id === 'D1')!;
+      const anode = d1.pins.find(p => p.net === '0')!;
+      const cathode = d1.pins.find(p => p.net === 'out')!;
+      // Anode (ground) is physically below cathode.
+      expect(anode.y).toBeGreaterThan(cathode.y);
+      // The symbol's triangle path must now point UP (tip closer to cathode y
+      // than base). We detect this by checking the triangle path in the
+      // symbol: the tip y-coordinate sits above the base y-coordinate.
+      const sym = getSymbol('D', d1.component.displayValue ?? '', d1.horizontal ?? false, d1.stretchH, d1.stretchW, d1.flipped ?? false);
+      const trianglePath = sym.elements.find(el => el.tag === 'path')!;
+      const d = trianglePath.attrs.d as string;
+      // Triangle path format: M<x>,<y> L<x>,<y> L<x>,<y> Z. For a vertical
+      // diode flipped so triangle points up, the tip y is the SMALLEST y
+      // among the three points (tip at top, base spans across bottom).
+      const matches = [...d.matchAll(/[ML]\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)/g)];
+      const ys = matches.map(m => parseFloat(m[2]));
+      const tipY = ys[2]; // third point is the tip in our M L L Z pattern
+      const baseY1 = ys[0], baseY2 = ys[1];
+      expect(tipY).toBeLessThan(Math.min(baseY1, baseY2));
     });
 
     it('buck converter: freewheel diode D1 (anode=0, cathode=sw) draws vertically', () => {

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -254,6 +254,21 @@ describe('layoutSchematic', () => {
       expect(inY).toBeLessThan(outY);
     });
 
+    it('RC low-pass: V1, R1, C1 top pins all sit on a single horizontal rail', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'out' }], params: { resistance: 1000 }, displayValue: '1k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-9 }, displayValue: '100n' },
+      );
+      const layout = layoutSchematic(circuit);
+      const v1in = layout.components.find(c => c.component.id === 'V1')!.pins.find(p => p.net === 'in')!;
+      const r1in = layout.components.find(c => c.component.id === 'R1')!.pins.find(p => p.net === 'in')!;
+      const r1out = layout.components.find(c => c.component.id === 'R1')!.pins.find(p => p.net === 'out')!;
+      const c1out = layout.components.find(c => c.component.id === 'C1')!.pins.find(p => p.net === 'out')!;
+      expect(v1in.y).toBe(r1in.y);
+      expect(r1out.y).toBe(c1out.y);
+    });
+
     it('RC low-pass: components flow V1 → R1 → C1 from left to right', () => {
       const circuit = makeCircuit(
         { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -250,16 +250,18 @@ describe('layoutSchematic', () => {
 
     it('voltage divider: R in a DC loop stays rank-differentiating', () => {
       // V-R1-R2-gnd: removing either R leaves a DC path via the other R and V,
-      // so both R's carry DC current and must separate ranks.
+      // so both R's carry DC current and must separate ranks. R1 and R2 stack
+      // in one column so the `out` tap between them sits strictly below `in`.
       const circuit = makeCircuit(
         { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
         { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'out' }], params: { resistance: 1000 }, displayValue: '1k' },
         { type: 'R', id: 'R2', name: 'R2', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }],  params: { resistance: 2000 }, displayValue: '2k' },
       );
       const layout = layoutSchematic(circuit);
-      const inY  = horizontalBusY(layout, 'in')!;
-      const outY = horizontalBusY(layout, 'out')!;
-      expect(inY).toBeLessThan(outY);
+      const r1 = layout.components.find(c => c.component.id === 'R1')!;
+      const inPinY = r1.pins.find(p => p.net === 'in')!.y;
+      const outPinY = r1.pins.find(p => p.net === 'out')!.y;
+      expect(inPinY).toBeLessThan(outPinY);
     });
 
     it('RC low-pass: V1, R1, C1 top pins all sit on a single horizontal rail', () => {
@@ -374,6 +376,483 @@ describe('layoutSchematic', () => {
       for (const [a, b, name] of [[inY, n1Y, 'in/n1'], [n1Y, n2Y, 'n1/n2'], [n2Y, outY, 'n2/out']] as const) {
         expect(Math.abs(a - b), `${name} not on same rail`).toBeLessThanOrEqual(GRID * 2);
       }
+    });
+
+    it('Sallen-Key: no wire segments cross at the opamp inputs', () => {
+      // When -in and +in connect to different nets whose buses sit on the
+      // same side of the opamp, the drop-wires must neither overlap (same x)
+      // nor cross (one net's drop passing through another's bus). This test
+      // checks the stronger property: for any two distinct-net segments
+      // (one vertical, one horizontal), they don't intersect in the plane.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 1 }, displayValue: 'AC 1' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'n1' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'R', id: 'R2', name: 'R2', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'n2' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'out' }], params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'C', id: 'C2', name: 'C2', ports: [{ name: 'p', net: 'n2' }, { name: 'n', net: '0' }],  params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'E', id: 'E1', name: 'E1', ports: [
+          { name: 'ctrlP', net: 'n2' },
+          { name: 'ctrlN', net: 'out' },
+          { name: 'outP',  net: 'out' },
+          { name: 'outN',  net: '0' },
+        ], params: { gain: 1e6 }, displayValue: '1e6' },
+      );
+      const layout = layoutSchematic(circuit);
+      type Seg = { net: string; x1: number; y1: number; x2: number; y2: number };
+      const segs: Seg[] = [];
+      for (const w of layout.wires) for (const s of w.segments) segs.push({ net: w.net, ...s });
+      for (let i = 0; i < segs.length; i++) {
+        for (let j = i + 1; j < segs.length; j++) {
+          const a = segs[i], b = segs[j];
+          if (a.net === b.net) continue;
+          const aH = a.y1 === a.y2, bH = b.y1 === b.y2;
+          if (aH === bH) continue; // both horizontal or both vertical — skip
+          const h = aH ? a : b, v = aH ? b : a;
+          const xMin = Math.min(h.x1, h.x2), xMax = Math.max(h.x1, h.x2);
+          const yMin = Math.min(v.y1, v.y2), yMax = Math.max(v.y1, v.y2);
+          // Strict interior intersection (endpoints touching is fine).
+          const xi = v.x1, yi = h.y1;
+          if (xi > xMin && xi < xMax && yi > yMin && yi < yMax) {
+            throw new Error(`Crossing at (${xi},${yi}): net ${h.net} horizontal crosses net ${v.net} vertical`);
+          }
+        }
+      }
+    });
+
+    it('Sallen-Key: opamp input pins do not share an x-coordinate', () => {
+      // ctrlP (+in) connects to n2 whose bus is above the opamp; ctrlN (-in)
+      // connects to out whose bus is also above. If both pins sit at the same
+      // x, their vertical drop-wires to those two different buses run atop
+      // each other and visually merge into one line. The symbol must separate
+      // them horizontally so each drop has its own corridor.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 1 }, displayValue: 'AC 1' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'n1' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'R', id: 'R2', name: 'R2', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'n2' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'out' }], params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'C', id: 'C2', name: 'C2', ports: [{ name: 'p', net: 'n2' }, { name: 'n', net: '0' }],  params: { capacitance: 10e-9 }, displayValue: '10n' },
+        { type: 'E', id: 'E1', name: 'E1', ports: [
+          { name: 'ctrlP', net: 'n2' },
+          { name: 'ctrlN', net: 'out' },
+          { name: 'outP',  net: 'out' },
+          { name: 'outN',  net: '0' },
+        ], params: { gain: 1e6 }, displayValue: '1e6' },
+      );
+      const layout = layoutSchematic(circuit);
+      const e1 = layout.components.find(c => c.component.id === 'E1')!;
+      const ctrlP = e1.pins[0], ctrlN = e1.pins[1];
+      expect(ctrlP.x).not.toBe(ctrlN.x);
+    });
+
+    it('half-wave rectifier: out rail sits above ground, not collapsed onto it', () => {
+      // Rl carries the rectified DC current from out to ground through the
+      // diode path V1→0 ... anode←D1←out. Without diodes treated as DC-
+      // conductive, the DC-path check for Rl falsely concludes there's no
+      // other route from out to 0 and marks Rl rank-preserving. That collapses
+      // 'out' onto the ground rank, drawing Rl and Cl horizontally along the
+      // bus — so the horizontal out-bus wire runs through Rl's body.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 5 }, displayValue: 'SIN 0 5 1k' },
+        { type: 'R', id: 'Rs', name: 'Rs', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'anode' }], params: { resistance: 10 }, displayValue: '10' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: 'anode' }, { name: 'n', net: 'out' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'R', id: 'Rl', name: 'Rl', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'Cl', name: 'Cl', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 10e-6 }, displayValue: '10u' },
+      );
+      const layout = layoutSchematic(circuit);
+      const rl = layout.components.find(c => c.component.id === 'Rl')!;
+      const outPin = rl.pins.find(p => p.net === 'out')!;
+      const gndPin = rl.pins.find(p => p.net === '0')!;
+      // Sanity: the ground pin sits visibly below the out pin (load resistor
+      // drops its current toward ground, not collapsed onto the ground rail).
+      expect(gndPin.y).toBeGreaterThan(outPin.y);
+    });
+
+    it('half-wave rectifier: Rl draws vertically between out rail and ground', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 5 }, displayValue: 'SIN 0 5 1k' },
+        { type: 'R', id: 'Rs', name: 'Rs', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'anode' }], params: { resistance: 10 }, displayValue: '10' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: 'anode' }, { name: 'n', net: 'out' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'R', id: 'Rl', name: 'Rl', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'Cl', name: 'Cl', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 10e-6 }, displayValue: '10u' },
+      );
+      const layout = layoutSchematic(circuit);
+      const rl = layout.components.find(c => c.component.id === 'Rl')!;
+      const outPin = rl.pins.find(p => p.net === 'out')!;
+      const gndPin = rl.pins.find(p => p.net === '0')!;
+      // A vertical resistor has its rail-side pin strictly above its ground
+      // pin (pin-Y differs by the full rank span, not both sitting on a
+      // horizontal body).
+      expect(outPin.y).toBeLessThan(gndPin.y - GRID);
+    });
+
+    it('half-wave rectifier: V1, Rl, and Cl ground pins share a single ground rail Y', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { ac: 5 }, displayValue: 'SIN 0 5 1k' },
+        { type: 'R', id: 'Rs', name: 'Rs', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'anode' }], params: { resistance: 10 }, displayValue: '10' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: 'anode' }, { name: 'n', net: 'out' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'R', id: 'Rl', name: 'Rl', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'C', id: 'Cl', name: 'Cl', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 10e-6 }, displayValue: '10u' },
+      );
+      const layout = layoutSchematic(circuit);
+      const gnds = ['V1', 'Rl', 'Cl'].map(id =>
+        layout.components.find(c => c.component.id === id)!.pins.find(p => p.net === '0')!.y
+      );
+      for (let i = 1; i < gnds.length; i++) expect(gnds[i]).toBe(gnds[0]);
+    });
+
+    it('buck/boost converter: horizontal buses do not pass through V-source bodies', () => {
+      // A common same-rank topology has multiple V sources driving different
+      // input nets (Vin for the supply, Vg for the gate). Horizontal buses
+      // between other components must skirt above the V-source bodies, which
+      // hang from the rail down to ground.
+      function check(circuit: CircuitIR) {
+        const layout = layoutSchematic(circuit);
+        const vBodies: Array<{ x1: number; x2: number; y1: number; y2: number }> = [];
+        for (const pc of layout.components) {
+          if (pc.component.type !== 'V' && pc.component.type !== 'I') continue;
+          const xs = pc.pins.map(p => p.x);
+          const ys = pc.pins.map(p => p.y);
+          // The actual symbol body is a circle of ~GRID*0.9 radius centered
+          // between the pins; long connecting leads stretch between the body
+          // and each pin when the source spans multiple ranks. A bus crossing
+          // a lead is acceptable (standard no-junction crossing); crossing
+          // the body circle is not.
+          const yMin = Math.min(...ys), yMax = Math.max(...ys);
+          const center = (yMin + yMax) / 2;
+          const half = Math.min((yMax - yMin) / 2, GRID * 0.9);
+          vBodies.push({ x1: Math.min(...xs), x2: Math.max(...xs), y1: center - half, y2: center + half });
+        }
+        const vPins = new Set<string>();
+        for (const pc of layout.components) {
+          if (pc.component.type !== 'V' && pc.component.type !== 'I') continue;
+          for (const p of pc.pins) vPins.add(`${p.x},${p.y}`);
+        }
+        for (const w of layout.wires) {
+          for (const s of w.segments) {
+            if (s.y1 !== s.y2) continue; // only horizontal bus segments
+            const x1 = Math.min(s.x1, s.x2), x2 = Math.max(s.x1, s.x2);
+            for (const b of vBodies) {
+              if (s.y1 <= b.y1 || s.y1 >= b.y2) continue;
+              if (x2 <= b.x1 || x1 >= b.x2) continue;
+              // The bus y is strictly inside the V body y-range AND x-ranges overlap.
+              const crossesVPin = vPins.has(`${b.x1},${s.y1}`) || vPins.has(`${b.x2},${s.y1}`);
+              if (!crossesVPin) {
+                throw new Error(`wire on net ${w.net} at y=${s.y1} crosses through V body [${b.x1}..${b.x2}, ${b.y1}..${b.y2}]`);
+              }
+            }
+          }
+        }
+      }
+      check(makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: 'in' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: '0' }, { name: 'n', net: 'sw' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      ));
+      check(makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'sw' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: '0' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      ));
+    });
+
+    it('buck converter: L1 inductor stays straight horizontal (no drops at its pins)', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: 'in' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: '0' }, { name: 'n', net: 'sw' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      );
+      const layout = layoutSchematic(circuit);
+      const l1 = layout.components.find(c => c.component.id === 'L1')!;
+      const swPin = l1.pins.find(p => p.net === 'sw')!;
+      const outPin = l1.pins.find(p => p.net === 'out')!;
+      // Both pins sit on the rail — neither net's bus should force a drop at
+      // the inductor ends.
+      const swBusY = layout.wires.find(w => w.net === 'sw')?.segments.find(s => s.y1 === s.y2)?.y1;
+      const outBusY = layout.wires.find(w => w.net === 'out')?.segments.find(s => s.y1 === s.y2)?.y1;
+      expect(swBusY).toBe(swPin.y);
+      expect(outBusY).toBe(outPin.y);
+    });
+
+    it('boost converter: L1 inductor and sw bus share the rail (no drops at its pins)', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'sw' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: '0' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      );
+      const layout = layoutSchematic(circuit);
+      const l1 = layout.components.find(c => c.component.id === 'L1')!;
+      const inPin = l1.pins.find(p => p.net === 'in')!;
+      const swPin = l1.pins.find(p => p.net === 'sw')!;
+      const inBusY = layout.wires.find(w => w.net === 'in')?.segments.find(s => s.y1 === s.y2)?.y1;
+      const swBusY = layout.wires.find(w => w.net === 'sw')?.segments.find(s => s.y1 === s.y2)?.y1;
+      expect(inBusY).toBe(inPin.y);
+      expect(swBusY).toBe(swPin.y);
+    });
+
+    it('buck converter: in bus does not route through M1 transistor body', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: 'in' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: '0' }, { name: 'n', net: 'sw' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      );
+      const layout = layoutSchematic(circuit);
+      const m1 = layout.components.find(c => c.component.id === 'M1')!;
+      // M1's symbol bounding box
+      const m1X1 = m1.x, m1X2 = m1.x + 50;  // MOSFET width 2.5*GRID
+      const m1Y1 = m1.y, m1Y2 = m1.y + 50;  // MOSFET height 2.5*GRID
+      const inWire = layout.wires.find(w => w.net === 'in')!;
+      for (const s of inWire.segments) {
+        if (s.y1 !== s.y2) continue; // only horizontal buses
+        const xMin = Math.min(s.x1, s.x2), xMax = Math.max(s.x1, s.x2);
+        const xOverlaps = xMax > m1X1 && xMin < m1X2;
+        const yStrictlyInside = s.y1 > m1Y1 && s.y1 < m1Y2;
+        const atPin = m1.pins.some(p => Math.abs(p.y - s.y1) < 1);
+        expect(!(xOverlaps && yStrictlyInside && !atPin), `in bus at y=${s.y1} routes through M1 body [${m1X1}..${m1X2}, ${m1Y1}..${m1Y2}]`).toBe(true);
+      }
+    });
+
+    it('buck-boost inverting: Rload draws vertically from neg rail down to ground', () => {
+      // In an inverting buck-boost, the output cap C1 sits on the `neg` rail
+      // and Rload pulls `neg` toward ground. Without a parallel DC path via
+      // other components, the rank heuristic wrongly collapses `neg` onto the
+      // ground rail — Rload ends up horizontal. A load resistor on a cap
+      // output must always draw vertically.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'in' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: 'sw' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'n1' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: '0' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' }, { name: 'n', net: 'neg' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'neg' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      );
+      const layout = layoutSchematic(circuit);
+      const rload = layout.components.find(c => c.component.id === 'Rload')!;
+      const negPin = rload.pins.find(p => p.net === 'neg')!;
+      const gndPin = rload.pins.find(p => p.net === '0')!;
+      // Pins on different Y (vertical body), ground strictly below neg.
+      expect(negPin.y).toBeLessThan(gndPin.y - GRID);
+    });
+
+    it('buck converter: in bus does not cross Vg source body', () => {
+      // In a buck converter with two V sources (Vin driving `in`, Vg driving
+      // `gate`), Vg gets stretched upward so its + pin lines up with the
+      // MOSFET gate. That stretches Vg's body across the `in` bus Y, so Vin
+      // must be placed to the RIGHT of Vg; otherwise Vin's bus runs through
+      // Vg's body.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: 'in' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: '0' }, { name: 'n', net: 'sw' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      );
+      const layout = layoutSchematic(circuit);
+      const vg = layout.components.find(c => c.component.id === 'Vg')!;
+      const vgBodyYMin = Math.min(vg.pins[0].y, vg.pins[1].y);
+      const vgBodyYMax = Math.max(vg.pins[0].y, vg.pins[1].y);
+      // V-source body circle is at pin-center x, use a tight horizontal band.
+      const vgCenterX = vg.pins[0].x;
+      const inWire = layout.wires.find(w => w.net === 'in')!;
+      for (const s of inWire.segments) {
+        if (s.y1 !== s.y2) continue;
+        const xMin = Math.min(s.x1, s.x2), xMax = Math.max(s.x1, s.x2);
+        const xCrosses = vgCenterX > xMin && vgCenterX < xMax;
+        const yInBody = s.y1 >= vgBodyYMin && s.y1 <= vgBodyYMax;
+        expect(xCrosses && yInBody, `in bus at y=${s.y1} x=[${xMin},${xMax}] crosses Vg body at x=${vgCenterX} y=[${vgBodyYMin},${vgBodyYMax}]`).toBe(false);
+      }
+    });
+
+    it('buck converter: freewheel diode D1 (anode=0, cathode=sw) draws vertically', () => {
+      // D1 bridges ground (rank 0) to the switch node (higher rank). A
+      // horizontal diode body would put both pins on a midline row with long
+      // drop-wires on each side. Drawing vertically keeps the cathode on the
+      // sw rail and the anode on the ground rail.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: 'in' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: '0' }, { name: 'n', net: 'sw' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      );
+      const layout = layoutSchematic(circuit);
+      const d1 = layout.components.find(c => c.component.id === 'D1')!;
+      const swPin = d1.pins.find(p => p.net === 'sw')!;
+      const gndPin = d1.pins.find(p => p.net === '0')!;
+      // Vertical diode: cathode on sw rail, anode strictly below on ground.
+      expect(swPin.y).toBeLessThan(gndPin.y - GRID);
+      // x-coordinates coincide (pins stacked, not side by side).
+      expect(swPin.x).toBe(gndPin.x);
+    });
+
+    it('buck converter: sw bus does not pass through L1 inductor body', () => {
+      // D1 (freewheel) sits on the sw node, same as M1.drain and L1.sw. If D1
+      // is placed to the RIGHT of L1, the horizontal sw bus connecting them
+      // runs visually through L1's body at the top rail — the inductor looks
+      // like "a line is going through it." Canonical buck draws D1 between M1
+      // and L1 so the bus stays on M1's side of L1.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'Vin', name: 'Vin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg', name: 'Vg', ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 }, displayValue: 'PULSE' },
+        { type: 'M', id: 'M1', name: 'M1', ports: [
+          { name: 'drain', net: 'sw' }, { name: 'gate', net: 'gate' },
+          { name: 'source', net: 'in' }, { name: 'bulk', net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'D', id: 'D1', name: 'D1', ports: [{ name: 'p', net: '0' }, { name: 'n', net: 'sw' }], params: { modelName: 'DMOD' }, displayValue: 'DMOD' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'sw' }, { name: 'n', net: 'out' }], params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { resistance: 10 }, displayValue: '10' },
+      );
+      const layout = layoutSchematic(circuit);
+      const l1 = layout.components.find(c => c.component.id === 'L1')!;
+      const l1SwPin = l1.pins.find(p => p.net === 'sw')!;
+      const l1OutPin = l1.pins.find(p => p.net === 'out')!;
+      const l1X1 = Math.min(l1SwPin.x, l1OutPin.x);
+      const l1X2 = Math.max(l1SwPin.x, l1OutPin.x);
+      const swWire = layout.wires.find(w => w.net === 'sw')!;
+      for (const s of swWire.segments) {
+        if (s.y1 !== s.y2) continue; // horizontal only
+        const xMin = Math.min(s.x1, s.x2), xMax = Math.max(s.x1, s.x2);
+        // Segments must not cross INTO L1's x-range (touching a pin is OK:
+        // xMax <= l1X1 or xMin >= l1X2).
+        const strictOverlap = xMax > l1X1 && xMin < l1X2;
+        expect(strictOverlap, `sw bus segment [${xMin},${xMax}] crosses L1 body [${l1X1},${l1X2}]`).toBe(false);
+      }
+    });
+
+    it('common-source amp: RD aligns horizontally with M1 drain (straight line)', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'VDD', name: 'VDD', ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'V', id: 'VGS', name: 'VGS', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }], params: { dc: 1.5 }, displayValue: 'AC 1' },
+        { type: 'M', id: 'M1',  name: 'M1',  ports: [
+          { name: 'drain',  net: 'out' },
+          { name: 'gate',   net: 'in' },
+          { name: 'source', net: '0' },
+          { name: 'bulk',   net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'R', id: 'RD',  name: 'RD',  ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: 'out' }], params: { resistance: 10000 }, displayValue: '10k' },
+      );
+      const layout = layoutSchematic(circuit);
+      const rd = layout.components.find(c => c.component.id === 'RD')!;
+      const m1 = layout.components.find(c => c.component.id === 'M1')!;
+      const rdOut = rd.pins.find(p => p.net === 'out')!;
+      const m1Drain = m1.pins.find(p => p.net === 'out')!;
+      // RD's bottom pin should sit directly above M1's drain — no horizontal
+      // jog in the out net between them.
+      expect(rdOut.x).toBe(m1Drain.x);
+    });
+
+    it('common-source amp: RD draws vertically between vdd rail and out', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'VDD', name: 'VDD', ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'V', id: 'VGS', name: 'VGS', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }], params: { dc: 1.5 }, displayValue: 'AC 1' },
+        { type: 'M', id: 'M1',  name: 'M1',  ports: [
+          { name: 'drain',  net: 'out' },
+          { name: 'gate',   net: 'in' },
+          { name: 'source', net: '0' },
+          { name: 'bulk',   net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'R', id: 'RD',  name: 'RD',  ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: 'out' }], params: { resistance: 10000 }, displayValue: '10k' },
+      );
+      const layout = layoutSchematic(circuit);
+      const rd = layout.components.find(c => c.component.id === 'RD')!;
+      const vddPin = rd.pins.find(p => p.net === 'vdd')!;
+      const outPin = rd.pins.find(p => p.net === 'out')!;
+      expect(vddPin.y).toBeLessThan(outPin.y - GRID);
+    });
+
+    it('inverting amp: Rin lies on the main signal rail (straight line into opamp -in)', () => {
+      // Rin connects V1+ to the opamp's -in. With the feedback resistor Rf
+      // closing the loop from -in back to out, Rin must stay on the same
+      // horizontal rail as V1 and the opamp's -in — no detour above or below.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 0.1 }, displayValue: 'PULSE' },
+        { type: 'R', id: 'Rin', name: 'Rin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'nm' }], params: { resistance: 1000 }, displayValue: '1k' },
+        { type: 'R', id: 'Rf', name: 'Rf', ports: [{ name: 'p', net: 'nm' }, { name: 'n', net: 'out' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'E', id: 'E1', name: 'E1', ports: [
+          { name: 'ctrlP', net: '0' }, { name: 'ctrlN', net: 'nm' },
+          { name: 'outP',  net: 'out' }, { name: 'outN',  net: '0' },
+        ], params: { gain: 1e6 }, displayValue: '1e6' },
+      );
+      const layout = layoutSchematic(circuit);
+      const v1 = layout.components.find(c => c.component.id === 'V1')!;
+      const rin = layout.components.find(c => c.component.id === 'Rin')!;
+      const e1 = layout.components.find(c => c.component.id === 'E1')!;
+      const v1InPin = v1.pins.find(p => p.net === 'in')!;
+      const rinInPin = rin.pins.find(p => p.net === 'in')!;
+      const rinNmPin = rin.pins.find(p => p.net === 'nm')!;
+      const e1NmPin = e1.pins.find(p => p.net === 'nm')!;
+      // V1+ and Rin's in pin on same rail
+      expect(Math.abs(v1InPin.y - rinInPin.y)).toBeLessThanOrEqual(GRID);
+      // Rin's two pins on same Y (horizontal body)
+      expect(rinInPin.y).toBe(rinNmPin.y);
+      // Rin's nm pin and opamp's -in pin on the same rail (± one grid for the
+      // opamp lead offset we added earlier).
+      expect(Math.abs(rinNmPin.y - e1NmPin.y)).toBeLessThanOrEqual(GRID * 2);
+    });
+
+    it('inverting amp: Rf is elevated as a feedback loop above the rail', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 0.1 }, displayValue: 'PULSE' },
+        { type: 'R', id: 'Rin', name: 'Rin', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'nm' }], params: { resistance: 1000 }, displayValue: '1k' },
+        { type: 'R', id: 'Rf', name: 'Rf', ports: [{ name: 'p', net: 'nm' }, { name: 'n', net: 'out' }], params: { resistance: 10000 }, displayValue: '10k' },
+        { type: 'E', id: 'E1', name: 'E1', ports: [
+          { name: 'ctrlP', net: '0' }, { name: 'ctrlN', net: 'nm' },
+          { name: 'outP',  net: 'out' }, { name: 'outN',  net: '0' },
+        ], params: { gain: 1e6 }, displayValue: '1e6' },
+      );
+      const layout = layoutSchematic(circuit);
+      const rin = layout.components.find(c => c.component.id === 'Rin')!;
+      const rf = layout.components.find(c => c.component.id === 'Rf')!;
+      expect(rf.pins[0].y).toBeLessThan(rin.pins[0].y - GRID * 2);
     });
 
     it('CMOS inverter: MP and MN stack in the same column', () => {

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -92,4 +92,94 @@ describe('layoutSchematic', () => {
     expect(layout.bounds.width).toBe(0);
     expect(layout.bounds.height).toBe(0);
   });
+
+  describe('buck-boost inverting topology', () => {
+    function makeBuckBoost(): CircuitIR {
+      return makeCircuit(
+        { type: 'V', id: 'Vin',   name: 'Vin',   ports: [{ name: 'p', net: 'in' },   { name: 'n', net: '0' }], params: { dc: 12 }, displayValue: 'DC 12' },
+        { type: 'V', id: 'Vg',    name: 'Vg',    ports: [{ name: 'p', net: 'gate' }, { name: 'n', net: '0' }], params: { dc: 0 },  displayValue: 'PULSE' },
+        { type: 'M', id: 'M1',    name: 'M1',    ports: [
+          { name: 'drain',  net: 'in' },
+          { name: 'gate',   net: 'gate' },
+          { name: 'source', net: 'sw' },
+          { name: 'bulk',   net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'L', id: 'L1',    name: 'L1',    ports: [{ name: 'p', net: 'sw' },   { name: 'n', net: 'n1' }],  params: { inductance: 100e-6 }, displayValue: '100u' },
+        { type: 'D', id: 'D1',    name: 'D1',    ports: [{ name: 'p', net: 'n1' },   { name: 'n', net: '0' }],  params: { modelName: 'DMOD' },   displayValue: 'DMOD' },
+        { type: 'C', id: 'C1',    name: 'C1',    ports: [{ name: 'p', net: 'n1' },   { name: 'n', net: 'neg' }], params: { capacitance: 100e-6 }, displayValue: '100u' },
+        { type: 'R', id: 'Rload', name: 'Rload', ports: [{ name: 'p', net: 'neg' },  { name: 'n', net: '0' }],  params: { resistance: 10 },      displayValue: '10' },
+      );
+    }
+
+    function horizontalBusY(layout: ReturnType<typeof layoutSchematic>, net: string): number | undefined {
+      const w = layout.wires.find(w => w.net === net);
+      if (!w) return undefined;
+      const hSeg = w.segments.find(s => s.y1 === s.y2);
+      return hSeg?.y1;
+    }
+
+    it('assigns distinct vertical positions to in, gate, sw nets', () => {
+      const layout = layoutSchematic(makeBuckBoost());
+      const inY = horizontalBusY(layout, 'in');
+      const gateY = horizontalBusY(layout, 'gate');
+      const swY = horizontalBusY(layout, 'sw');
+
+      expect(inY).toBeDefined();
+      expect(gateY).toBeDefined();
+      expect(swY).toBeDefined();
+      const ys = new Set([inY, gateY, swY]);
+      expect(ys.size).toBe(3);
+    });
+
+    it('orders nets by potential: in above sw above n1 (lower Y = higher on screen)', () => {
+      const layout = layoutSchematic(makeBuckBoost());
+      const inY = horizontalBusY(layout, 'in')!;
+      const swY = horizontalBusY(layout, 'sw')!;
+      const n1Y = horizontalBusY(layout, 'n1')!;
+
+      expect(inY).toBeLessThan(swY);
+      expect(swY).toBeLessThan(n1Y);
+    });
+
+    it('places M1 with drain pin above source pin', () => {
+      const layout = layoutSchematic(makeBuckBoost());
+      const m1 = layout.components.find(c => c.component.id === 'M1')!;
+      const drain = m1.pins[0];
+      const source = m1.pins[2];
+      expect(drain.y).toBeLessThan(source.y);
+    });
+
+    it('places no two-terminal component degenerately (endpoints on the same rank)', () => {
+      const layout = layoutSchematic(makeBuckBoost());
+      const twoTerm = ['Vin', 'L1', 'D1', 'C1', 'Rload'];
+      for (const id of twoTerm) {
+        const pc = layout.components.find(c => c.component.id === id)!;
+        const busYs = pc.pins.map(p => horizontalBusY(layout, p.net) ?? p.y);
+        const distinctYs = new Set(busYs);
+        expect(distinctYs.size, `${id} endpoints should span distinct vertical positions`).toBeGreaterThan(1);
+      }
+    });
+
+    it('does not draw horizontal buses of different nets on the same pixel row with overlapping x ranges', () => {
+      const layout = layoutSchematic(makeBuckBoost());
+      type HSeg = { net: string; y: number; xMin: number; xMax: number };
+      const hSegs: HSeg[] = [];
+      for (const w of layout.wires) {
+        for (const s of w.segments) {
+          if (s.y1 === s.y2) {
+            hSegs.push({ net: w.net, y: s.y1, xMin: Math.min(s.x1, s.x2), xMax: Math.max(s.x1, s.x2) });
+          }
+        }
+      }
+      for (let i = 0; i < hSegs.length; i++) {
+        for (let j = i + 1; j < hSegs.length; j++) {
+          const a = hSegs[i], b = hSegs[j];
+          if (a.net === b.net) continue;
+          if (a.y !== b.y) continue;
+          const overlap = Math.min(a.xMax, b.xMax) - Math.max(a.xMin, b.xMin);
+          expect(overlap, `nets ${a.net} and ${b.net} overlap on y=${a.y}`).toBeLessThanOrEqual(0);
+        }
+      }
+    });
+  });
 });

--- a/packages/ui/src/schematic/layout.test.ts
+++ b/packages/ui/src/schematic/layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { layoutSchematic } from './layout.js';
+import { GRID } from './symbols.js';
 import type { CircuitIR } from './types.js';
 
 /** Helper to build a simple CircuitIR for testing. */
@@ -131,14 +132,16 @@ describe('layoutSchematic', () => {
       expect(ys.size).toBe(3);
     });
 
-    it('orders nets by potential: in above sw above n1 (lower Y = higher on screen)', () => {
+    it('orders nets by potential: in above the sw/n1 rail (lower Y = higher on screen)', () => {
       const layout = layoutSchematic(makeBuckBoost());
       const inY = horizontalBusY(layout, 'in')!;
       const swY = horizontalBusY(layout, 'sw')!;
       const n1Y = horizontalBusY(layout, 'n1')!;
 
+      // sw and n1 share a rail (L1 has no DC drop)
+      expect(Math.abs(swY - n1Y)).toBeLessThanOrEqual(GRID * 2);
+      // in sits above the sw/n1 rail
       expect(inY).toBeLessThan(swY);
-      expect(swY).toBeLessThan(n1Y);
     });
 
     it('places M1 with drain pin above source pin', () => {
@@ -149,10 +152,11 @@ describe('layoutSchematic', () => {
       expect(drain.y).toBeLessThan(source.y);
     });
 
-    it('places no two-terminal component degenerately (endpoints on the same rank)', () => {
+    it('rank-differentiating components (V, D, C) span distinct vertical positions', () => {
+      // R and L can legitimately be rank-preserving (same rail on both ends)
+      // when no DC current flows through them. V, D, C must cross rails.
       const layout = layoutSchematic(makeBuckBoost());
-      const twoTerm = ['Vin', 'L1', 'D1', 'C1', 'Rload'];
-      for (const id of twoTerm) {
+      for (const id of ['Vin', 'D1', 'C1']) {
         const pc = layout.components.find(c => c.component.id === id)!;
         const busYs = pc.pins.map(p => horizontalBusY(layout, p.net) ?? p.y);
         const distinctYs = new Set(busYs);
@@ -180,6 +184,173 @@ describe('layoutSchematic', () => {
           expect(overlap, `nets ${a.net} and ${b.net} overlap on y=${a.y}`).toBeLessThanOrEqual(0);
         }
       }
+    });
+  });
+
+  describe('common textbook topologies', () => {
+    function horizontalBusY(layout: ReturnType<typeof layoutSchematic>, net: string): number | undefined {
+      const w = layout.wires.find(w => w.net === net);
+      if (!w) return undefined;
+      const hSeg = w.segments.find(s => s.y1 === s.y2);
+      if (hSeg) return hSeg.y1;
+      // No explicit horizontal segment — the net's bus Y is the Y that shared
+      // by all vertical drops' endpoints.
+      const ys = w.segments.flatMap(s => [s.y1, s.y2]);
+      const counts = new Map<number, number>();
+      for (const y of ys) counts.set(y, (counts.get(y) ?? 0) + 1);
+      let best = -Infinity, bestN = 0;
+      for (const [y, n] of counts) if (n > bestN) { best = y; bestN = n; }
+      return bestN >= 2 ? best : undefined;
+    }
+
+    it('RC low-pass: R with no DC current → in and out share the top rail', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'out' }], params: { resistance: 1000 }, displayValue: '1k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-9 }, displayValue: '100n' },
+      );
+      const layout = layoutSchematic(circuit);
+      const inY = horizontalBusY(layout, 'in')!;
+      const outY = horizontalBusY(layout, 'out')!;
+      // in and out must be on the same rail (within the corridor-offset band)
+      expect(Math.abs(inY - outY)).toBeLessThanOrEqual(GRID * 2);
+      // R1 should render horizontally (both pins at the same Y)
+      const r1 = layout.components.find(c => c.component.id === 'R1')!;
+      expect(r1.pins[0].y).toBe(r1.pins[1].y);
+    });
+
+    it('RLC series bandpass: R and L have no DC drop → in/mid/n1 share the top rail', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }],  params: { dc: 5 }, displayValue: 'PULSE' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'mid' }], params: { resistance: 100 }, displayValue: '100' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'mid' }, { name: 'n', net: 'n1' }],  params: { inductance: 10e-3 }, displayValue: '10m' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' },  { name: 'n', net: '0' }],   params: { capacitance: 1e-6 }, displayValue: '1u' },
+      );
+      const layout = layoutSchematic(circuit);
+      const inY  = horizontalBusY(layout, 'in')!;
+      const midY = horizontalBusY(layout, 'mid')!;
+      const n1Y  = horizontalBusY(layout, 'n1')!;
+      // All three share the same rail
+      expect(Math.abs(inY - midY)).toBeLessThanOrEqual(GRID * 2);
+      expect(Math.abs(midY - n1Y)).toBeLessThanOrEqual(GRID * 2);
+      // R1 and L1 render horizontally
+      for (const id of ['R1', 'L1']) {
+        const c = layout.components.find(c => c.component.id === id)!;
+        expect(c.pins[0].y).toBe(c.pins[1].y);
+      }
+    });
+
+    it('voltage divider: R in a DC loop stays rank-differentiating', () => {
+      // V-R1-R2-gnd: removing either R leaves a DC path via the other R and V,
+      // so both R's carry DC current and must separate ranks.
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'out' }], params: { resistance: 1000 }, displayValue: '1k' },
+        { type: 'R', id: 'R2', name: 'R2', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }],  params: { resistance: 2000 }, displayValue: '2k' },
+      );
+      const layout = layoutSchematic(circuit);
+      const inY  = horizontalBusY(layout, 'in')!;
+      const outY = horizontalBusY(layout, 'out')!;
+      expect(inY).toBeLessThan(outY);
+    });
+
+    it('RC low-pass: components flow V1 → R1 → C1 from left to right', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' }, { name: 'n', net: 'out' }], params: { resistance: 1000 }, displayValue: '1k' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'out' }, { name: 'n', net: '0' }], params: { capacitance: 100e-9 }, displayValue: '100n' },
+      );
+      const layout = layoutSchematic(circuit);
+      const v1 = layout.components.find(c => c.component.id === 'V1')!;
+      const r1 = layout.components.find(c => c.component.id === 'R1')!;
+      const c1 = layout.components.find(c => c.component.id === 'C1')!;
+      expect(v1.x).toBeLessThan(r1.x);
+      expect(r1.x).toBeLessThan(c1.x);
+    });
+
+    it('RLC bandpass: components flow V1 → R1 → L1 → C1', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'V1', name: 'V1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }],  params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'R', id: 'R1', name: 'R1', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: 'mid' }], params: { resistance: 100 }, displayValue: '100' },
+        { type: 'L', id: 'L1', name: 'L1', ports: [{ name: 'p', net: 'mid' }, { name: 'n', net: 'n1' }],  params: { inductance: 10e-3 }, displayValue: '10m' },
+        { type: 'C', id: 'C1', name: 'C1', ports: [{ name: 'p', net: 'n1' },  { name: 'n', net: '0' }],   params: { capacitance: 1e-6 }, displayValue: '1u' },
+      );
+      const layout = layoutSchematic(circuit);
+      const xs = ['V1', 'R1', 'L1', 'C1'].map(id => layout.components.find(c => c.component.id === id)!.x);
+      expect(xs[0]).toBeLessThan(xs[1]);
+      expect(xs[1]).toBeLessThan(xs[2]);
+      expect(xs[2]).toBeLessThan(xs[3]);
+    });
+
+    it('CMOS inverter: MP and MN stack in the same column', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'VDD', name: 'VDD', ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: '0' }], params: { dc: 1.8 }, displayValue: 'DC 1.8' },
+        { type: 'V', id: 'VIN', name: 'VIN', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }], params: { dc: 0 },   displayValue: 'DC 0' },
+        { type: 'M', id: 'MP',  name: 'MP',  ports: [
+          { name: 'drain',  net: 'out' },
+          { name: 'gate',   net: 'in' },
+          { name: 'source', net: 'vdd' },
+          { name: 'bulk',   net: 'vdd' },
+        ], params: { modelName: 'PMOD', channelType: 'p' }, displayValue: 'PMOD' },
+        { type: 'M', id: 'MN',  name: 'MN',  ports: [
+          { name: 'drain',  net: 'out' },
+          { name: 'gate',   net: 'in' },
+          { name: 'source', net: '0' },
+          { name: 'bulk',   net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+      );
+      const layout = layoutSchematic(circuit);
+      const mp = layout.components.find(c => c.component.id === 'MP')!;
+      const mn = layout.components.find(c => c.component.id === 'MN')!;
+      expect(mp.x).toBe(mn.x);
+      expect(mp.y).toBeLessThan(mn.y);
+    });
+
+    it('common-source amp: RD with a DC path through the MOSFET stays differentiating', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'VDD', name: 'VDD', ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: '0' }], params: { dc: 5 }, displayValue: 'DC 5' },
+        { type: 'V', id: 'VGS', name: 'VGS', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }], params: { dc: 1.5 }, displayValue: 'AC 1' },
+        { type: 'M', id: 'M1',  name: 'M1',  ports: [
+          { name: 'drain',  net: 'out' },
+          { name: 'gate',   net: 'in' },
+          { name: 'source', net: '0' },
+          { name: 'bulk',   net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+        { type: 'R', id: 'RD',  name: 'RD',  ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: 'out' }], params: { resistance: 10000 }, displayValue: '10k' },
+      );
+      const layout = layoutSchematic(circuit);
+      const vddY = horizontalBusY(layout, 'vdd')!;
+      const outY = horizontalBusY(layout, 'out')!;
+      expect(vddY).toBeLessThan(outY);
+    });
+
+    it('CMOS inverter: vdd rail sits above out, which sits above gnd', () => {
+      const circuit = makeCircuit(
+        { type: 'V', id: 'VDD', name: 'VDD', ports: [{ name: 'p', net: 'vdd' }, { name: 'n', net: '0' }], params: { dc: 1.8 }, displayValue: 'DC 1.8' },
+        { type: 'V', id: 'VIN', name: 'VIN', ports: [{ name: 'p', net: 'in' },  { name: 'n', net: '0' }], params: { dc: 0 },   displayValue: 'DC 0' },
+        { type: 'M', id: 'MP',  name: 'MP',  ports: [
+          { name: 'drain',  net: 'out' },
+          { name: 'gate',   net: 'in' },
+          { name: 'source', net: 'vdd' },
+          { name: 'bulk',   net: 'vdd' },
+        ], params: { modelName: 'PMOD', channelType: 'p' }, displayValue: 'PMOD' },
+        { type: 'M', id: 'MN',  name: 'MN',  ports: [
+          { name: 'drain',  net: 'out' },
+          { name: 'gate',   net: 'in' },
+          { name: 'source', net: '0' },
+          { name: 'bulk',   net: '0' },
+        ], params: { modelName: 'NMOD', channelType: 'n' }, displayValue: 'NMOD' },
+      );
+      const layout = layoutSchematic(circuit);
+      const vddY = horizontalBusY(layout, 'vdd')!;
+      const outY = horizontalBusY(layout, 'out')!;
+      expect(vddY).toBeLessThan(outY);
+
+      // MP drain should be below its source (source=vdd is the high side for PMOS)
+      const mp = layout.components.find(c => c.component.id === 'MP')!;
+      const mpDrain  = mp.pins[0];
+      const mpSource = mp.pins[2];
+      expect(mpDrain.y).toBeGreaterThan(mpSource.y);
     });
   });
 });

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -37,12 +37,16 @@ function componentEndpoints(comp: IRComponent): [string, string] {
 /* ------------------------------------------------------------------ */
 
 /**
- * Assign vertical ranks to nodes using directed longest-path from ground.
+ * Assign vertical ranks to nodes by longest path from ground in a mixed graph.
  *
- * Uses component-type-aware directed edges (drain→source for MOSFET,
- * anode→cathode for diode, pos→neg for sources) to build a DAG, then
- * computes the longest path from ground to each node. This gives proper
- * intermediate ranks (e.g., sw between in and 0 in a buck converter).
+ * 1. BFS distance from ground through the undirected component graph.
+ * 2. Orient each undirected edge from the node closer to ground toward the one
+ *    farther away (lexicographic tiebreak for equal distance), so every edge
+ *    contributes rank separation.
+ * 3. Override with known polarity (V/I: + above −, MOSFET: drain above source,
+ *    BJT: collector above emitter, E/G: outP above outN) — reversing the
+ *    oriented edge if necessary.
+ * 4. Longest path from ground in the resulting DAG via Bellman–Ford relaxation.
  *
  * Ground = rank 0 (bottom of schematic, highest Y).
  * Higher rank = higher potential = top of schematic (lowest Y).
@@ -50,101 +54,105 @@ function componentEndpoints(comp: IRComponent): [string, string] {
 function rankNodes(circuit: CircuitIR): Map<string, number> {
   const GND = '0';
 
-  // Collect all unique nets
   const allNets = new Set<string>();
   for (const comp of circuit.components) {
     for (const p of comp.ports) allNets.add(p.net);
   }
+  allNets.add(GND);
 
-  // Build directed adjacency: highNet → lowNet edges (current flow direction)
-  // Also keep undirected for fallback connectivity
-  const directedDown = new Map<string, Set<string>>(); // high → low
-  const directedUp = new Map<string, Set<string>>();   // low → high
-  const undirected = new Map<string, Set<string>>();
-  for (const n of allNets) {
-    directedDown.set(n, new Set());
-    directedUp.set(n, new Set());
-    undirected.set(n, new Set());
-  }
+  // Gather edges. Every component contributes an undirected edge between its
+  // two primary endpoints; components with known polarity also contribute a
+  // directed high→low constraint.
+  const undirectedPairs: Array<[string, string]> = [];
+  const directedHighLow: Array<[string, string]> = [];
 
   for (const comp of circuit.components) {
     const [a, b] = componentEndpoints(comp);
-    undirected.get(a)!.add(b);
-    undirected.get(b)!.add(a);
+    if (a !== b) undirectedPairs.push([a, b]);
 
-    // Only add directed edges for components with known polarity.
-    // Passive components (R, L, C) are undirected — we don't know voltage direction.
     let high: string | null = null, low: string | null = null;
     switch (comp.type) {
       case 'V': case 'I':
-        high = comp.ports[0].net; // positive terminal
-        low = comp.ports[1].net;  // negative terminal
-        break;
+        high = comp.ports[0].net; low = comp.ports[1].net; break;
       case 'M':
-        high = comp.ports[0].net; // drain
-        low = comp.ports[2].net;  // source
-        break;
+        high = comp.ports[0].net; low = comp.ports[2].net; break;
       case 'Q':
-        high = comp.ports[0].net; // collector
-        low = comp.ports[2].net;  // emitter
-        break;
-      // D (diode): polarity depends on circuit context (forward vs freewheeling).
-      // Treat as undirected — let other directed edges determine rank ordering.
+        high = comp.ports[0].net; low = comp.ports[2].net; break;
       case 'E': case 'G':
-        high = comp.ports[2].net; // outP
-        low = comp.ports[3].net;  // outN
-        break;
-      // R, L, C, F, H, X: no directed edge — undirected only
+        high = comp.ports[2].net; low = comp.ports[3].net; break;
+      // D, R, L, C, F, H, X: undirected only
     }
-
-    if (high !== null && low !== null) {
-      directedDown.get(high)!.add(low);
-      directedUp.get(low)!.add(high);
+    if (high !== null && low !== null && high !== low) {
+      directedHighLow.push([high, low]);
     }
   }
 
-  // Longest path from ground upward using directed edges
-  // Use iterative relaxation (Bellman-Ford style for longest path in DAG)
-  const rank = new Map<string, number>();
-  for (const n of allNets) rank.set(n, -1);
-  rank.set(GND, 0);
+  // Undirected adjacency for BFS.
+  const undirected = new Map<string, Set<string>>();
+  for (const n of allNets) undirected.set(n, new Set());
+  for (const [a, b] of undirectedPairs) {
+    undirected.get(a)!.add(b);
+    undirected.get(b)!.add(a);
+  }
 
-  // Relaxation: repeatedly update ranks via directed-up edges
-  let changed = true;
-  let iterations = 0;
-  while (changed && iterations < allNets.size + 1) {
-    changed = false;
-    for (const [node, currentRank] of rank) {
-      if (currentRank < 0) continue;
-      // Follow edges upward: neighbors that are at higher potential
-      for (const higher of directedUp.get(node) ?? []) {
-        const newRank = currentRank + 1;
-        if (newRank > (rank.get(higher) ?? -1)) {
-          rank.set(higher, newRank);
+  // Step 1: BFS distance from ground through undirected graph.
+  const dist = new Map<string, number>();
+  for (const n of allNets) dist.set(n, Infinity);
+  dist.set(GND, 0);
+  const bfs: string[] = [GND];
+  while (bfs.length > 0) {
+    const node = bfs.shift()!;
+    const d = dist.get(node)!;
+    for (const neighbor of undirected.get(node)!) {
+      if (dist.get(neighbor)! > d + 1) {
+        dist.set(neighbor, d + 1);
+        bfs.push(neighbor);
+      }
+    }
+  }
+  // Isolated nets (no path to ground) get a small positive distance so
+  // longest-path relaxation still places them above ground.
+  for (const n of allNets) {
+    if (dist.get(n) === Infinity) dist.set(n, 1);
+  }
+
+  // Step 2: Build DAG by orienting each undirected edge from lower to higher
+  // BFS distance. Equal distances use lexicographic tiebreak.
+  const dagFrom = new Map<string, Set<string>>();
+  for (const n of allNets) dagFrom.set(n, new Set());
+  for (const [a, b] of undirectedPairs) {
+    const da = dist.get(a)!, db = dist.get(b)!;
+    let lo: string, hi: string;
+    if (da < db) { lo = a; hi = b; }
+    else if (db < da) { lo = b; hi = a; }
+    else { [lo, hi] = a < b ? [a, b] : [b, a]; }
+    dagFrom.get(lo)!.add(hi);
+  }
+
+  // Step 3: Apply directed polarity. For each high→low pair, ensure the edge
+  // runs low→high in the DAG (reverse the existing edge if needed).
+  for (const [high, low] of directedHighLow) {
+    dagFrom.get(high)?.delete(low);
+    dagFrom.get(low)?.add(high);
+  }
+
+  // Step 4: Longest path from ground via Bellman–Ford-style relaxation.
+  const rank = new Map<string, number>();
+  for (const n of allNets) rank.set(n, 0);
+
+  const maxIter = allNets.size * 2 + 1;
+  for (let i = 0; i < maxIter; i++) {
+    let changed = false;
+    for (const [from, tos] of dagFrom) {
+      const fromRank = rank.get(from)!;
+      for (const to of tos) {
+        if (fromRank + 1 > rank.get(to)!) {
+          rank.set(to, fromRank + 1);
           changed = true;
         }
       }
     }
-    iterations++;
-  }
-
-  // Fallback: unranked nodes connected via undirected edges (R, L, C)
-  // get the SAME rank as their ranked neighbor — they're at similar potential.
-  const queue = [...allNets].filter(n => (rank.get(n) ?? -1) >= 0);
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    const currentRank = rank.get(current)!;
-    for (const neighbor of undirected.get(current) ?? []) {
-      if ((rank.get(neighbor) ?? -1) < 0) {
-        rank.set(neighbor, currentRank); // same rank, not +1
-        queue.push(neighbor);
-      }
-    }
-  }
-
-  // Final fallback: truly disconnected nodes
-  for (const n of allNets) {
-    if ((rank.get(n) ?? -1) < 0) rank.set(n, 1);
+    if (!changed) break;
   }
 
   return rank;
@@ -273,17 +281,34 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     }
   }
 
-  // Route each net: connect all pins with orthogonal segments
-  // Use a shared horizontal bus at the net's rank Y, then vertical drops to each pin
+  // Route each net: connect all pins with orthogonal segments.
+  // Each net has a dedicated horizontal bus at its rank Y; when several nets
+  // share a rank, they are fanned out around the base Y so their buses don't
+  // render on the same pixel row.
   const CORRIDOR_OFFSET = GRID * 0.4;
+
+  const netsByRank = new Map<number, string[]>();
+  for (const net of netPins.keys()) {
+    if (net === '0') continue;
+    const r = nodeRanks.get(net) ?? 0;
+    if (!netsByRank.has(r)) netsByRank.set(r, []);
+    netsByRank.get(r)!.push(net);
+  }
+  const netBusY = new Map<string, number>();
+  for (const [r, nets] of netsByRank) {
+    const baseY = MARGIN + (maxRank - r) * RANK_SPACING;
+    nets.sort();
+    nets.forEach((net, i) => {
+      const offset = (i - (nets.length - 1) / 2) * CORRIDOR_OFFSET;
+      netBusY.set(net, baseY + offset);
+    });
+  }
 
   for (const [net, pins] of netPins) {
     if (net === '0' || pins.length < 2) continue;
     const segments: { x1: number; y1: number; x2: number; y2: number }[] = [];
 
-    // Compute the bus Y for this net (at its rank level)
-    const netRank = nodeRanks.get(net) ?? 0;
-    const busY = MARGIN + (maxRank - netRank) * RANK_SPACING;
+    const busY = netBusY.get(net)!;
 
     const sorted = [...pins].sort((a, b) => a.x - b.x || a.y - b.y);
 

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -69,7 +69,12 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
   // component differentiates ranks; if they don't, the component is a
   // "signal-chain" hop whose endpoints are at the same DC potential and
   // should share a rank.
-  const DC_TYPES = new Set(['V', 'I', 'R', 'L', 'M', 'Q', 'E', 'G', 'F', 'H']);
+  // Independent sources and devices whose DC-bias path is part of the static
+  // voltage/current graph. Dependent sources (E/G/F/H) are excluded so an
+  // opamp's output→ground dc edge doesn't create a spurious parallel path
+  // for every resistor touching the feedback rail. D is included because a
+  // forward-biased diode conducts DC current like a resistor.
+  const DC_TYPES = new Set(['V', 'I', 'R', 'L', 'M', 'Q', 'D']);
   const dcEdges: Array<{ id: string; a: string; b: string }> = [];
   for (const comp of circuit.components) {
     if (!DC_TYPES.has(comp.type)) continue;
@@ -95,12 +100,53 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
     return false;
   };
 
+  // Nets that a diode touches. Used to recognise signal-path resistors that
+  // feed or follow a diode (e.g. the source resistor in a half-wave
+  // rectifier) — those R's should stay on the same rail as the diode.
+  const diodeNets = new Set<string>();
+  for (const comp of circuit.components) {
+    if (comp.type === 'D') {
+      for (const p of comp.ports) diodeNets.add(p.net);
+    }
+  }
+
   const rankPreserving = new Set<string>();
   for (const comp of circuit.components) {
-    if (comp.type !== 'R' && comp.type !== 'L') continue;
+    if (comp.type !== 'R' && comp.type !== 'L' && comp.type !== 'D') continue;
     const [a, b] = componentEndpoints(comp);
     if (a === b) continue;
-    if (!dcConnectedSkipping(comp.id, a, b)) rankPreserving.add(comp.id);
+    // Ideal inductor — zero DC drop regardless of loop topology.
+    if (comp.type === 'L') {
+      rankPreserving.add(comp.id);
+      continue;
+    }
+    // Signal-path diode (neither endpoint ground): drawn in-line on the rail
+    // with its ~0.7 V drop visually suppressed. A diode with a ground
+    // endpoint (Zener, freewheel) must differentiate so it can hang off the
+    // rail toward ground.
+    if (comp.type === 'D') {
+      if (a !== GND && b !== GND) rankPreserving.add(comp.id);
+      continue;
+    }
+    // R preserves when current cannot flow through it (no parallel DC path)
+    // or when it sits next to a diode in a non-ground chain — the rectifier
+    // pattern V → Rs → D → R_load should draw Rs and D horizontally even
+    // though Rs has a parallel DC path through the load.
+    const bothNonGround = a !== GND && b !== GND;
+    const adjacentToDiode = bothNonGround && (diodeNets.has(a) || diodeNets.has(b));
+    // Exception: a load resistor (one endpoint on ground, other on a cap
+    // output plate) should always differentiate even without a DC parallel
+    // path. The cap blocks DC in steady-state analysis, but the R is still
+    // visually a vertical pull-down.
+    const nonGndEnd = a === GND ? b : (b === GND ? a : null);
+    const isCapLoad = nonGndEnd !== null && circuit.components.some(c =>
+      c.type === 'C' && c.id !== comp.id && c.ports.some(p => p.net === nonGndEnd)
+    );
+    if (isCapLoad) {
+      // Explicitly differentiating — skip rank-preserving.
+    } else if (!dcConnectedSkipping(comp.id, a, b) || adjacentToDiode) {
+      rankPreserving.add(comp.id);
+    }
   }
 
   // --- Union-find: merge nets joined by rank-preserving R/L ------------
@@ -153,6 +199,27 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
   const dagCandidates: UEdge[] = [];
   const directedHighLow: Array<[string, string]> = [];
 
+  // Series output capacitors (e.g. C1 in an inverting buck-boost spanning n1
+  // and neg, where each side has its own R/D shunt to ground) must rank-
+  // separate their endpoints so the cap draws vertically. Feedback caps over
+  // an opamp loop lack such ground shunts and stay same-rank (horizontal arc).
+  const hasGndShunt = (net: string, exceptId: string): boolean =>
+    circuit.components.some(c =>
+      c.id !== exceptId &&
+      (c.type === 'R' || c.type === 'D') &&
+      c.ports.some(p => p.net === net) &&
+      c.ports.some(p => p.net === GND)
+    );
+  const seriesOutputCaps = new Set<string>();
+  for (const comp of circuit.components) {
+    if (comp.type !== 'C' || comp.ports.length !== 2) continue;
+    const a = comp.ports[0].net, b = comp.ports[1].net;
+    if (a === GND || b === GND || a === b) continue;
+    if (hasGndShunt(a, comp.id) && hasGndShunt(b, comp.id)) {
+      seriesOutputCaps.add(comp.id);
+    }
+  }
+
   for (const comp of circuit.components) {
     const [a, b] = componentEndpoints(comp);
     const sa = find(a), sb = find(b);
@@ -162,7 +229,8 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
         // Differentiating R/L is the only type that must insist on a rank
         // step even when BFS distance is equal.
         const isRL = comp.type === 'R' || comp.type === 'L';
-        const keepAtSameDist = isRL && !rankPreserving.has(comp.id);
+        const isSeriesCap = seriesOutputCaps.has(comp.id);
+        const keepAtSameDist = (isRL && !rankPreserving.has(comp.id)) || isSeriesCap;
         dagCandidates.push({ a: sa, b: sb, keepAtSameDist });
       }
     }
@@ -185,7 +253,23 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
       }
       case 'E': case 'G':
         high = comp.ports[2].net; low = comp.ports[3].net; break;
-      // D, C, X: undirected only
+      case 'C': {
+        if (!seriesOutputCaps.has(comp.id)) break;
+        // Whichever side has more non-gnd-shunt DC neighbors is upstream.
+        const [na, nb] = [comp.ports[0].net, comp.ports[1].net];
+        const upstreamCount = (net: string) => circuit.components.filter(c =>
+          c.id !== comp.id && DC_TYPES.has(c.type) &&
+          c.ports.some(p => p.net === net) &&
+          !c.ports.some(p => p.net === GND)
+        ).length;
+        const ca = upstreamCount(na), cb = upstreamCount(nb);
+        if (ca !== cb) {
+          high = ca > cb ? na : nb;
+          low  = ca > cb ? nb : na;
+        }
+        break;
+      }
+      // D, X: undirected only
     }
     if (high !== null && low !== null) {
       const sh = find(high), sl = find(low);
@@ -345,6 +429,28 @@ function assignColumns(circuit: CircuitIR): Map<string, number> {
   for (const c of circuit.components) {
     if (!col.has(c.id)) col.set(c.id, fallback++);
   }
+
+  // Refinement: a component whose net's FIRST carrier sits earlier in the
+  // BFS should be pulled back to that carrier's column. This keeps shunts
+  // (e.g. a freewheel diode from sw→gnd) in the SAME column as the source
+  // that drives their live net, leaving the next column free for the chain
+  // that continues onward (e.g. the inductor out of sw). Without this, a
+  // buck converter ends up with D1 placed to the RIGHT of L1 and the sw bus
+  // visually runs through L1's body.
+  const netMinCol = new Map<string, number>();
+  for (const [net, comps] of netToComps) {
+    if (comps.length === 0) continue;
+    netMinCol.set(net, Math.min(...comps.map(id => col.get(id) ?? 0)));
+  }
+  for (const c of circuit.components) {
+    let m = 0;
+    for (const p of c.ports) {
+      if (p.net === '0') continue;
+      const nc = netMinCol.get(p.net);
+      if (nc !== undefined) m = Math.max(m, nc);
+    }
+    col.set(c.id, m);
+  }
   return col;
 }
 
@@ -387,38 +493,64 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   // ground stubs would overlap. Each sub-column consumes one SLOT_SPACING of
   // horizontal space.
   const STACK_GAP = GRID / 2;
+  // V/I/C have a natural central body (circle, plates) that tolerates lead
+  // extension when stretched. Resistors are stretched only when one endpoint
+  // is ground — the stretch keeps the ground pin on the ground rail so a
+  // row of pull-down R's and decoupling C's share a single ground line.
+  // A pull-up R between two live rails (e.g. RD in a common-source amp)
+  // keeps natural size to avoid the elongated zigzag look.
   const STRETCH_TYPES = new Set(['V', 'I', 'C']);
   const symbolFor = (pl: Placement) => {
-    const horizontal = pl.comp.type === 'C' && pl.topRank === pl.bottomRank;
-    // Vertical 2-terminal symbols stretch to match the rank span so their pins
-    // align with both rail Ys without a dangling lead-wire at either end.
-    const stretchH = !horizontal && STRETCH_TYPES.has(pl.comp.type) && pl.topRank > pl.bottomRank
+    const sameRank = pl.topRank === pl.bottomRank;
+    const horizontal =
+      (pl.comp.type === 'C' && sameRank) ||
+      (pl.comp.type === 'R' && sameRank) ||
+      (pl.comp.type === 'D' && sameRank);
+    const hasGroundEndpoint = pl.comp.ports.some(p => p.net === '0');
+    const stretchEligible = STRETCH_TYPES.has(pl.comp.type) ||
+      ((pl.comp.type === 'R' || pl.comp.type === 'D') && hasGroundEndpoint);
+    const stretchH = !horizontal && stretchEligible && pl.topRank > pl.bottomRank
       ? (pl.topRank - pl.bottomRank) * RANK_SPACING
       : undefined;
     return { horizontal, stretchH, sym: getSymbol(pl.comp.type, pl.comp.displayValue ?? '', horizontal, stretchH) };
   };
-  // Feedback caps (a capacitor whose two endpoints are both non-ground nets
-  // collapsed onto a single rail) are conventionally drawn as a loop ABOVE
-  // the signal chain, with short drop-wires joining each pin to the rail.
-  // Detect them and shift their centerY up by one rank-spacing so the rail
-  // runs uninterrupted through the rest of the chain.
-  const isFeedbackCap = (pl: Placement): boolean =>
-    pl.comp.type === 'C' &&
-    pl.topRank === pl.bottomRank &&
-    pl.comp.ports[0].net !== '0' &&
-    pl.comp.ports[1].net !== '0';
+  // Feedback components span a loop that closes back through an opamp or over
+  // a signal rail — a capacitor between two non-ground same-rank nets, or a
+  // resistor whose endpoints sit on the same rail AND coincide with an
+  // opamp's input/output pair. Feedback components render as an arc ABOVE the
+  // signal chain with short drop-wires joining each pin to the rail.
+  const opampLoops = new Set<string>();
+  for (const comp of circuit.components) {
+    if (comp.type !== 'E' && comp.type !== 'G') continue;
+    const ctrlP = comp.ports[0]?.net, ctrlN = comp.ports[1]?.net, outP = comp.ports[2]?.net;
+    for (const input of [ctrlP, ctrlN]) {
+      if (input && outP && input !== outP) {
+        opampLoops.add(`${input}|${outP}`);
+        opampLoops.add(`${outP}|${input}`);
+      }
+    }
+  }
+  const isFeedback = (pl: Placement): boolean => {
+    if (pl.comp.type !== 'C' && pl.comp.type !== 'R') return false;
+    if (pl.topRank !== pl.bottomRank) return false;
+    const a = pl.comp.ports[0].net;
+    const b = pl.comp.ports[1].net;
+    if (a === '0' || b === '0') return false;
+    if (pl.comp.type === 'C') return true;
+    return opampLoops.has(`${a}|${b}`);
+  };
   const centerYFor = (pl: Placement) => {
     const topY = MARGIN + (maxRank - pl.topRank) * RANK_SPACING;
     const bottomY = MARGIN + (maxRank - pl.bottomRank) * RANK_SPACING;
     const base = (topY + bottomY) / 2;
-    return isFeedbackCap(pl) ? base - RANK_SPACING : base;
+    return isFeedback(pl) ? base - RANK_SPACING : base;
   };
 
   const byCol = new Map<number, Placement[]>();
   for (const pl of placements) {
     // Feedback caps are positioned in a second pass once the main chain is
     // laid out — they span the x-range between their endpoints' other pins.
-    if (isFeedbackCap(pl)) continue;
+    if (isFeedback(pl)) continue;
     if (!byCol.has(pl.col)) byCol.set(pl.col, []);
     byCol.get(pl.col)!.push(pl);
   }
@@ -464,7 +596,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   const placedComponents: PlacedComponent[] = [];
 
   for (const pl of placements) {
-    if (isFeedbackCap(pl)) continue;
+    if (isFeedback(pl)) continue;
     const { comp } = pl;
     const { horizontal, stretchH, sym: symbol } = symbolFor(pl);
     const nets = comp.ports.map(p => p.net);
@@ -492,12 +624,39 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     placedComponents.push({ component: comp, x, y, rotation: 0, horizontal, stretchH, pins });
   }
 
-  // --- Pass 2: feedback caps ----------------------------------------------
-  // Now that the main chain is positioned, stretch each feedback cap so its
-  // two pins span the feedback region: left pin sits over the leftmost other
-  // pin on net A, right pin over the rightmost other pin on net B.
+  // --- Pin alignment: pull vertical 2-terminal R's onto their peer's column
+  // When a vertical R shares a net with a transistor in the same BFS column,
+  // shift the R horizontally so its pin sits directly above/below the
+  // transistor pin. Without this, a pull-up/pull-down resistor renders with
+  // a jog in the connecting wire rather than a straight vertical line.
+  for (const pc of placedComponents) {
+    if (pc.component.type !== 'R' || pc.horizontal) continue;
+    if (pc.pins.length !== 2) continue;
+    for (const pin of pc.pins) {
+      if (pin.net === '0') continue;
+      const peer = placedComponents.find(other =>
+        other !== pc &&
+        (other.component.type === 'M' || other.component.type === 'Q') &&
+        Math.abs(other.x - pc.x) < SLOT_SPACING / 2 &&
+        other.pins.some(p => p.net === pin.net)
+      );
+      if (!peer) continue;
+      const peerPin = peer.pins.find(p => p.net === pin.net)!;
+      const dx = peerPin.x - pin.x;
+      if (dx === 0) break;
+      pc.x += dx;
+      for (const p of pc.pins) p.x += dx;
+      break;
+    }
+  }
+
+  // --- Pass 2: feedback components ----------------------------------------
+  // Now that the main chain is positioned, stretch each feedback cap or
+  // resistor so its two pins span the feedback region: left pin sits over
+  // the leftmost other pin on net A, right pin over the rightmost other pin
+  // on net B.
   for (const pl of placements) {
-    if (!isFeedbackCap(pl)) continue;
+    if (!isFeedback(pl)) continue;
     const { comp } = pl;
     const netA = comp.ports[0].net;
     const netB = comp.ports[1].net;
@@ -543,6 +702,111 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     for (const pc of placedComponents) {
       pc.y += yShift;
       for (const p of pc.pins) p.y += yShift;
+    }
+  }
+
+  // --- Shrink V/I sources whose top pin is crossed by a through-bus ---
+  // In circuits with multiple V sources sharing a column (e.g. Vin and Vg in a
+  // buck/boost converter), a stretched V-source puts its top pin right on the
+  // rail, and an unrelated rail bus passing between other components ends up
+  // routing THROUGH that pin. Detecting the conflict and shrinking the V
+  // source to natural size (bottom pin stays on the ground rail, top pin
+  // drops to between-rank height) moves the top pin out of the bus path.
+  {
+    const roughXRange = new Map<string, [number, number]>();
+    for (const pc of placedComponents) {
+      for (const p of pc.pins) {
+        const r = roughXRange.get(p.net);
+        if (!r) roughXRange.set(p.net, [p.x, p.x]);
+        else { r[0] = Math.min(r[0], p.x); r[1] = Math.max(r[1], p.x); }
+      }
+    }
+    for (const pc of placedComponents) {
+      if (pc.component.type !== 'V' && pc.component.type !== 'I') continue;
+      if (pc.pins.length !== 2 || !pc.stretchH) continue;
+      const topPin = pc.pins[0].y < pc.pins[1].y ? pc.pins[0] : pc.pins[1];
+      let conflict = false;
+      for (const [net, [xMin, xMax]] of roughXRange) {
+        if (net === topPin.net || net === '0') continue;
+        if (topPin.x <= xMin || topPin.x >= xMax) continue;
+        // The other net has pins at topPin.y (on the same rail)?
+        const hits = placedComponents.some(pc2 =>
+          pc2 !== pc && pc2.pins.some(p => p.net === net && Math.abs(p.y - topPin.y) < 1)
+        );
+        if (hits) { conflict = true; break; }
+      }
+      if (!conflict) continue;
+      // Target the modal Y of the top net's OTHER pins so the gate-side wire
+      // runs straight into the driven pin (e.g. Vg's + lines up with the
+      // MOSFET gate). If no other pin is available, fall back to natural
+      // shrink (top pin below the blocking bus).
+      const bottomPin = pc.pins[0].y > pc.pins[1].y ? pc.pins[0] : pc.pins[1];
+      const topNet = topPin.net, bottomNet = bottomPin.net;
+      const otherYs = placedComponents.flatMap(pc2 =>
+        pc2 === pc ? [] : pc2.pins.filter(p => p.net === topNet).map(p => p.y)
+      );
+      let targetY: number;
+      if (otherYs.length > 0) {
+        const counts = new Map<number, number>();
+        for (const y of otherYs) counts.set(y, (counts.get(y) ?? 0) + 1);
+        let bestY = otherYs[0], bestC = 0;
+        for (const [y, c] of counts) if (c > bestC) { bestC = c; bestY = y; }
+        targetY = bestY;
+      } else {
+        const naturalH = getSymbol(pc.component.type, pc.component.displayValue ?? '', false).height;
+        targetY = bottomPin.y - naturalH;
+      }
+      const newH = bottomPin.y - targetY;
+      const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', false, newH);
+      pc.y = targetY;
+      pc.stretchH = newH > sym.height - 1 && newH > GRID * 2 ? newH : undefined;
+      pc.pins = [
+        { net: topNet,    x: pc.x + sym.pins[0].dx, y: targetY + sym.pins[0].dy },
+        { net: bottomNet, x: pc.x + sym.pins[1].dx, y: targetY + sym.pins[1].dy },
+      ];
+    }
+  }
+
+  // --- Reorder V/I sources whose stretched body blocks a peer's bus ---
+  // After the stretch pass, one V/I source's body may span across another's
+  // horizontal bus Y. If the blocker sits to the RIGHT of the victim, their
+  // bus runs visually through the blocker's body (Vin→M1.in crossing Vg in a
+  // buck converter). Swap the two sources so the blocker is on the outside.
+  // Skip when both sources would block each other — swapping can't help.
+  {
+    const sources = placedComponents.filter(pc =>
+      (pc.component.type === 'V' || pc.component.type === 'I') && pc.pins.length === 2
+    );
+    for (let i = 0; i < sources.length; i++) {
+      for (let j = i + 1; j < sources.length; j++) {
+        const [left, right] = sources[i].x < sources[j].x
+          ? [sources[i], sources[j]]
+          : [sources[j], sources[i]];
+        if (right.x - left.x > SLOT_SPACING * 1.5) continue;
+        const leftTop = left.pins[0].y < left.pins[1].y ? left.pins[0] : left.pins[1];
+        const rightTop = right.pins[0].y < right.pins[1].y ? right.pins[0] : right.pins[1];
+        const peers = placedComponents
+          .filter(pc => pc !== left)
+          .flatMap(pc => pc.pins.filter(p => p.net === leftTop.net).map(p => p.x));
+        if (peers.length === 0) continue;
+        const busXMin = Math.min(leftTop.x, ...peers);
+        const busXMax = Math.max(leftTop.x, ...peers);
+        const rBodyMin = Math.min(right.pins[0].y, right.pins[1].y);
+        const rBodyMax = Math.max(right.pins[0].y, right.pins[1].y);
+        const rBodyX = right.pins[0].x;
+        const lBodyMin = Math.min(left.pins[0].y, left.pins[1].y);
+        const lBodyMax = Math.max(left.pins[0].y, left.pins[1].y);
+        if (leftTop.y < rBodyMin || leftTop.y > rBodyMax) continue;
+        if (rBodyX <= busXMin || rBodyX >= busXMax) continue;
+        // If swapping would just move the crossing (left also blocks right's
+        // bus Y), leave them alone.
+        if (rightTop.y >= lBodyMin && rightTop.y <= lBodyMax) continue;
+        const dx = right.x - left.x;
+        left.x += dx;
+        for (const p of left.pins) p.x += dx;
+        right.x -= dx;
+        for (const p of right.pins) p.x -= dx;
+      }
     }
   }
 
@@ -607,13 +871,103 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
       groups.push([net]);
     }
 
+    // Nets with disjoint x-ranges may share the same bus Y without visually
+    // overlapping; separately, two nets that sit on the same rail because an
+    // L or same-rank R/D bridges them (e.g. sw and out across a buck-inductor)
+    // may also share a Y — their combined bus reads as a single rail, which
+    // is what the reader expects.
+    const sameRailSet = new Map<string, string>();
+    const findRail = (n: string): string => {
+      let r = n;
+      while (sameRailSet.get(r) !== r) r = sameRailSet.get(r)!;
+      return r;
+    };
+    for (const net of netPins.keys()) sameRailSet.set(net, net);
+    for (const comp of circuit.components) {
+      if (comp.type !== 'R' && comp.type !== 'L' && comp.type !== 'D') continue;
+      if (comp.ports.length !== 2) continue;
+      const a = comp.ports[0].net, b = comp.ports[1].net;
+      if (a === '0' || b === '0' || a === b) continue;
+      if (nodeRanks.get(a) === nodeRanks.get(b)) {
+        const ra = findRail(a), rb = findRail(b);
+        if (ra !== rb) sameRailSet.set(ra, rb);
+      }
+    }
+    const yUsersX = new Map<number, Array<{ xMin: number; xMax: number; net: string }>>();
     for (const g of groups) {
       if (g.length === 1) { netBusY.set(g[0], baseY); continue; }
-      g.sort();
-      g.forEach((net, i) => {
-        const offset = (i - (g.length - 1) / 2) * CORRIDOR_OFFSET;
-        netBusY.set(net, baseY + offset);
+      // Wider nets go closest to baseY — they cover more components, so a
+      // small corridor offset is enough to clear the rail while keeping the
+      // bus from sinking deep into a transistor body sitting above the rail.
+      g.sort((a, b) => {
+        const ra = xRangeByNet.get(a)!, rb = xRangeByNet.get(b)!;
+        const wa = ra[1] - ra[0], wb = rb[1] - rb[0];
+        if (wa !== wb) return wb - wa;
+        return a.localeCompare(b);
       });
+      // For each net, pick the Y closest to its natural pin Y (preferring the
+      // modal pin Y, then baseY, then stepwise corridor offsets above the
+      // rail). Skip Ys that would plant the bus inside another component's
+      // body or overlap another net's bus in the x-range.
+      for (const net of g) {
+        const range = xRangeByNet.get(net)!;
+        const [xMin, xMax] = range;
+        const forbidden: Array<{ y1: number; y2: number; pinYs: number[] }> = [];
+        for (const pc of placedComponents) {
+          const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW);
+          const bX1 = pc.x, bX2 = pc.x + sym.width;
+          let bY1 = pc.y, bY2 = pc.y + sym.height;
+          if (xMax <= bX1 || xMin >= bX2) continue;
+          // A stretched V/I source is mostly a long thin lead with a natural-
+          // sized body (the circle) at the vertical centre. Shrink the
+          // forbidden region to that central circle so a through-bus can
+          // legitimately cross the lead without being pushed off the rail.
+          if ((pc.component.type === 'V' || pc.component.type === 'I') && pc.stretchH) {
+            const center = (bY1 + bY2) / 2;
+            const half = GRID * 0.9;
+            bY1 = center - half;
+            bY2 = center + half;
+          }
+          forbidden.push({ y1: bY1, y2: bY2, pinYs: pc.pins.map(p => p.y) });
+        }
+        // Prefer the modal pin Y when it's a safe candidate — that lets the
+        // bus run straight through the pins instead of dropping off the rail.
+        const pinYs = netPins.get(net)!.map(p => Math.round(p.y));
+        const yCounts = new Map<number, number>();
+        for (const y of pinYs) yCounts.set(y, (yCounts.get(y) ?? 0) + 1);
+        let modalY = baseY, modalCount = 0;
+        for (const [y, c] of yCounts) {
+          if (c > modalCount) { modalCount = c; modalY = y; }
+        }
+        const candidates: number[] = [];
+        const seen = new Set<number>();
+        const add = (y: number) => { if (!seen.has(y)) { seen.add(y); candidates.push(y); } };
+        add(modalY);
+        add(baseY);
+        for (let k = 1; k < 30; k++) add(baseY - k * CORRIDOR_OFFSET);
+        for (const y of candidates) {
+          // A horizontal component's pin row (e.g. an inductor's leads at y=cy)
+          // coincides with the bus when the bus is at pinY — that's not a body
+          // crossing, it's the bus passing through the pin on its way to
+          // another pin on the same net, so don't mark it as forbidden.
+          const inBody = forbidden.some(({ y1, y2, pinYs }) =>
+            y > y1 && y < y2 && !pinYs.some(py => Math.abs(py - y) < 1)
+          );
+          if (inBody) continue;
+          const occupants = yUsersX.get(y) ?? [];
+          const netRail = findRail(net);
+          const overlaps = occupants.some(({ xMin: ox1, xMax: ox2, net: other }) => {
+            if (findRail(other) === netRail) return false;
+            return !(xMax < ox1 || ox2 < xMin);
+          });
+          if (overlaps) continue;
+          netBusY.set(net, y);
+          if (!yUsersX.has(y)) yUsersX.set(y, []);
+          yUsersX.get(y)!.push({ xMin, xMax, net });
+          break;
+        }
+        if (!netBusY.has(net)) netBusY.set(net, baseY);
+      }
     }
   }
 

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -621,7 +621,11 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
       return { net, x: x + sp.dx, y: y + sp.dy };
     });
 
-    placedComponents.push({ component: comp, x, y, rotation: 0, horizontal, stretchH, pins });
+    // Diodes are directional: when flip2Term remaps the anode to pin 1 (so it
+    // renders at the cathode's visual position), the triangle must also flip
+    // so the arrow still points from anode to cathode.
+    const flipped = comp.type === 'D' && flip2Term;
+    placedComponents.push({ component: comp, x, y, rotation: 0, horizontal, stretchH, flipped, pins });
   }
 
   // --- Pin alignment: pull vertical 2-terminal R's onto their peer's column

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -60,46 +60,135 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
   }
   allNets.add(GND);
 
-  // Gather edges. Every component contributes an undirected edge between its
-  // two primary endpoints; components with known polarity also contribute a
-  // directed high→low constraint.
+  // --- Rank-preservation via DC-loop analysis ---------------------------
+  // A resistor or inductor has no DC voltage drop when no DC current flows
+  // through it — i.e., when it's terminated by a capacitor or an opamp input
+  // rather than by a path back to the same supply. Detect this by checking
+  // whether the endpoints stay connected in the graph of DC-conductive
+  // components after the R/L is removed. If they do, current can flow and the
+  // component differentiates ranks; if they don't, the component is a
+  // "signal-chain" hop whose endpoints are at the same DC potential and
+  // should share a rank.
+  const DC_TYPES = new Set(['V', 'I', 'R', 'L', 'M', 'Q', 'E', 'G', 'F', 'H']);
+  const dcEdges: Array<{ id: string; a: string; b: string }> = [];
+  for (const comp of circuit.components) {
+    if (!DC_TYPES.has(comp.type)) continue;
+    const [a, b] = componentEndpoints(comp);
+    if (a !== b) dcEdges.push({ id: comp.id, a, b });
+  }
+
+  const dcConnectedSkipping = (skip: string, from: string, to: string): boolean => {
+    if (from === to) return true;
+    const visited = new Set<string>([from]);
+    const queue = [from];
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+      for (const e of dcEdges) {
+        if (e.id === skip) continue;
+        const other = e.a === node ? e.b : e.b === node ? e.a : null;
+        if (other === null || visited.has(other)) continue;
+        if (other === to) return true;
+        visited.add(other);
+        queue.push(other);
+      }
+    }
+    return false;
+  };
+
+  const rankPreserving = new Set<string>();
+  for (const comp of circuit.components) {
+    if (comp.type !== 'R' && comp.type !== 'L') continue;
+    const [a, b] = componentEndpoints(comp);
+    if (a === b) continue;
+    if (!dcConnectedSkipping(comp.id, a, b)) rankPreserving.add(comp.id);
+  }
+
+  // --- Union-find: merge nets joined by rank-preserving R/L ------------
+  const parent = new Map<string, string>();
+  for (const n of allNets) parent.set(n, n);
+  const find = (n: string): string => {
+    let r = n;
+    while (parent.get(r)! !== r) r = parent.get(r)!;
+    let cur = n;
+    while (parent.get(cur)! !== r) {
+      const next = parent.get(cur)!;
+      parent.set(cur, r);
+      cur = next;
+    }
+    return r;
+  };
+  const union = (a: string, b: string) => {
+    const ra = find(a), rb = find(b);
+    if (ra === rb) return;
+    // Prefer ground as the set root so GND stays at rank 0.
+    if (ra === GND) parent.set(rb, ra);
+    else if (rb === GND) parent.set(ra, rb);
+    else parent.set(ra, rb);
+  };
+  for (const comp of circuit.components) {
+    if (!rankPreserving.has(comp.id)) continue;
+    const [a, b] = componentEndpoints(comp);
+    if (a !== b) union(a, b);
+  }
+
+  // --- Edge collection at set level -----------------------------------
+  // Non-source components contribute an undirected edge (between set
+  // representatives) used for BFS distance. Rank-preserving R/L are already
+  // collapsed via union-find, so their edges are self-loops and dropped.
+  // Source components (V/I/E/G/F/H) contribute only a directed polarity
+  // constraint; their terminals define the voltage hierarchy rather than a
+  // hop in the signal chain.
+  const SOURCE_TYPES = new Set(['V', 'I', 'E', 'G', 'F', 'H']);
   const undirectedPairs: Array<[string, string]> = [];
   const directedHighLow: Array<[string, string]> = [];
 
   for (const comp of circuit.components) {
     const [a, b] = componentEndpoints(comp);
-    if (a !== b) undirectedPairs.push([a, b]);
+    const sa = find(a), sb = find(b);
+    if (sa !== sb && !SOURCE_TYPES.has(comp.type)) undirectedPairs.push([sa, sb]);
 
     let high: string | null = null, low: string | null = null;
     switch (comp.type) {
       case 'V': case 'I':
         high = comp.ports[0].net; low = comp.ports[1].net; break;
-      case 'M':
-        high = comp.ports[0].net; low = comp.ports[2].net; break;
-      case 'Q':
-        high = comp.ports[0].net; low = comp.ports[2].net; break;
+      case 'M': {
+        const isP = comp.params?.channelType === 'p';
+        high = isP ? comp.ports[2].net : comp.ports[0].net;
+        low  = isP ? comp.ports[0].net : comp.ports[2].net;
+        break;
+      }
+      case 'Q': {
+        const isPnp = comp.params?.type === 'pnp';
+        high = isPnp ? comp.ports[2].net : comp.ports[0].net;
+        low  = isPnp ? comp.ports[0].net : comp.ports[2].net;
+        break;
+      }
       case 'E': case 'G':
         high = comp.ports[2].net; low = comp.ports[3].net; break;
-      // D, R, L, C, F, H, X: undirected only
+      // D, C, X: undirected only
     }
-    if (high !== null && low !== null && high !== low) {
-      directedHighLow.push([high, low]);
+    if (high !== null && low !== null) {
+      const sh = find(high), sl = find(low);
+      if (sh !== sl) directedHighLow.push([sh, sl]);
     }
   }
 
-  // Undirected adjacency for BFS.
+  const reps = new Set<string>();
+  for (const n of allNets) reps.add(find(n));
+
+  // --- Step 1: BFS distance from ground's set through undirected edges --
+  const gndRep = find(GND);
   const undirected = new Map<string, Set<string>>();
-  for (const n of allNets) undirected.set(n, new Set());
+  for (const r of reps) undirected.set(r, new Set());
   for (const [a, b] of undirectedPairs) {
     undirected.get(a)!.add(b);
     undirected.get(b)!.add(a);
   }
 
-  // Step 1: BFS distance from ground through undirected graph.
   const dist = new Map<string, number>();
-  for (const n of allNets) dist.set(n, Infinity);
-  dist.set(GND, 0);
-  const bfs: string[] = [GND];
+  for (const r of reps) dist.set(r, Infinity);
+  dist.set(gndRep, 0);
+  const bfs: string[] = [gndRep];
   while (bfs.length > 0) {
     const node = bfs.shift()!;
     const d = dist.get(node)!;
@@ -110,44 +199,43 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
       }
     }
   }
-  // Isolated nets (no path to ground) get a small positive distance so
-  // longest-path relaxation still places them above ground.
-  for (const n of allNets) {
-    if (dist.get(n) === Infinity) dist.set(n, 1);
+  for (const r of reps) {
+    if (dist.get(r) === Infinity) dist.set(r, 1);
   }
 
-  // Step 2: Build DAG by orienting each undirected edge from lower to higher
-  // BFS distance. Equal distances use lexicographic tiebreak.
+  // --- Step 2: Build DAG at set level ----------------------------------
+  // Orient each undirected edge from the lower-distance endpoint to the
+  // higher-distance one. Drop edges whose endpoints share a BFS distance —
+  // those carry no rank-ordering information and would otherwise introduce a
+  // spurious rank step (e.g., a feedback capacitor between two nodes that
+  // are both on the same signal rail).
   const dagFrom = new Map<string, Set<string>>();
-  for (const n of allNets) dagFrom.set(n, new Set());
+  for (const r of reps) dagFrom.set(r, new Set());
   for (const [a, b] of undirectedPairs) {
     const da = dist.get(a)!, db = dist.get(b)!;
-    let lo: string, hi: string;
-    if (da < db) { lo = a; hi = b; }
-    else if (db < da) { lo = b; hi = a; }
-    else { [lo, hi] = a < b ? [a, b] : [b, a]; }
+    if (da === db) continue;
+    const [lo, hi] = da < db ? [a, b] : [b, a];
     dagFrom.get(lo)!.add(hi);
   }
 
-  // Step 3: Apply directed polarity. For each high→low pair, ensure the edge
-  // runs low→high in the DAG (reverse the existing edge if needed).
+  // --- Step 3: Apply directed polarity overrides -----------------------
   for (const [high, low] of directedHighLow) {
     dagFrom.get(high)?.delete(low);
     dagFrom.get(low)?.add(high);
   }
 
-  // Step 4: Longest path from ground via Bellman–Ford-style relaxation.
-  const rank = new Map<string, number>();
-  for (const n of allNets) rank.set(n, 0);
+  // --- Step 4: Longest path from ground's set --------------------------
+  const rankByRep = new Map<string, number>();
+  for (const r of reps) rankByRep.set(r, 0);
 
-  const maxIter = allNets.size * 2 + 1;
+  const maxIter = reps.size * 2 + 1;
   for (let i = 0; i < maxIter; i++) {
     let changed = false;
     for (const [from, tos] of dagFrom) {
-      const fromRank = rank.get(from)!;
+      const fromRank = rankByRep.get(from)!;
       for (const to of tos) {
-        if (fromRank + 1 > rank.get(to)!) {
-          rank.set(to, fromRank + 1);
+        if (fromRank + 1 > rankByRep.get(to)!) {
+          rankByRep.set(to, fromRank + 1);
           changed = true;
         }
       }
@@ -155,6 +243,9 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
     if (!changed) break;
   }
 
+  // --- Step 5: Project set ranks back onto every net -------------------
+  const rank = new Map<string, number>();
+  for (const n of allNets) rank.set(n, rankByRep.get(find(n))!);
   return rank;
 }
 
@@ -164,37 +255,81 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
 
 interface Placement {
   comp: IRComponent;
-  col: number;   // horizontal slot
+  col: number;   // BFS distance from the nearest source component
   topRank: number;    // higher-potential node rank
   bottomRank: number; // lower-potential node rank
 }
 
+/** Assign each component a column by BFS from voltage/current sources through
+ * shared non-ground nets. The result reflects signal flow: V1 at col 0, a
+ * series R between V1's + and the output at col 1, the output capacitor at
+ * col 2, and so on. Components that share the same intermediate net (e.g. MP
+ * and MN both touching `out` in a CMOS inverter) land in the same column. */
+function assignColumns(circuit: CircuitIR): Map<string, number> {
+  const col = new Map<string, number>();
+  const netToComps = new Map<string, string[]>();
+  for (const c of circuit.components) {
+    for (const p of c.ports) {
+      if (p.net === '0') continue;
+      if (!netToComps.has(p.net)) netToComps.set(p.net, []);
+      netToComps.get(p.net)!.push(c.id);
+    }
+  }
+  const compById = new Map(circuit.components.map(c => [c.id, c]));
+
+  const queue: string[] = [];
+  for (const c of circuit.components) {
+    if (c.type === 'V' || c.type === 'I') {
+      col.set(c.id, 0);
+      queue.push(c.id);
+    }
+  }
+  // Degenerate circuit with no sources — anchor BFS on the first component.
+  if (queue.length === 0 && circuit.components.length > 0) {
+    col.set(circuit.components[0].id, 0);
+    queue.push(circuit.components[0].id);
+  }
+
+  while (queue.length > 0) {
+    const cid = queue.shift()!;
+    const c = compById.get(cid)!;
+    const next = col.get(cid)! + 1;
+    const seen = new Set<string>();
+    for (const p of c.ports) {
+      if (p.net === '0') continue;
+      for (const nid of netToComps.get(p.net) ?? []) {
+        if (nid === cid || seen.has(nid)) continue;
+        seen.add(nid);
+        if (!col.has(nid)) {
+          col.set(nid, next);
+          queue.push(nid);
+        }
+      }
+    }
+  }
+
+  // Any unreached components (isolated) get placed after the rest.
+  let fallback = Math.max(0, ...col.values()) + 1;
+  for (const c of circuit.components) {
+    if (!col.has(c.id)) col.set(c.id, fallback++);
+  }
+  return col;
+}
+
 function placeComponents(circuit: CircuitIR, nodeRanks: Map<string, number>): Placement[] {
+  const columns = assignColumns(circuit);
   const placements: Placement[] = [];
-
-  // Group components by which pair of ranks they span
-  const spanGroups = new Map<string, IRComponent[]>();
-
   for (const comp of circuit.components) {
     const [netA, netB] = componentEndpoints(comp);
     const rankA = nodeRanks.get(netA) ?? 0;
     const rankB = nodeRanks.get(netB) ?? 0;
-    const topRank = Math.max(rankA, rankB);
-    const bottomRank = Math.min(rankA, rankB);
-    const key = `${topRank}-${bottomRank}`;
-
-    if (!spanGroups.has(key)) spanGroups.set(key, []);
-    spanGroups.get(key)!.push(comp);
-  }
-
-  // Assign columns within each span group
-  for (const [key, comps] of spanGroups) {
-    const [topRank, bottomRank] = key.split('-').map(Number);
-    comps.forEach((comp, i) => {
-      placements.push({ comp, col: i, topRank, bottomRank });
+    placements.push({
+      comp,
+      col: columns.get(comp.id) ?? 0,
+      topRank: Math.max(rankA, rankB),
+      bottomRank: Math.min(rankA, rankB),
     });
   }
-
   return placements;
 }
 
@@ -214,57 +349,103 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   // --- Component placement ---
   const placements = placeComponents(circuit, nodeRanks);
 
-  // Compute the global column count per span group to avoid overlap
-  // We need to assign absolute X positions so components don't collide
-  // Strategy: lay out all components left-to-right, grouped by their span
-  const spanCols = new Map<string, number>(); // span key → starting absolute column
-  let nextAbsCol = 0;
+  // Within each BFS column, pack components into sub-columns. Two placements
+  // can share a sub-column (stack vertically) only when their symbol Y ranges
+  // are separated by at least STACK_GAP pixels — otherwise their bodies or
+  // ground stubs would overlap. Each sub-column consumes one SLOT_SPACING of
+  // horizontal space.
+  const STACK_GAP = GRID / 2;
+  const symbolFor = (pl: Placement) => {
+    const horizontal = pl.comp.type === 'C' && pl.topRank === pl.bottomRank;
+    return { horizontal, sym: getSymbol(pl.comp.type, pl.comp.displayValue ?? '', horizontal) };
+  };
+  const centerYFor = (pl: Placement) => {
+    const topY = MARGIN + (maxRank - pl.topRank) * RANK_SPACING;
+    const bottomY = MARGIN + (maxRank - pl.bottomRank) * RANK_SPACING;
+    return (topY + bottomY) / 2;
+  };
 
-  // Sort span groups: prioritize spans that include higher ranks (appear more to the left)
-  const spanKeys = [...new Set(placements.map(p => `${p.topRank}-${p.bottomRank}`))];
-  spanKeys.sort((a, b) => {
-    const [aTop] = a.split('-').map(Number);
-    const [bTop] = b.split('-').map(Number);
-    return bTop - aTop; // higher rank first
-  });
+  const byCol = new Map<number, Placement[]>();
+  for (const pl of placements) {
+    if (!byCol.has(pl.col)) byCol.set(pl.col, []);
+    byCol.get(pl.col)!.push(pl);
+  }
 
-  for (const key of spanKeys) {
-    const count = placements.filter(p => `${p.topRank}-${p.bottomRank}` === key).length;
-    spanCols.set(key, nextAbsCol);
-    nextAbsCol += count;
+  const xForComp = new Map<string, number>();
+  let nextAbsX = MARGIN;
+  const cols = [...byCol.keys()].sort((a, b) => a - b);
+
+  for (const col of cols) {
+    const pls = byCol.get(col)!;
+    // Sort top-to-bottom (highest rank first = lowest Y)
+    pls.sort((a, b) => {
+      if (a.topRank !== b.topRank) return b.topRank - a.topRank;
+      return b.bottomRank - a.bottomRank;
+    });
+
+    // Greedy column packing: place each component in the first sub-column
+    // that still has vertical room below the last component.
+    const subCols: { bottomY: number }[] = [];
+    const subColForComp = new Map<string, number>();
+    for (const pl of pls) {
+      const { sym } = symbolFor(pl);
+      const cy = centerYFor(pl);
+      const topY = cy - sym.height / 2;
+      const bottomY = cy + sym.height / 2;
+      let sc = -1;
+      for (let i = 0; i < subCols.length; i++) {
+        if (topY >= subCols[i].bottomY + STACK_GAP) { sc = i; break; }
+      }
+      if (sc === -1) { sc = subCols.length; subCols.push({ bottomY }); }
+      else subCols[sc].bottomY = bottomY;
+      subColForComp.set(pl.comp.id, sc);
+    }
+
+    for (const pl of pls) {
+      const sc = subColForComp.get(pl.comp.id)!;
+      xForComp.set(pl.comp.id, nextAbsX + sc * SLOT_SPACING);
+    }
+    nextAbsX += subCols.length * SLOT_SPACING;
   }
 
   // --- Pixel positions ---
   const placedComponents: PlacedComponent[] = [];
 
   for (const pl of placements) {
-    const { comp, col, topRank, bottomRank } = pl;
-    const spanKey = `${topRank}-${bottomRank}`;
-    const absCol = (spanCols.get(spanKey) ?? 0) + col;
+    const { comp, topRank, bottomRank } = pl;
 
-    const symbol = getSymbol(comp.type, comp.displayValue ?? '');
+    const { horizontal, sym: symbol } = symbolFor(pl);
     const nets = comp.ports.map(p => p.net);
 
-    // Y position: center the component between its top and bottom rank rails
-    // Ranks are inverted for display: highest rank = top of screen (lowest Y)
-    const topY = MARGIN + (maxRank - topRank) * RANK_SPACING;
-    const bottomY = MARGIN + (maxRank - bottomRank) * RANK_SPACING;
-    const centerY = (topY + bottomY) / 2;
-
-    // X position based on absolute column
-    const x = MARGIN + absCol * SLOT_SPACING;
+    const centerY = centerYFor(pl);
+    const x = xForComp.get(comp.id)!;
     const y = centerY - symbol.height / 2;
 
-    // Map pins: symbol pins get assigned to component port nets
-    const pins: Pin[] = symbol.pins.map((p, i) => ({
-      net: i < nets.length ? nets[i] : '0',
-      x: x + p.dx,
-      y: y + p.dy,
-    }));
+    // Map IR port i to a symbol pin position. For PMOS / PNP, swap the
+    // drain/collector and source/emitter positions so the "source-side" pin
+    // (which sits at higher potential) renders above the drain/collector.
+    // For undirected 2-terminal symbols (R, L, C, D) whose IR port ordering
+    // happens to put the lower-rank net first, swap pins 0 and 1 so the
+    // higher-rank net always renders at the top/left of the symbol body.
+    const flipForP =
+      (comp.type === 'M' && comp.params?.channelType === 'p') ||
+      (comp.type === 'Q' && comp.params?.type === 'pnp');
+    const flip2Term =
+      symbol.pins.length === 2 &&
+      (nodeRanks.get(nets[0]) ?? 0) < (nodeRanks.get(nets[1]) ?? 0);
+    const symIdx = (i: number): number => {
+      if (flipForP && (i === 0 || i === 2)) return i === 0 ? 2 : 0;
+      if (flip2Term && (i === 0 || i === 1)) return 1 - i;
+      return i;
+    };
+    const pins: Pin[] = nets.slice(0, symbol.pins.length).map((net, i) => {
+      const sp = symbol.pins[symIdx(i)];
+      return { net, x: x + sp.dx, y: y + sp.dy };
+    });
 
     placedComponents.push({
       component: comp,
-      x, y, rotation: 0,
+      x, y, rotation: 0, horizontal,
       pins,
     });
   }
@@ -363,7 +544,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   // --- Bounds ---
   let maxX = 0, maxY = 0;
   for (const pc of placedComponents) {
-    const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '');
+    const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal);
     maxX = Math.max(maxX, pc.x + sym.width);
     maxY = Math.max(maxY, pc.y + sym.height);
   }

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -474,6 +474,18 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   // render on the same pixel row.
   const CORRIDOR_OFFSET = GRID * 0.4;
 
+  // Group nets by rank, and within each rank group further partition by
+  // transitive x-range overlap. Only nets whose horizontal buses would
+  // actually collide need a corridor offset; disjoint nets can share the
+  // base rail Y, which keeps the rail perfectly horizontal through their
+  // pins.
+  const xRangeByNet = new Map<string, [number, number]>();
+  for (const [net, pins] of netPins) {
+    if (net === '0' || pins.length < 2) continue;
+    const xs = pins.map(p => p.x);
+    xRangeByNet.set(net, [Math.min(...xs), Math.max(...xs)]);
+  }
+
   const netsByRank = new Map<number, string[]>();
   for (const net of netPins.keys()) {
     if (net === '0') continue;
@@ -481,14 +493,38 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     if (!netsByRank.has(r)) netsByRank.set(r, []);
     netsByRank.get(r)!.push(net);
   }
+
   const netBusY = new Map<string, number>();
   for (const [r, nets] of netsByRank) {
     const baseY = MARGIN + (maxRank - r) * RANK_SPACING;
-    nets.sort();
-    nets.forEach((net, i) => {
-      const offset = (i - (nets.length - 1) / 2) * CORRIDOR_OFFSET;
-      netBusY.set(net, baseY + offset);
+    // Partition into x-overlap groups. Sort by minX first so scan is linear.
+    const sorted = [...nets].sort((a, b) => {
+      const ra = xRangeByNet.get(a), rb = xRangeByNet.get(b);
+      if (!ra || !rb) return a.localeCompare(b);
+      return ra[0] - rb[0];
     });
+    const groups: string[][] = [];
+    for (const net of sorted) {
+      const range = xRangeByNet.get(net);
+      const current = groups[groups.length - 1];
+      if (current && range) {
+        const overlaps = current.some(other => {
+          const o = xRangeByNet.get(other);
+          return o && !(range[1] < o[0] || o[1] < range[0]);
+        });
+        if (overlaps) { current.push(net); continue; }
+      }
+      groups.push([net]);
+    }
+
+    for (const g of groups) {
+      if (g.length === 1) { netBusY.set(g[0], baseY); continue; }
+      g.sort();
+      g.forEach((net, i) => {
+        const offset = (i - (g.length - 1) / 2) * CORRIDOR_OFFSET;
+        netBusY.set(net, baseY + offset);
+      });
+    }
   }
 
   for (const [net, pins] of netPins) {

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -355,9 +355,15 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   // ground stubs would overlap. Each sub-column consumes one SLOT_SPACING of
   // horizontal space.
   const STACK_GAP = GRID / 2;
+  const STRETCH_TYPES = new Set(['V', 'I', 'C']);
   const symbolFor = (pl: Placement) => {
     const horizontal = pl.comp.type === 'C' && pl.topRank === pl.bottomRank;
-    return { horizontal, sym: getSymbol(pl.comp.type, pl.comp.displayValue ?? '', horizontal) };
+    // Vertical 2-terminal symbols stretch to match the rank span so their pins
+    // align with both rail Ys without a dangling lead-wire at either end.
+    const stretchH = !horizontal && STRETCH_TYPES.has(pl.comp.type) && pl.topRank > pl.bottomRank
+      ? (pl.topRank - pl.bottomRank) * RANK_SPACING
+      : undefined;
+    return { horizontal, stretchH, sym: getSymbol(pl.comp.type, pl.comp.displayValue ?? '', horizontal, stretchH) };
   };
   const centerYFor = (pl: Placement) => {
     const topY = MARGIN + (maxRank - pl.topRank) * RANK_SPACING;
@@ -414,7 +420,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   for (const pl of placements) {
     const { comp, topRank, bottomRank } = pl;
 
-    const { horizontal, sym: symbol } = symbolFor(pl);
+    const { horizontal, stretchH, sym: symbol } = symbolFor(pl);
     const nets = comp.ports.map(p => p.net);
 
     const centerY = centerYFor(pl);
@@ -445,7 +451,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
 
     placedComponents.push({
       component: comp,
-      x, y, rotation: 0, horizontal,
+      x, y, rotation: 0, horizontal, stretchH,
       pins,
     });
   }
@@ -544,7 +550,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   // --- Bounds ---
   let maxX = 0, maxY = 0;
   for (const pc of placedComponents) {
-    const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal);
+    const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH);
     maxX = Math.max(maxX, pc.x + sym.width);
     maxY = Math.max(maxY, pc.y + sym.height);
   }

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -132,20 +132,40 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
   }
 
   // --- Edge collection at set level -----------------------------------
-  // Non-source components contribute an undirected edge (between set
-  // representatives) used for BFS distance. Rank-preserving R/L are already
-  // collapsed via union-find, so their edges are self-loops and dropped.
-  // Source components (V/I/E/G/F/H) contribute only a directed polarity
-  // constraint; their terminals define the voltage hierarchy rather than a
-  // hop in the signal chain.
+  // Rank-preserving R/L are already collapsed via union-find, so their edges
+  // are self-loops and dropped. Every other component contributes an
+  // undirected edge between set representatives; sources (V/I/E/G/F/H) also
+  // contribute a directed polarity constraint.
+  //
+  // The undirected edges feed two things:
+  //   - BFS distance from ground (used for orienting edges away from ground).
+  //   - The DAG itself (longest-path relaxation).
+  // Source components participate in BFS so the side they drive (e.g. the
+  // opamp output) picks up a finite distance from ground, but they are not
+  // added as DAG edges: their polarity constraint handles ordering. A
+  // differentiating R/L whose endpoints happen to share a BFS distance must
+  // still contribute a rank step (e.g. RD in a common-source amp where both
+  // vdd and out are dist 1 via VDD and M1's drain), so it stays in the DAG
+  // with a lexicographic tiebreak.
   const SOURCE_TYPES = new Set(['V', 'I', 'E', 'G', 'F', 'H']);
-  const undirectedPairs: Array<[string, string]> = [];
+  interface UEdge { a: string; b: string; keepAtSameDist: boolean }
+  const bfsEdges: Array<[string, string]> = [];
+  const dagCandidates: UEdge[] = [];
   const directedHighLow: Array<[string, string]> = [];
 
   for (const comp of circuit.components) {
     const [a, b] = componentEndpoints(comp);
     const sa = find(a), sb = find(b);
-    if (sa !== sb && !SOURCE_TYPES.has(comp.type)) undirectedPairs.push([sa, sb]);
+    if (sa !== sb) {
+      bfsEdges.push([sa, sb]);
+      if (!SOURCE_TYPES.has(comp.type)) {
+        // Differentiating R/L is the only type that must insist on a rank
+        // step even when BFS distance is equal.
+        const isRL = comp.type === 'R' || comp.type === 'L';
+        const keepAtSameDist = isRL && !rankPreserving.has(comp.id);
+        dagCandidates.push({ a: sa, b: sb, keepAtSameDist });
+      }
+    }
 
     let high: string | null = null, low: string | null = null;
     switch (comp.type) {
@@ -180,7 +200,7 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
   const gndRep = find(GND);
   const undirected = new Map<string, Set<string>>();
   for (const r of reps) undirected.set(r, new Set());
-  for (const [a, b] of undirectedPairs) {
+  for (const [a, b] of bfsEdges) {
     undirected.get(a)!.add(b);
     undirected.get(b)!.add(a);
   }
@@ -205,17 +225,29 @@ function rankNodes(circuit: CircuitIR): Map<string, number> {
 
   // --- Step 2: Build DAG at set level ----------------------------------
   // Orient each undirected edge from the lower-distance endpoint to the
-  // higher-distance one. Drop edges whose endpoints share a BFS distance —
-  // those carry no rank-ordering information and would otherwise introduce a
-  // spurious rank step (e.g., a feedback capacitor between two nodes that
-  // are both on the same signal rail).
+  // higher-distance one. Drop same-distance edges unless the component
+  // insists on a rank step (see `keepAtSameDist` above) — that keeps feedback
+  // caps and similar soft links from introducing a spurious extra rank. When
+  // a same-distance edge IS kept, orient it so the V-source-driven endpoint
+  // ends up at the higher rank (e.g. vdd above out across RD in a
+  // common-source amp, in above out across R1 in a voltage divider).
+  const vPlusReps = new Set<string>();
+  for (const comp of circuit.components) {
+    if (comp.type === 'V' || comp.type === 'I') vPlusReps.add(find(comp.ports[0].net));
+  }
   const dagFrom = new Map<string, Set<string>>();
   for (const r of reps) dagFrom.set(r, new Set());
-  for (const [a, b] of undirectedPairs) {
+  for (const { a, b, keepAtSameDist } of dagCandidates) {
     const da = dist.get(a)!, db = dist.get(b)!;
-    if (da === db) continue;
-    const [lo, hi] = da < db ? [a, b] : [b, a];
-    dagFrom.get(lo)!.add(hi);
+    if (da < db) dagFrom.get(a)!.add(b);
+    else if (db < da) dagFrom.get(b)!.add(a);
+    else if (keepAtSameDist) {
+      let lo: string, hi: string;
+      if (vPlusReps.has(a) && !vPlusReps.has(b)) { hi = a; lo = b; }
+      else if (vPlusReps.has(b) && !vPlusReps.has(a)) { hi = b; lo = a; }
+      else { [lo, hi] = a < b ? [a, b] : [b, a]; }
+      dagFrom.get(lo)!.add(hi);
+    }
   }
 
   // --- Step 3: Apply directed polarity overrides -----------------------

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -1,201 +1,253 @@
 import type { CircuitIR, IRComponent, SchematicLayout, PlacedComponent, Wire, Junction, Pin } from './types.js';
 import { getSymbol, GRID } from './symbols.js';
 
-const COL_SPACING = GRID * 5;
-const ROW_SPACING = GRID * 4;
+const RANK_SPACING = GRID * 4;   // vertical distance between node ranks
+const SLOT_SPACING = GRID * 5;   // horizontal distance between component slots
 const MARGIN = GRID * 2;
 
-/** Extract net names from an IR component's ports. */
-function componentNets(comp: IRComponent): string[] {
-  return comp.ports.map(p => p.net);
+/* ------------------------------------------------------------------ */
+/*  Step 1: Build node graph                                          */
+/* ------------------------------------------------------------------ */
+
+interface NodeInfo {
+  net: string;
+  rank: number;
+  components: IRComponent[]; // components that touch this node
 }
 
-/**
- * Get the pin index to use for vertical rail alignment.
- * Multi-terminal devices align by their input pin (gate, base, +in).
- * Two-terminal devices align by the first non-ground pin.
- * Falls back to any non-ground pin if the preferred pin is ground.
- */
-function alignmentPinIndex(comp: IRComponent, nets: string[]): number {
-  // Preferred input pin indices per device type
-  const preferred: number[] = [];
-  switch (comp.type) {
-    case 'M': preferred.push(1); break; // gate
-    case 'Q': preferred.push(1); break; // base
-    case 'E': case 'G': preferred.push(0, 1); break; // ctrlP, ctrlN
-  }
-
-  // Try preferred pins first, fall back to any non-ground
-  for (const idx of preferred) {
-    if (idx < nets.length && nets[idx] !== '0') return idx;
-  }
-  const fallback = nets.findIndex(n => n !== '0');
-  return fallback >= 0 ? fallback : 0;
+/** Get the two primary nodes a component connects (ignoring ground duplicates). */
+function componentEndpoints(comp: IRComponent): [string, string] {
+  const nets = comp.ports.map(p => p.net);
+  // For 2-terminal: straightforward
+  if (nets.length === 2) return [nets[0], nets[1]];
+  // For MOSFET: primary path is drain→source
+  if (comp.type === 'M') return [nets[0], nets[2]]; // drain, source
+  // For BJT: primary path is collector→emitter
+  if (comp.type === 'Q') return [nets[0], nets[2]]; // collector, emitter
+  // For E/G (opamp): output path is outP→outN (ports 2,3)
+  if (comp.type === 'E' || comp.type === 'G') return [nets[2], nets[3]];
+  // For diode: anode→cathode
+  if (comp.type === 'D') return [nets[0], nets[1]];
+  // Fallback: first and last
+  return [nets[0], nets[nets.length - 1]];
 }
 
+/* ------------------------------------------------------------------ */
+/*  Step 2: Rank nodes by voltage potential                           */
+/* ------------------------------------------------------------------ */
+
 /**
- * Get the "input" nets for a component — the nets most meaningful for
- * signal-flow column placement.
+ * Assign vertical ranks to nodes using directed longest-path from ground.
+ *
+ * Uses component-type-aware directed edges (drain→source for MOSFET,
+ * anode→cathode for diode, pos→neg for sources) to build a DAG, then
+ * computes the longest path from ground to each node. This gives proper
+ * intermediate ranks (e.g., sw between in and 0 in a buck converter).
+ *
+ * Ground = rank 0 (bottom of schematic, highest Y).
+ * Higher rank = higher potential = top of schematic (lowest Y).
  */
-function inputNets(comp: IRComponent): Set<string> {
-  const nets = new Set<string>();
-  switch (comp.type) {
-    case 'M':
-      if (comp.ports[1]?.net !== '0') nets.add(comp.ports[1].net);
-      break;
-    case 'Q':
-      if (comp.ports[1]?.net !== '0') nets.add(comp.ports[1].net);
-      break;
-    case 'E': case 'G':
-      if (comp.ports[0]?.net !== '0') nets.add(comp.ports[0].net);
-      if (comp.ports[1]?.net !== '0') nets.add(comp.ports[1].net);
-      break;
-    default:
-      for (const p of comp.ports) {
-        if (p.net !== '0') nets.add(p.net);
-      }
+function rankNodes(circuit: CircuitIR): Map<string, number> {
+  const GND = '0';
+
+  // Collect all unique nets
+  const allNets = new Set<string>();
+  for (const comp of circuit.components) {
+    for (const p of comp.ports) allNets.add(p.net);
   }
-  if (nets.size === 0) {
-    for (const p of comp.ports) {
-      if (p.net !== '0') nets.add(p.net);
+
+  // Build directed adjacency: highNet → lowNet edges (current flow direction)
+  // Also keep undirected for fallback connectivity
+  const directedDown = new Map<string, Set<string>>(); // high → low
+  const directedUp = new Map<string, Set<string>>();   // low → high
+  const undirected = new Map<string, Set<string>>();
+  for (const n of allNets) {
+    directedDown.set(n, new Set());
+    directedUp.set(n, new Set());
+    undirected.set(n, new Set());
+  }
+
+  for (const comp of circuit.components) {
+    const [a, b] = componentEndpoints(comp);
+    undirected.get(a)!.add(b);
+    undirected.get(b)!.add(a);
+
+    // Only add directed edges for components with known polarity.
+    // Passive components (R, L, C) are undirected — we don't know voltage direction.
+    let high: string | null = null, low: string | null = null;
+    switch (comp.type) {
+      case 'V': case 'I':
+        high = comp.ports[0].net; // positive terminal
+        low = comp.ports[1].net;  // negative terminal
+        break;
+      case 'M':
+        high = comp.ports[0].net; // drain
+        low = comp.ports[2].net;  // source
+        break;
+      case 'Q':
+        high = comp.ports[0].net; // collector
+        low = comp.ports[2].net;  // emitter
+        break;
+      // D (diode): polarity depends on circuit context (forward vs freewheeling).
+      // Treat as undirected — let other directed edges determine rank ordering.
+      case 'E': case 'G':
+        high = comp.ports[2].net; // outP
+        low = comp.ports[3].net;  // outN
+        break;
+      // R, L, C, F, H, X: no directed edge — undirected only
+    }
+
+    if (high !== null && low !== null) {
+      directedDown.get(high)!.add(low);
+      directedUp.get(low)!.add(high);
     }
   }
-  return nets;
+
+  // Longest path from ground upward using directed edges
+  // Use iterative relaxation (Bellman-Ford style for longest path in DAG)
+  const rank = new Map<string, number>();
+  for (const n of allNets) rank.set(n, -1);
+  rank.set(GND, 0);
+
+  // Relaxation: repeatedly update ranks via directed-up edges
+  let changed = true;
+  let iterations = 0;
+  while (changed && iterations < allNets.size + 1) {
+    changed = false;
+    for (const [node, currentRank] of rank) {
+      if (currentRank < 0) continue;
+      // Follow edges upward: neighbors that are at higher potential
+      for (const higher of directedUp.get(node) ?? []) {
+        const newRank = currentRank + 1;
+        if (newRank > (rank.get(higher) ?? -1)) {
+          rank.set(higher, newRank);
+          changed = true;
+        }
+      }
+    }
+    iterations++;
+  }
+
+  // Fallback: unranked nodes connected via undirected edges (R, L, C)
+  // get the SAME rank as their ranked neighbor — they're at similar potential.
+  const queue = [...allNets].filter(n => (rank.get(n) ?? -1) >= 0);
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const currentRank = rank.get(current)!;
+    for (const neighbor of undirected.get(current) ?? []) {
+      if ((rank.get(neighbor) ?? -1) < 0) {
+        rank.set(neighbor, currentRank); // same rank, not +1
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  // Final fallback: truly disconnected nodes
+  for (const n of allNets) {
+    if ((rank.get(n) ?? -1) < 0) rank.set(n, 1);
+  }
+
+  return rank;
 }
 
-/**
- * Auto-layout a circuit IR using left-to-right signal flow.
- *
- * 1. Sources (V, I) placed in column 0
- * 2. BFS through nets to place remaining components in subsequent columns
- * 3. Wire routing: orthogonal L-shaped segments connecting pins on the same net
- */
+/* ------------------------------------------------------------------ */
+/*  Step 3: Place components between their ranked nodes               */
+/* ------------------------------------------------------------------ */
+
+interface Placement {
+  comp: IRComponent;
+  col: number;   // horizontal slot
+  topRank: number;    // higher-potential node rank
+  bottomRank: number; // lower-potential node rank
+}
+
+function placeComponents(circuit: CircuitIR, nodeRanks: Map<string, number>): Placement[] {
+  const placements: Placement[] = [];
+
+  // Group components by which pair of ranks they span
+  const spanGroups = new Map<string, IRComponent[]>();
+
+  for (const comp of circuit.components) {
+    const [netA, netB] = componentEndpoints(comp);
+    const rankA = nodeRanks.get(netA) ?? 0;
+    const rankB = nodeRanks.get(netB) ?? 0;
+    const topRank = Math.max(rankA, rankB);
+    const bottomRank = Math.min(rankA, rankB);
+    const key = `${topRank}-${bottomRank}`;
+
+    if (!spanGroups.has(key)) spanGroups.set(key, []);
+    spanGroups.get(key)!.push(comp);
+  }
+
+  // Assign columns within each span group
+  for (const [key, comps] of spanGroups) {
+    const [topRank, bottomRank] = key.split('-').map(Number);
+    comps.forEach((comp, i) => {
+      placements.push({ comp, col: i, topRank, bottomRank });
+    });
+  }
+
+  return placements;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Step 4: Convert to pixel positions + route wires                  */
+/* ------------------------------------------------------------------ */
+
 export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   if (circuit.components.length === 0) {
     return { components: [], wires: [], junctions: [], bounds: { width: 0, height: 0 } };
   }
 
-  const sources = circuit.components.filter(c => c.type === 'V' || c.type === 'I');
-  const others = circuit.components.filter(c => c.type !== 'V' && c.type !== 'I');
+  // --- Node ranking ---
+  const nodeRanks = rankNodes(circuit);
+  const maxRank = Math.max(...nodeRanks.values());
 
-  // Assign grid positions via BFS from sources
-  const placed = new Map<string, { col: number; row: number }>();
-  const visited = new Set<string>();
+  // --- Component placement ---
+  const placements = placeComponents(circuit, nodeRanks);
 
-  // Build a map from each non-ground net to the source row that owns it,
-  // so non-source components can be placed on the same row as their source.
-  const netToSourceRow = new Map<string, number>();
-  sources.forEach((s, i) => {
-    placed.set(s.id, { col: 0, row: i });
-    visited.add(s.id);
-    for (const n of componentNets(s)) {
-      if (n !== '0' && !netToSourceRow.has(n)) netToSourceRow.set(n, i);
-    }
+  // Compute the global column count per span group to avoid overlap
+  // We need to assign absolute X positions so components don't collide
+  // Strategy: lay out all components left-to-right, grouped by their span
+  const spanCols = new Map<string, number>(); // span key → starting absolute column
+  let nextAbsCol = 0;
+
+  // Sort span groups: prioritize spans that include higher ranks (appear more to the left)
+  const spanKeys = [...new Set(placements.map(p => `${p.topRank}-${p.bottomRank}`))];
+  spanKeys.sort((a, b) => {
+    const [aTop] = a.split('-').map(Number);
+    const [bTop] = b.split('-').map(Number);
+    return bTop - aTop; // higher rank first
   });
 
-  let frontier = [...sources];
-  let col = 1;
-  let nextFreeRow = sources.length; // for components that don't match any source row
-
-  while (frontier.length > 0 && visited.size < circuit.components.length) {
-    const nextFrontier: typeof frontier = [];
-    const frontierNets = new Set<string>();
-    for (const comp of frontier) {
-      for (const n of componentNets(comp)) {
-        if (n !== '0') frontierNets.add(n);
-      }
-    }
-
-    // Track which rows are taken in this column
-    const rowsTaken = new Set<number>();
-
-    // Place components that match the frontier, assigning rows based on
-    // which source they connect to (so related components share a row).
-    const toPlace: { comp: IRComponent; inputMatch: boolean }[] = [];
-
-    for (const comp of others) {
-      if (visited.has(comp.id)) continue;
-      const inNets = inputNets(comp);
-      const allNets = componentNets(comp);
-      const matchesInput = [...inNets].some(n => frontierNets.has(n));
-      const sharesAny = allNets.some(n => n !== '0' && frontierNets.has(n));
-      if (matchesInput) {
-        toPlace.push({ comp, inputMatch: true });
-      } else if (sharesAny) {
-        toPlace.push({ comp, inputMatch: false });
-      }
-    }
-
-    // Sort: input-match first (signal flow priority)
-    toPlace.sort((a, b) => (b.inputMatch ? 1 : 0) - (a.inputMatch ? 1 : 0));
-
-    for (const { comp } of toPlace) {
-      // Find the best row: prefer the row of a source this component connects to
-      const allNets = componentNets(comp);
-      let bestRow = -1;
-      for (const n of allNets) {
-        if (n !== '0' && netToSourceRow.has(n)) {
-          const srcRow = netToSourceRow.get(n)!;
-          if (!rowsTaken.has(srcRow)) {
-            bestRow = srcRow;
-            break;
-          }
-        }
-      }
-      if (bestRow < 0) {
-        // No source row available — use next free row
-        while (rowsTaken.has(nextFreeRow)) nextFreeRow++;
-        bestRow = nextFreeRow;
-        nextFreeRow++;
-      }
-
-      placed.set(comp.id, { col, row: bestRow });
-      visited.add(comp.id);
-      rowsTaken.add(bestRow);
-      nextFrontier.push(comp);
-
-      // Propagate: this component's nets also belong to its row
-      for (const n of allNets) {
-        if (n !== '0' && !netToSourceRow.has(n)) {
-          netToSourceRow.set(n, bestRow);
-        }
-      }
-    }
-
-    frontier = nextFrontier;
-    col++;
+  for (const key of spanKeys) {
+    const count = placements.filter(p => `${p.topRank}-${p.bottomRank}` === key).length;
+    spanCols.set(key, nextAbsCol);
+    nextAbsCol += count;
   }
 
-  // Place any remaining unvisited components
-  for (const comp of circuit.components) {
-    if (!visited.has(comp.id)) {
-      placed.set(comp.id, { col, row: 0 });
-      col++;
-    }
-  }
-
-  // Convert to pixel positions.
-  // Vertically offset each component so its first non-ground signal pin
-  // aligns on a shared horizontal rail per row. This ensures wires between
-  // components in the same row are straight horizontal lines.
-  const SIGNAL_RAIL_Y = MARGIN + GRID * 2; // baseline for row 0 signal pins
+  // --- Pixel positions ---
   const placedComponents: PlacedComponent[] = [];
 
-  for (const comp of circuit.components) {
-    const pos = placed.get(comp.id)!;
-    const nets = componentNets(comp);
+  for (const pl of placements) {
+    const { comp, col, topRank, bottomRank } = pl;
+    const spanKey = `${topRank}-${bottomRank}`;
+    const absCol = (spanCols.get(spanKey) ?? 0) + col;
+
     const symbol = getSymbol(comp.type, comp.displayValue ?? '');
+    const nets = comp.ports.map(p => p.net);
 
-    const x = MARGIN + pos.col * COL_SPACING;
+    // Y position: center the component between its top and bottom rank rails
+    // Ranks are inverted for display: highest rank = top of screen (lowest Y)
+    const topY = MARGIN + (maxRank - topRank) * RANK_SPACING;
+    const bottomY = MARGIN + (maxRank - bottomRank) * RANK_SPACING;
+    const centerY = (topY + bottomY) / 2;
 
-    // Find the first non-ground pin's dy offset — that pin should sit on the rail
-    const alignIdx = alignmentPinIndex(comp, nets);
-    const signalPinDy = alignIdx < symbol.pins.length
-      ? symbol.pins[alignIdx].dy
-      : symbol.pins[0].dy;
-    const railY = SIGNAL_RAIL_Y + pos.row * ROW_SPACING;
-    const y = railY - signalPinDy;
+    // X position based on absolute column
+    const x = MARGIN + absCol * SLOT_SPACING;
+    const y = centerY - symbol.height / 2;
 
+    // Map pins: symbol pins get assigned to component port nets
     const pins: Pin[] = symbol.pins.map((p, i) => ({
       net: i < nets.length ? nets[i] : '0',
       x: x + p.dx,
@@ -209,7 +261,8 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     });
   }
 
-  // Wire routing
+  // --- Wire routing ---
+  // Collect all pins per net
   const wires: Wire[] = [];
   const netPins = new Map<string, { x: number; y: number }[]>();
 
@@ -220,37 +273,53 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     }
   }
 
+  // Route each net: connect all pins with orthogonal segments
+  // Use a shared horizontal bus at the net's rank Y, then vertical drops to each pin
   const CORRIDOR_OFFSET = GRID * 0.4;
-  const corridorMap = new Map<string, number>();
 
   for (const [net, pins] of netPins) {
     if (net === '0' || pins.length < 2) continue;
     const segments: { x1: number; y1: number; x2: number; y2: number }[] = [];
 
-    const sorted = [...pins].sort((a, b) => a.x - b.x || a.y - b.y);
-    for (let i = 0; i < sorted.length - 1; i++) {
-      const from = sorted[i];
-      const to = sorted[i + 1];
-      if (from.y === to.y) {
-        segments.push({ x1: from.x, y1: from.y, x2: to.x, y2: to.y });
-      } else {
-        const colKey = `${Math.round(from.x / COL_SPACING)}-${Math.round(to.x / COL_SPACING)}`;
-        const offsetIdx = corridorMap.get(colKey) ?? 0;
-        corridorMap.set(colKey, offsetIdx + 1);
-        const midX = (from.x + to.x) / 2 + (offsetIdx - 0.5) * CORRIDOR_OFFSET;
+    // Compute the bus Y for this net (at its rank level)
+    const netRank = nodeRanks.get(net) ?? 0;
+    const busY = MARGIN + (maxRank - netRank) * RANK_SPACING;
 
-        segments.push({ x1: from.x, y1: from.y, x2: midX, y2: from.y });
-        segments.push({ x1: midX, y1: from.y, x2: midX, y2: to.y });
-        segments.push({ x1: midX, y1: to.y, x2: to.x, y2: to.y });
+    const sorted = [...pins].sort((a, b) => a.x - b.x || a.y - b.y);
+
+    // Check if all pins are already at bus Y
+    const allOnBus = sorted.every(p => Math.abs(p.y - busY) < 1);
+
+    if (allOnBus) {
+      // Simple: horizontal wire through all pins
+      for (let i = 0; i < sorted.length - 1; i++) {
+        segments.push({ x1: sorted[i].x, y1: busY, x2: sorted[i + 1].x, y2: busY });
+      }
+    } else {
+      // Connect each pin to the bus with a vertical drop, then horizontal bus
+      const xs: number[] = [];
+      for (const pin of sorted) {
+        if (Math.abs(pin.y - busY) > 1) {
+          // Vertical segment from pin to bus
+          segments.push({ x1: pin.x, y1: pin.y, x2: pin.x, y2: busY });
+        }
+        xs.push(pin.x);
+      }
+      // Horizontal bus connecting all drop points
+      const minX = Math.min(...xs);
+      const maxX = Math.max(...xs);
+      if (maxX > minX) {
+        segments.push({ x1: minX, y1: busY, x2: maxX, y2: busY });
       }
     }
 
     wires.push({ net, segments });
   }
 
-  // Junctions
+  // --- Junctions ---
   const junctions: Junction[] = [];
   const pointCount = new Map<string, number>();
+  // Count segment endpoints + T-intersections
   for (const wire of wires) {
     for (const seg of wire.segments) {
       const k1 = `${seg.x1},${seg.y1}`;
@@ -266,7 +335,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     }
   }
 
-  // Bounds
+  // --- Bounds ---
   let maxX = 0, maxY = 0;
   for (const pc of placedComponents) {
     const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '');

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -397,10 +397,21 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
       : undefined;
     return { horizontal, stretchH, sym: getSymbol(pl.comp.type, pl.comp.displayValue ?? '', horizontal, stretchH) };
   };
+  // Feedback caps (a capacitor whose two endpoints are both non-ground nets
+  // collapsed onto a single rail) are conventionally drawn as a loop ABOVE
+  // the signal chain, with short drop-wires joining each pin to the rail.
+  // Detect them and shift their centerY up by one rank-spacing so the rail
+  // runs uninterrupted through the rest of the chain.
+  const isFeedbackCap = (pl: Placement): boolean =>
+    pl.comp.type === 'C' &&
+    pl.topRank === pl.bottomRank &&
+    pl.comp.ports[0].net !== '0' &&
+    pl.comp.ports[1].net !== '0';
   const centerYFor = (pl: Placement) => {
     const topY = MARGIN + (maxRank - pl.topRank) * RANK_SPACING;
     const bottomY = MARGIN + (maxRank - pl.bottomRank) * RANK_SPACING;
-    return (topY + bottomY) / 2;
+    const base = (topY + bottomY) / 2;
+    return isFeedbackCap(pl) ? base - RANK_SPACING : base;
   };
 
   const byCol = new Map<number, Placement[]>();
@@ -488,6 +499,18 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     });
   }
 
+  // If any elevated feedback caps pushed a component above the top margin,
+  // shift everyone down so the top of the schematic still honors MARGIN.
+  let minY = Infinity;
+  for (const pc of placedComponents) minY = Math.min(minY, pc.y);
+  const yShift = minY < MARGIN ? MARGIN - minY : 0;
+  if (yShift > 0) {
+    for (const pc of placedComponents) {
+      pc.y += yShift;
+      for (const p of pc.pins) p.y += yShift;
+    }
+  }
+
   // --- Wire routing ---
   // Collect all pins per net
   const wires: Wire[] = [];
@@ -528,7 +551,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
 
   const netBusY = new Map<string, number>();
   for (const [r, nets] of netsByRank) {
-    const baseY = MARGIN + (maxRank - r) * RANK_SPACING;
+    const baseY = MARGIN + (maxRank - r) * RANK_SPACING + yShift;
     // Partition into x-overlap groups. Sort by minX first so scan is linear.
     const sorted = [...nets].sort((a, b) => {
       const ra = xRangeByNet.get(a), rb = xRangeByNet.get(b);

--- a/packages/ui/src/schematic/layout.ts
+++ b/packages/ui/src/schematic/layout.ts
@@ -416,6 +416,9 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
 
   const byCol = new Map<number, Placement[]>();
   for (const pl of placements) {
+    // Feedback caps are positioned in a second pass once the main chain is
+    // laid out — they span the x-range between their endpoints' other pins.
+    if (isFeedbackCap(pl)) continue;
     if (!byCol.has(pl.col)) byCol.set(pl.col, []);
     byCol.get(pl.col)!.push(pl);
   }
@@ -461,8 +464,8 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   const placedComponents: PlacedComponent[] = [];
 
   for (const pl of placements) {
-    const { comp, topRank, bottomRank } = pl;
-
+    if (isFeedbackCap(pl)) continue;
+    const { comp } = pl;
     const { horizontal, stretchH, sym: symbol } = symbolFor(pl);
     const nets = comp.ports.map(p => p.net);
 
@@ -470,12 +473,6 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
     const x = xForComp.get(comp.id)!;
     const y = centerY - symbol.height / 2;
 
-    // Map IR port i to a symbol pin position. For PMOS / PNP, swap the
-    // drain/collector and source/emitter positions so the "source-side" pin
-    // (which sits at higher potential) renders above the drain/collector.
-    // For undirected 2-terminal symbols (R, L, C, D) whose IR port ordering
-    // happens to put the lower-rank net first, swap pins 0 and 1 so the
-    // higher-rank net always renders at the top/left of the symbol body.
     const flipForP =
       (comp.type === 'M' && comp.params?.channelType === 'p') ||
       (comp.type === 'Q' && comp.params?.type === 'pnp');
@@ -492,9 +489,47 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
       return { net, x: x + sp.dx, y: y + sp.dy };
     });
 
+    placedComponents.push({ component: comp, x, y, rotation: 0, horizontal, stretchH, pins });
+  }
+
+  // --- Pass 2: feedback caps ----------------------------------------------
+  // Now that the main chain is positioned, stretch each feedback cap so its
+  // two pins span the feedback region: left pin sits over the leftmost other
+  // pin on net A, right pin over the rightmost other pin on net B.
+  for (const pl of placements) {
+    if (!isFeedbackCap(pl)) continue;
+    const { comp } = pl;
+    const netA = comp.ports[0].net;
+    const netB = comp.ports[1].net;
+    const rankA = nodeRanks.get(netA) ?? 0;
+    const rankB = nodeRanks.get(netB) ?? 0;
+    // Orient so the lower-rank net is on the left side of the cap (matches
+    // the 2-terminal symbol-pin flip logic used elsewhere).
+    const leftNet  = rankA <= rankB ? netA : netB;
+    const rightNet = rankA <= rankB ? netB : netA;
+    const flipPorts = leftNet !== netA;
+
+    const collectX = (net: string) =>
+      placedComponents.flatMap(pc => pc.pins.filter(p => p.net === net).map(p => p.x));
+    const leftXs  = collectX(leftNet);
+    const rightXs = collectX(rightNet);
+    const leftX   = leftXs.length  ? Math.min(...leftXs)  : MARGIN;
+    const rightX  = rightXs.length ? Math.max(...rightXs) : leftX + GRID * 2;
+    const width   = Math.max(GRID * 2, rightX - leftX);
+
+    const symbol = getSymbol(comp.type, comp.displayValue ?? '', true, undefined, width);
+    const centerY = centerYFor(pl);
+    const y = centerY - symbol.height / 2;
+    const x = leftX;
+
+    const pins: Pin[] = [
+      { net: flipPorts ? rightNet : leftNet,  x: x + symbol.pins[0].dx, y: y + symbol.pins[0].dy },
+      { net: flipPorts ? leftNet  : rightNet, x: x + symbol.pins[1].dx, y: y + symbol.pins[1].dy },
+    ];
+
     placedComponents.push({
       component: comp,
-      x, y, rotation: 0, horizontal, stretchH,
+      x, y, rotation: 0, horizontal: true, stretchW: width,
       pins,
     });
   }
@@ -641,7 +676,7 @@ export function layoutSchematic(circuit: CircuitIR): SchematicLayout {
   // --- Bounds ---
   let maxX = 0, maxY = 0;
   for (const pc of placedComponents) {
-    const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH);
+    const sym = getSymbol(pc.component.type, pc.component.displayValue ?? '', pc.horizontal, pc.stretchH, pc.stretchW);
     maxX = Math.max(maxX, pc.x + sym.width);
     maxY = Math.max(maxY, pc.y + sym.height);
   }

--- a/packages/ui/src/schematic/symbols.ts
+++ b/packages/ui/src/schematic/symbols.ts
@@ -23,28 +23,61 @@ export interface SymbolDef {
 
 const PIN_R = 2.5;
 
-function resistorSymbol(): SymbolDef {
-  const w = GRID * 2, h = GRID;
+function resistorSymbol(stretchW?: number): SymbolDef {
+  const naturalW = GRID * 2;
+  const w = Math.max(naturalW, stretchW ?? naturalW);
+  const h = GRID;
   const cy = h / 2;
-  const lead = GRID * 0.3;
-  const bodyW = w - lead * 2;
+  const bodyW = naturalW * 0.4 * 2; // same zigzag width as natural
+  const leadLeft = (w - bodyW) / 2;
   const peaks = 4;
   const segW = bodyW / peaks;
   const amp = h * 0.38;
 
-  let d = `M0,${cy} L${lead},${cy}`;
+  let d = `M0,${cy} L${leadLeft},${cy}`;
   for (let i = 0; i < peaks; i++) {
-    const x1 = lead + i * segW + segW * 0.25;
-    const x2 = lead + i * segW + segW * 0.75;
+    const x1 = leadLeft + i * segW + segW * 0.25;
+    const x2 = leadLeft + i * segW + segW * 0.75;
     const y1 = i % 2 === 0 ? cy - amp : cy + amp;
     const y2 = i % 2 === 0 ? cy + amp : cy - amp;
     d += ` L${x1},${y1} L${x2},${y2}`;
   }
-  d += ` L${w - lead},${cy} L${w},${cy}`;
+  d += ` L${leadLeft + bodyW},${cy} L${w},${cy}`;
 
   return {
     elements: [{ tag: 'path', attrs: { d, fill: 'none' } }],
     pins: [{ dx: 0, dy: cy }, { dx: w, dy: cy }],
+    width: w, height: h,
+  };
+}
+
+/** Vertical resistor — pins on top and bottom, zigzag runs down. Used when
+ * a resistor's endpoints sit on different rank rails (e.g. a load resistor
+ * from the signal rail to ground or a pull-up from supply to output). */
+function verticalResistorSymbol(stretchH?: number): SymbolDef {
+  const w = GRID;
+  const naturalH = GRID * 2;
+  const h = Math.max(naturalH, stretchH ?? naturalH);
+  const cx = w / 2;
+  const bodyH = naturalH * 0.4 * 2;
+  const leadTop = (h - bodyH) / 2;
+  const peaks = 4;
+  const segH = bodyH / peaks;
+  const amp = w * 0.38;
+
+  let d = `M${cx},0 L${cx},${leadTop}`;
+  for (let i = 0; i < peaks; i++) {
+    const y1 = leadTop + i * segH + segH * 0.25;
+    const y2 = leadTop + i * segH + segH * 0.75;
+    const x1 = i % 2 === 0 ? cx - amp : cx + amp;
+    const x2 = i % 2 === 0 ? cx + amp : cx - amp;
+    d += ` L${x1},${y1} L${x2},${y2}`;
+  }
+  d += ` L${cx},${leadTop + bodyH} L${cx},${h}`;
+
+  return {
+    elements: [{ tag: 'path', attrs: { d, fill: 'none' } }],
+    pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: h }],
     width: w, height: h,
   };
 }
@@ -196,6 +229,32 @@ function diodeSymbol(): SymbolDef {
   };
 }
 
+/** Vertical diode — pins on top (anode) and bottom (cathode). Used when the
+ * diode connects rails at different ranks (e.g. a freewheel diode hanging
+ * from the switching node to ground in a buck converter). */
+function verticalDiodeSymbol(stretchH?: number): SymbolDef {
+  const w = GRID;
+  const naturalH = GRID * 1.5;
+  const h = Math.max(naturalH, stretchH ?? naturalH);
+  const cx = w / 2;
+  const triH = w * 0.6;
+  const bodyCenterY = h / 2;
+  // Triangle points downward toward the cathode bar (current flows anode→cathode).
+  const triTop = bodyCenterY - w * 0.35;
+  const triBot = bodyCenterY + w * 0.35;
+
+  return {
+    elements: [
+      { tag: 'line', attrs: { x1: cx, y1: 0, x2: cx, y2: triTop } },
+      { tag: 'path', attrs: { d: `M${cx - w * 0.35},${triTop} L${cx + w * 0.35},${triTop} L${cx},${triBot} Z`, fill: 'none' } },
+      { tag: 'line', attrs: { x1: cx - w * 0.35, y1: triBot, x2: cx + w * 0.35, y2: triBot } },
+      { tag: 'line', attrs: { x1: cx, y1: triBot, x2: cx, y2: h } },
+    ],
+    pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: h }],
+    width: w, height: h,
+  };
+}
+
 function mosfetSymbol(): SymbolDef {
   const w = GRID * 2.5, h = GRID * 2.5;
   const cy = h / 2;
@@ -246,28 +305,35 @@ function bjtSymbol(): SymbolDef {
 }
 
 function opampSymbol(): SymbolDef {
-  const w = GRID * 2.5, h = GRID * 3;
-  const tipX = w;
+  const bodyW = GRID * 2.5;
+  const h = GRID * 3;
+  // The +in lead is extended further left than the -in lead. In the common
+  // non-inverting topology (e.g. Sallen-Key voltage follower), the +in pin
+  // connects to the external signal chain on the left while the -in pin
+  // closes a local feedback loop to the output on the right. Putting +in
+  // further left keeps each input's bus on its own side of the body so the
+  // drop-wires do not cross each other's horizontal bus.
+  const leadOffset = GRID;
+  const bodyLeft = leadOffset + GRID * 0.5;
+  const tipX = leadOffset + bodyW;
+  const totalW = tipX + GRID * 0.5;
   const cy = h / 2;
 
-  // Convention: -in at top, +in at bottom (feedback path stays horizontal)
-  // Pin order matches IR: [ctrlP(+in)=0, ctrlN(-in)=1, outP=2]
-  // but visually -in is upper, +in is lower
   return {
     elements: [
-      { tag: 'path', attrs: { d: `M${GRID * 0.5},0 L${tipX},${cy} L${GRID * 0.5},${h} Z`, fill: 'none' } },
-      { tag: 'line', attrs: { x1: 0, y1: h * 0.3, x2: GRID * 0.5, y2: h * 0.3 } },
-      { tag: 'line', attrs: { x1: 0, y1: h * 0.7, x2: GRID * 0.5, y2: h * 0.7 } },
-      { tag: 'text', attrs: { x: GRID * 0.65, y: h * 0.35, 'font-size': 10 }, text: '\u2013' },
-      { tag: 'text', attrs: { x: GRID * 0.65, y: h * 0.75, 'font-size': 10 }, text: '+' },
-      { tag: 'line', attrs: { x1: tipX, y1: cy, x2: tipX + GRID * 0.5, y2: cy } },
+      { tag: 'path', attrs: { d: `M${bodyLeft},0 L${tipX},${cy} L${bodyLeft},${h} Z`, fill: 'none' } },
+      { tag: 'line', attrs: { x1: leadOffset, y1: h * 0.3, x2: bodyLeft, y2: h * 0.3 } },
+      { tag: 'line', attrs: { x1: 0,          y1: h * 0.7, x2: bodyLeft, y2: h * 0.7 } },
+      { tag: 'text', attrs: { x: bodyLeft + GRID * 0.15, y: h * 0.35, 'font-size': 10 }, text: '\u2013' },
+      { tag: 'text', attrs: { x: bodyLeft + GRID * 0.15, y: h * 0.75, 'font-size': 10 }, text: '+' },
+      { tag: 'line', attrs: { x1: tipX, y1: cy, x2: totalW, y2: cy } },
     ],
     pins: [
-      { dx: 0, dy: h * 0.7 },             // ctrlP (+in) — bottom
-      { dx: 0, dy: h * 0.3 },             // ctrlN (-in) — top
-      { dx: tipX + GRID * 0.5, dy: cy },  // outP — right
+      { dx: 0,          dy: h * 0.7 },   // ctrlP (+in) — bottom, extended left
+      { dx: leadOffset, dy: h * 0.3 },   // ctrlN (-in) — top
+      { dx: totalW,     dy: cy },        // outP — right
     ],
-    width: tipX + GRID * 0.5, height: h,
+    width: totalW, height: h,
   };
 }
 
@@ -316,7 +382,7 @@ export function getSymbol(
   stretchW?: number,
 ): SymbolDef {
   switch (type) {
-    case 'R': return resistorSymbol();
+    case 'R': return horizontal ? resistorSymbol(stretchW) : verticalResistorSymbol(stretchH);
     case 'C': return horizontal ? horizontalCapacitorSymbol(stretchW) : capacitorSymbol(stretchH);
     case 'L': return inductorSymbol();
     case 'V': return voltageSourceSymbol(
@@ -325,7 +391,7 @@ export function getSymbol(
       stretchH,
     );
     case 'I': return currentSourceSymbol(stretchH);
-    case 'D': return diodeSymbol();
+    case 'D': return horizontal ? diodeSymbol() : verticalDiodeSymbol(stretchH);
     case 'Q': return bjtSymbol();
     case 'M': return mosfetSymbol();
     case 'E': case 'G': return opampSymbol();

--- a/packages/ui/src/schematic/symbols.ts
+++ b/packages/ui/src/schematic/symbols.ts
@@ -49,18 +49,21 @@ function resistorSymbol(): SymbolDef {
   };
 }
 
-function capacitorSymbol(): SymbolDef {
-  const w = GRID, h = GRID * 2;
+function capacitorSymbol(stretchH?: number): SymbolDef {
+  const w = GRID;
+  const naturalH = GRID * 2;
+  const h = Math.max(naturalH, stretchH ?? naturalH);
   const cx = w / 2;
   const gap = 6;
   const plateW = w * 0.7;
+  const cy = h / 2;
 
   return {
     elements: [
-      { tag: 'line', attrs: { x1: cx, y1: 0, x2: cx, y2: h / 2 - gap / 2 } },
-      { tag: 'line', attrs: { x1: cx - plateW / 2, y1: h / 2 - gap / 2, x2: cx + plateW / 2, y2: h / 2 - gap / 2 } },
-      { tag: 'line', attrs: { x1: cx - plateW / 2, y1: h / 2 + gap / 2, x2: cx + plateW / 2, y2: h / 2 + gap / 2 } },
-      { tag: 'line', attrs: { x1: cx, y1: h / 2 + gap / 2, x2: cx, y2: h } },
+      { tag: 'line', attrs: { x1: cx, y1: 0, x2: cx, y2: cy - gap / 2 } },
+      { tag: 'line', attrs: { x1: cx - plateW / 2, y1: cy - gap / 2, x2: cx + plateW / 2, y2: cy - gap / 2 } },
+      { tag: 'line', attrs: { x1: cx - plateW / 2, y1: cy + gap / 2, x2: cx + plateW / 2, y2: cy + gap / 2 } },
+      { tag: 'line', attrs: { x1: cx, y1: cy + gap / 2, x2: cx, y2: h } },
     ],
     pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: h }],
     width: w, height: h,
@@ -109,14 +112,17 @@ function inductorSymbol(): SymbolDef {
   };
 }
 
-function voltageSourceSymbol(isAC: boolean): SymbolDef {
-  const size = GRID * 2;
-  const cx = size / 2, cy = size / 2;
-  const r = size * 0.38;
+function voltageSourceSymbol(isAC: boolean, stretchH?: number): SymbolDef {
+  const naturalSize = GRID * 2;
+  const w = naturalSize;
+  const h = Math.max(naturalSize, stretchH ?? naturalSize);
+  const cx = w / 2;
+  const cy = h / 2;
+  const r = naturalSize * 0.38;
 
   const elements: SvgElement[] = [
     { tag: 'line', attrs: { x1: cx, y1: 0, x2: cx, y2: cy - r } },
-    { tag: 'line', attrs: { x1: cx, y1: cy + r, x2: cx, y2: size } },
+    { tag: 'line', attrs: { x1: cx, y1: cy + r, x2: cx, y2: h } },
     { tag: 'circle', attrs: { cx, cy, r, fill: 'none' } },
   ];
 
@@ -140,26 +146,29 @@ function voltageSourceSymbol(isAC: boolean): SymbolDef {
 
   return {
     elements,
-    pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: size }],
-    width: size, height: size,
+    pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: h }],
+    width: w, height: h,
   };
 }
 
-function currentSourceSymbol(): SymbolDef {
-  const size = GRID * 2;
-  const cx = size / 2, cy = size / 2;
-  const r = size * 0.38;
+function currentSourceSymbol(stretchH?: number): SymbolDef {
+  const naturalSize = GRID * 2;
+  const w = naturalSize;
+  const h = Math.max(naturalSize, stretchH ?? naturalSize);
+  const cx = w / 2;
+  const cy = h / 2;
+  const r = naturalSize * 0.38;
 
   return {
     elements: [
       { tag: 'line', attrs: { x1: cx, y1: 0, x2: cx, y2: cy - r } },
-      { tag: 'line', attrs: { x1: cx, y1: cy + r, x2: cx, y2: size } },
+      { tag: 'line', attrs: { x1: cx, y1: cy + r, x2: cx, y2: h } },
       { tag: 'circle', attrs: { cx, cy, r, fill: 'none' } },
       { tag: 'line', attrs: { x1: cx, y1: cy + r * 0.5, x2: cx, y2: cy - r * 0.5 } },
       { tag: 'polyline', attrs: { points: `${cx - 4},${cy - r * 0.2} ${cx},${cy - r * 0.5} ${cx + 4},${cy - r * 0.2}`, fill: 'none' } },
     ],
-    pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: size }],
-    width: size, height: size,
+    pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: h }],
+    width: w, height: h,
   };
 }
 
@@ -290,17 +299,25 @@ function dependentSourceSymbol(): SymbolDef {
   };
 }
 
-/** Look up the symbol definition for a device type. */
-export function getSymbol(type: string, displayValue?: string, horizontal = false): SymbolDef {
+/** Look up the symbol definition for a device type. `stretchH` extends the
+ * leads of vertical two-terminal symbols (V, I, C) so their pins sit flush on
+ * the rank rails instead of needing a vertical drop-wire at each end. */
+export function getSymbol(
+  type: string,
+  displayValue?: string,
+  horizontal = false,
+  stretchH?: number,
+): SymbolDef {
   switch (type) {
     case 'R': return resistorSymbol();
-    case 'C': return horizontal ? horizontalCapacitorSymbol() : capacitorSymbol();
+    case 'C': return horizontal ? horizontalCapacitorSymbol() : capacitorSymbol(stretchH);
     case 'L': return inductorSymbol();
     case 'V': return voltageSourceSymbol(
       (displayValue ?? '').toUpperCase().startsWith('AC') ||
-      (displayValue ?? '').toUpperCase().startsWith('SIN')
+      (displayValue ?? '').toUpperCase().startsWith('SIN'),
+      stretchH,
     );
-    case 'I': return currentSourceSymbol();
+    case 'I': return currentSourceSymbol(stretchH);
     case 'D': return diodeSymbol();
     case 'Q': return bjtSymbol();
     case 'M': return mosfetSymbol();

--- a/packages/ui/src/schematic/symbols.ts
+++ b/packages/ui/src/schematic/symbols.ts
@@ -67,6 +67,25 @@ function capacitorSymbol(): SymbolDef {
   };
 }
 
+/** Horizontal capacitor variant — used when both endpoints share a rank. */
+function horizontalCapacitorSymbol(): SymbolDef {
+  const w = GRID * 2, h = GRID;
+  const cy = h / 2;
+  const gap = 6;
+  const plateH = h * 0.7;
+
+  return {
+    elements: [
+      { tag: 'line', attrs: { x1: 0, y1: cy, x2: w / 2 - gap / 2, y2: cy } },
+      { tag: 'line', attrs: { x1: w / 2 - gap / 2, y1: cy - plateH / 2, x2: w / 2 - gap / 2, y2: cy + plateH / 2 } },
+      { tag: 'line', attrs: { x1: w / 2 + gap / 2, y1: cy - plateH / 2, x2: w / 2 + gap / 2, y2: cy + plateH / 2 } },
+      { tag: 'line', attrs: { x1: w / 2 + gap / 2, y1: cy, x2: w, y2: cy } },
+    ],
+    pins: [{ dx: 0, dy: cy }, { dx: w, dy: cy }],
+    width: w, height: h,
+  };
+}
+
 function inductorSymbol(): SymbolDef {
   const w = GRID * 3, h = GRID;
   const cy = h / 2;
@@ -272,10 +291,10 @@ function dependentSourceSymbol(): SymbolDef {
 }
 
 /** Look up the symbol definition for a device type. */
-export function getSymbol(type: string, displayValue?: string): SymbolDef {
+export function getSymbol(type: string, displayValue?: string, horizontal = false): SymbolDef {
   switch (type) {
     case 'R': return resistorSymbol();
-    case 'C': return capacitorSymbol();
+    case 'C': return horizontal ? horizontalCapacitorSymbol() : capacitorSymbol();
     case 'L': return inductorSymbol();
     case 'V': return voltageSourceSymbol(
       (displayValue ?? '').toUpperCase().startsWith('AC') ||

--- a/packages/ui/src/schematic/symbols.ts
+++ b/packages/ui/src/schematic/symbols.ts
@@ -211,44 +211,56 @@ function currentSourceSymbol(stretchH?: number): SymbolDef {
   };
 }
 
-function diodeSymbol(): SymbolDef {
+function diodeSymbol(flipped = false): SymbolDef {
   const w = GRID * 1.5, h = GRID;
   const cy = h / 2;
   const triW = h * 0.6;
   const cx = w / 2;
+  // Non-flipped: anode left, triangle points right. Flipped: anode right,
+  // triangle points left. Keeps pin positions identical so layout logic
+  // (which remaps IR ports via flip2Term) does not need to know.
+  const tipX = flipped ? cx - triW / 2 : cx + triW / 2;
+  const baseX = flipped ? cx + triW / 2 : cx - triW / 2;
+  const barX = tipX;
 
   return {
     elements: [
-      { tag: 'line', attrs: { x1: 0, y1: cy, x2: cx - triW / 2, y2: cy } },
-      { tag: 'path', attrs: { d: `M${cx - triW / 2},${cy - h * 0.35} L${cx + triW / 2},${cy} L${cx - triW / 2},${cy + h * 0.35} Z`, fill: 'none' } },
-      { tag: 'line', attrs: { x1: cx + triW / 2, y1: cy - h * 0.35, x2: cx + triW / 2, y2: cy + h * 0.35 } },
-      { tag: 'line', attrs: { x1: cx + triW / 2, y1: cy, x2: w, y2: cy } },
+      { tag: 'line', attrs: { x1: 0, y1: cy, x2: flipped ? barX : baseX, y2: cy } },
+      { tag: 'path', attrs: { d: `M${baseX},${cy - h * 0.35} L${tipX},${cy} L${baseX},${cy + h * 0.35} Z`, fill: 'none' } },
+      { tag: 'line', attrs: { x1: barX, y1: cy - h * 0.35, x2: barX, y2: cy + h * 0.35 } },
+      { tag: 'line', attrs: { x1: flipped ? baseX : barX, y1: cy, x2: w, y2: cy } },
     ],
     pins: [{ dx: 0, dy: cy }, { dx: w, dy: cy }],
     width: w, height: h,
   };
 }
 
-/** Vertical diode — pins on top (anode) and bottom (cathode). Used when the
+/** Vertical diode — pins on top (pin 0) and bottom (pin 1). Used when the
  * diode connects rails at different ranks (e.g. a freewheel diode hanging
- * from the switching node to ground in a buck converter). */
-function verticalDiodeSymbol(stretchH?: number): SymbolDef {
+ * from the switching node to ground in a buck converter). `flipped` points
+ * the triangle upward (tip at top) when the IR port-0 (anode) gets remapped
+ * to the bottom pin position via rank-driven flip — keeps current-flow arrow
+ * running from anode to cathode visually. */
+function verticalDiodeSymbol(stretchH?: number, flipped = false): SymbolDef {
   const w = GRID;
   const naturalH = GRID * 1.5;
   const h = Math.max(naturalH, stretchH ?? naturalH);
   const cx = w / 2;
-  const triH = w * 0.6;
   const bodyCenterY = h / 2;
-  // Triangle points downward toward the cathode bar (current flows anode→cathode).
   const triTop = bodyCenterY - w * 0.35;
   const triBot = bodyCenterY + w * 0.35;
+  // Non-flipped: tip at triBot (triangle points down), cathode bar at triBot.
+  // Flipped: tip at triTop (triangle points up), cathode bar at triTop.
+  const tipY = flipped ? triTop : triBot;
+  const baseY = flipped ? triBot : triTop;
+  const barY = tipY;
 
   return {
     elements: [
-      { tag: 'line', attrs: { x1: cx, y1: 0, x2: cx, y2: triTop } },
-      { tag: 'path', attrs: { d: `M${cx - w * 0.35},${triTop} L${cx + w * 0.35},${triTop} L${cx},${triBot} Z`, fill: 'none' } },
-      { tag: 'line', attrs: { x1: cx - w * 0.35, y1: triBot, x2: cx + w * 0.35, y2: triBot } },
-      { tag: 'line', attrs: { x1: cx, y1: triBot, x2: cx, y2: h } },
+      { tag: 'line', attrs: { x1: cx, y1: 0, x2: cx, y2: flipped ? barY : baseY } },
+      { tag: 'path', attrs: { d: `M${cx - w * 0.35},${baseY} L${cx + w * 0.35},${baseY} L${cx},${tipY} Z`, fill: 'none' } },
+      { tag: 'line', attrs: { x1: cx - w * 0.35, y1: barY, x2: cx + w * 0.35, y2: barY } },
+      { tag: 'line', attrs: { x1: cx, y1: flipped ? baseY : barY, x2: cx, y2: h } },
     ],
     pins: [{ dx: cx, dy: 0 }, { dx: cx, dy: h }],
     width: w, height: h,
@@ -380,6 +392,7 @@ export function getSymbol(
   horizontal = false,
   stretchH?: number,
   stretchW?: number,
+  flipped = false,
 ): SymbolDef {
   switch (type) {
     case 'R': return horizontal ? resistorSymbol(stretchW) : verticalResistorSymbol(stretchH);
@@ -391,7 +404,7 @@ export function getSymbol(
       stretchH,
     );
     case 'I': return currentSourceSymbol(stretchH);
-    case 'D': return horizontal ? diodeSymbol() : verticalDiodeSymbol(stretchH);
+    case 'D': return horizontal ? diodeSymbol(flipped) : verticalDiodeSymbol(stretchH, flipped);
     case 'Q': return bjtSymbol();
     case 'M': return mosfetSymbol();
     case 'E': case 'G': return opampSymbol();

--- a/packages/ui/src/schematic/symbols.ts
+++ b/packages/ui/src/schematic/symbols.ts
@@ -70,19 +70,25 @@ function capacitorSymbol(stretchH?: number): SymbolDef {
   };
 }
 
-/** Horizontal capacitor variant — used when both endpoints share a rank. */
-function horizontalCapacitorSymbol(): SymbolDef {
-  const w = GRID * 2, h = GRID;
+/** Horizontal capacitor variant — used when both endpoints share a rank.
+ * `stretchW` extends the side leads so the body spans a wider section of the
+ * schematic (e.g. a Sallen-Key feedback cap whose plates sit between the
+ * leftmost input-side pin and the rightmost output-side pin). */
+function horizontalCapacitorSymbol(stretchW?: number): SymbolDef {
+  const naturalW = GRID * 2;
+  const w = Math.max(naturalW, stretchW ?? naturalW);
+  const h = GRID;
   const cy = h / 2;
   const gap = 6;
   const plateH = h * 0.7;
+  const cx = w / 2;
 
   return {
     elements: [
-      { tag: 'line', attrs: { x1: 0, y1: cy, x2: w / 2 - gap / 2, y2: cy } },
-      { tag: 'line', attrs: { x1: w / 2 - gap / 2, y1: cy - plateH / 2, x2: w / 2 - gap / 2, y2: cy + plateH / 2 } },
-      { tag: 'line', attrs: { x1: w / 2 + gap / 2, y1: cy - plateH / 2, x2: w / 2 + gap / 2, y2: cy + plateH / 2 } },
-      { tag: 'line', attrs: { x1: w / 2 + gap / 2, y1: cy, x2: w, y2: cy } },
+      { tag: 'line', attrs: { x1: 0, y1: cy, x2: cx - gap / 2, y2: cy } },
+      { tag: 'line', attrs: { x1: cx - gap / 2, y1: cy - plateH / 2, x2: cx - gap / 2, y2: cy + plateH / 2 } },
+      { tag: 'line', attrs: { x1: cx + gap / 2, y1: cy - plateH / 2, x2: cx + gap / 2, y2: cy + plateH / 2 } },
+      { tag: 'line', attrs: { x1: cx + gap / 2, y1: cy, x2: w, y2: cy } },
     ],
     pins: [{ dx: 0, dy: cy }, { dx: w, dy: cy }],
     width: w, height: h,
@@ -307,10 +313,11 @@ export function getSymbol(
   displayValue?: string,
   horizontal = false,
   stretchH?: number,
+  stretchW?: number,
 ): SymbolDef {
   switch (type) {
     case 'R': return resistorSymbol();
-    case 'C': return horizontal ? horizontalCapacitorSymbol() : capacitorSymbol(stretchH);
+    case 'C': return horizontal ? horizontalCapacitorSymbol(stretchW) : capacitorSymbol(stretchH);
     case 'L': return inductorSymbol();
     case 'V': return voltageSourceSymbol(
       (displayValue ?? '').toUpperCase().startsWith('AC') ||

--- a/packages/ui/src/schematic/types.ts
+++ b/packages/ui/src/schematic/types.ts
@@ -28,6 +28,9 @@ export interface PlacedComponent {
   /** Total height (in pixels) requested for a stretchable vertical symbol so
    * its pins sit flush on the top and bottom rank rails. */
   stretchH?: number;
+  /** Total width requested for a stretchable horizontal symbol (e.g. a
+   * feedback capacitor spanning the chain width). */
+  stretchW?: number;
   /** Pin positions after placement + rotation */
   pins: Pin[];
 }

--- a/packages/ui/src/schematic/types.ts
+++ b/packages/ui/src/schematic/types.ts
@@ -22,6 +22,9 @@ export interface PlacedComponent {
   y: number;
   /** Rotation in degrees: 0, 90, 180, 270 */
   rotation: number;
+  /** True when the component uses its horizontal-orientation symbol variant
+   * (e.g. a capacitor between two nets on the same rail). */
+  horizontal?: boolean;
   /** Pin positions after placement + rotation */
   pins: Pin[];
 }

--- a/packages/ui/src/schematic/types.ts
+++ b/packages/ui/src/schematic/types.ts
@@ -25,6 +25,9 @@ export interface PlacedComponent {
   /** True when the component uses its horizontal-orientation symbol variant
    * (e.g. a capacitor between two nets on the same rail). */
   horizontal?: boolean;
+  /** Total height (in pixels) requested for a stretchable vertical symbol so
+   * its pins sit flush on the top and bottom rank rails. */
+  stretchH?: number;
   /** Pin positions after placement + rotation */
   pins: Pin[];
 }

--- a/packages/ui/src/schematic/types.ts
+++ b/packages/ui/src/schematic/types.ts
@@ -31,6 +31,10 @@ export interface PlacedComponent {
   /** Total width requested for a stretchable horizontal symbol (e.g. a
    * feedback capacitor spanning the chain width). */
   stretchW?: number;
+  /** True when the symbol must be flipped along its primary axis so its
+   * directional graphics (e.g. a diode triangle) stay consistent with the
+   * net polarity after a rank-driven pin swap. */
+  flipped?: boolean;
   /** Pin positions after placement + rotation */
   pins: Pin[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
-        specifier: ^4.3.0
-        version: 4.7.0(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -141,40 +141,6 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -183,41 +149,13 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -424,9 +362,6 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -535,11 +470,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
-
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -694,18 +629,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
-
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -738,11 +661,18 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
@@ -815,16 +745,6 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  baseline-browser-mapping@2.10.18:
-    resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -838,9 +758,6 @@ packages:
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
-
-  caniuse-lite@1.0.30001787:
-    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -941,9 +858,6 @@ packages:
   eecircuit-engine@1.7.0:
     resolution: {integrity: sha512-ZDpr/w/H81uCH3n2vjf0vohxOQqQ4NCsvaXkoYwcH+LCxIGKpBdvAIvGN5IdozW6AFJ8tojquKvDya3337yjSQ==}
 
-  electron-to-chromium@1.5.335:
-    resolution: {integrity: sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==}
-
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -971,10 +885,6 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
-
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1006,10 +916,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1099,16 +1005,6 @@ packages:
       canvas:
         optional: true
 
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -1197,9 +1093,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1239,9 +1132,6 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -1311,10 +1201,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -1355,10 +1241,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1478,12 +1360,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -1614,9 +1490,6 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
 snapshots:
 
   '@asamuzakjp/css-color@3.2.0':
@@ -1633,108 +1506,15 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
-
-  '@babel/core@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/helper-compilation-targets@7.28.6':
-    dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-globals@7.28.0': {}
-
-  '@babel/helper-module-imports@7.28.6':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-plugin-utils@7.28.6': {}
-
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/helper-validator-option@7.27.1': {}
-
-  '@babel/helpers@7.29.2':
-    dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/runtime@7.29.2': {}
-
-  '@babel/template@7.28.6':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-
-  '@babel/traverse@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -1862,11 +1642,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -1934,9 +1709,9 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
-
   '@rolldown/pluginutils@1.0.0-rc.15': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -2043,27 +1818,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2096,17 +1850,10 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
+      '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -2187,16 +1934,6 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  baseline-browser-mapping@2.10.18: {}
-
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.18
-      caniuse-lite: 1.0.30001787
-      electron-to-chromium: 1.5.335
-      node-releases: 2.0.37
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -2208,8 +1945,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-
-  caniuse-lite@1.0.30001787: {}
 
   chai@6.2.2: {}
 
@@ -2291,8 +2026,6 @@ snapshots:
 
   eecircuit-engine@1.7.0: {}
 
-  electron-to-chromium@1.5.335: {}
-
   entities@6.0.1: {}
 
   es-define-property@1.0.1: {}
@@ -2341,8 +2074,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
-  escalade@3.2.0: {}
-
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2371,8 +2102,6 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
-
-  gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2485,10 +2214,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsesc@3.1.0: {}
-
-  json5@2.2.3: {}
-
   lightningcss-android-arm64@1.32.0:
     optional: true
 
@@ -2550,10 +2275,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -2594,8 +2315,6 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
-
-  node-releases@2.0.37: {}
 
   nwsapi@2.2.23: {}
 
@@ -2649,8 +2368,6 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@17.0.2: {}
-
-  react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
@@ -2727,8 +2444,6 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -2841,12 +2556,6 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -2916,5 +2625,3 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
-
-  yallist@3.1.1: {}


### PR DESCRIPTION
## Summary
- Replaces the BFS-column layout with a node-ranking algorithm: components are placed between their two endpoint ranks (vertical potential), not chained left-to-right.
- Ranks are computed from undirected BFS distance to ground, re-oriented by known polarity (V/I: + above −; MOSFET: drain above source; BJT: collector above emitter; E/G: outP above outN), and relaxed to longest-path in the resulting DAG. This places intermediate nodes like a MOSFET source or an LC tank correctly — previously they collapsed onto an adjacent rank via a "same rank as neighbor" fallback and rendered as degenerate zero-height components.
- Wires for nets sharing a rank are fanned out around the base bus Y via ` + '`CORRIDOR_OFFSET`' + ` so they don't render on the same pixel row.

## Test plan
- [x] ` + '`pnpm --filter @spice-ts/ui test`' + ` — 176/176 pass, including 5 new buck-boost topology tests
- [x] ` + '`pnpm --filter @spice-ts/core test`' + ` — 350/350 pass
- [x] ` + '`pnpm --filter @spice-ts/ui lint`' + ` clean
- [ ] Visual check in the showcase with a buck-boost netlist (Vin, Vg, M1, L1, D1, C1, Rload) — wires no longer overlap on the top rail; M1, L1, C1 render with vertical extent instead of as zero-height components

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mfiumara/spice-ts/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
