### PR TITLE
[codex] Add ngspice backend and passive parasitics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm @spice-ts/ui](https://img.shields.io/npm/v/@spice-ts/ui?label=%40spice-ts%2Fui)](https://www.npmjs.com/package/@spice-ts/ui)
 [![GitHub stars](https://img.shields.io/github/stars/mfiumara/spice-ts?style=social)](https://github.com/mfiumara/spice-ts/stargazers)
 
-A zero-dependency TypeScript SPICE circuit simulator. Parse netlists and run DC, transient, and AC analysis directly in Node.js or the browser — no native binaries, no WASM.
+A TypeScript-native SPICE circuit simulator. Parse netlists and run DC, transient, and AC analysis directly in Node.js or the browser with the built-in solver, or swap to an optional ngspice WASM backend.
 
 **[Live Showcase](https://mfiumara.github.io/spice-ts/)** — interactive demos with streaming parametric sweeps running entirely in your browser.
 
@@ -39,6 +39,7 @@ Requires Node.js ≥ 20.
 - **Transient analysis** — backward Euler and trapezoidal integration with adaptive timestep
 - **AC small-signal** — frequency sweep (dec/oct/lin) via complex LU solve
 - **Device models** — R, C, L, V, I, Diode (Shockley), BJT (Ebers-Moll NPN/PNP), MOSFET (Level 1 Shichman-Hodges NMOS/PMOS), BSIM3v3 (LEVEL=49)
+- **Passive parasitics** — capacitor ESR/ESL/leakage and inductor DCR/core-loss/winding-capacitance expansion for AC and transient analysis
 - **Controlled sources** — VCVS (E), VCCS (G), CCVS (H), CCCS (F) with DC, AC, and subcircuit support
 - **Sparse solver** — Gilbert-Peierls LU with symbolic/numeric split, typed-array stamping, batch MOSFET evaluation. Competitive with ngspice-WASM on DC, AC, and nonlinear circuits
 - **Complex AC solver** — native complex sparse LU (no 2n×2n real expansion)
@@ -46,6 +47,7 @@ Requires Node.js ≥ 20.
 - **Library support** — `.include` file resolution, `.lib`/`.endl` section selection (process corners), `.param` expressions with SI suffixes
 - **Async parsing** — `parseAsync()` with platform-agnostic `IncludeResolver` callback for loading external files
 - **Streaming API** — `simulateStream()` yields results as an `AsyncIterableIterator`
+- **Swappable simulator backend** — use the default TypeScript solver or select optional `ngspice-wasm` via `simulate(..., { simulator })`
 - **Programmatic API** — build circuits in code with `Circuit`, or parse SPICE netlists with `parse()`
 - **Typed errors** — `ConvergenceError`, `SingularMatrixError`, `ParseError`, `CycleError`, and more
 - **Full TSDoc** — every public API export has JSDoc comments for IDE hover-docs
@@ -85,6 +87,37 @@ ckt.addAnalysis('op');
 const result = await simulate(ckt);
 console.log(result.dc?.voltage('out')); // 2.5
 ```
+
+### Passive Parasitics
+
+Capacitor and inductor instances can carry model or instance parameters. The native solver expands these into equivalent primitive networks before AC and transient analysis.
+
+```spice
+.model CLOSS C(CAP=1u ESR=250m ESL=10n RLEAK=1meg)
+C1 in 0 CLOSS
+
+.model LLOSS L(IND=10u RSER=400m RPAR=2k CPAR=3p)
+L1 out 0 LLOSS
+```
+
+Capacitors support `CAP`, geometry/temperature parameters, `ESR`/`RSER`/`RS`, `ESL`/`LSER`/`LS`, `RLEAK`/`RPAR`, and loss-derived `DF` or `Q` with `FREQ`. Inductors support `IND`/`L`, geometry/temperature parameters, `RSER`/`DCR`/`RDC`, `RPAR`, `CPAR`, `Q` with `FREQ`, and `SRF`-derived parallel capacitance.
+
+### Swappable Backend
+
+The TypeScript solver is used by default. To run through ngspice compiled to WASM, install `eecircuit-engine` and pass `simulator: 'ngspice-wasm'`:
+
+```ts
+import { simulate } from '@spice-ts/core';
+
+const result = await simulate(`
+  V1 1 0 DC 5
+  R1 1 2 1k
+  R2 2 0 2k
+  .op
+`, { simulator: 'ngspice-wasm' });
+```
+
+You can also pass a custom simulator adapter implementing `simulate(input, options)`.
 
 ### Streaming
 
@@ -169,6 +202,7 @@ The resolver is platform-agnostic — use `fetch()` in the browser, `readFile()`
 | `maxIterations` | `100` | Max Newton-Raphson iterations (DC) |
 | `maxTransientIterations` | `50` | Max NR iterations per timestep |
 | `integrationMethod` | `'trapezoidal'` | `'euler'` or `'trapezoidal'` |
+| `simulator` | `'spice-ts'` | Built-in TypeScript solver, `'ngspice-wasm'`, or a custom simulator adapter |
 | `resolveInclude` | — | Async callback `(path: string) => Promise<string>` for `.include`/`.lib` |
 
 ## Benchmarks
@@ -217,7 +251,7 @@ Batch MOSFET evaluation bypasses polymorphic dispatch — all transistors in a m
 | Ring oscillator (5 stg) | 37.6 ms | 40.5 ms | 20.8 ms | **1.1x faster** |
 | Ring oscillator (11 stg) | 84.3 ms | 69.8 ms | 37.4 ms | 1.2x slower |
 
-> **Where spice-ts shines:** DC (up to 5x faster than WASM), AC (1.6-3x faster via native complex sparse solver), nonlinear CMOS (1.1-1.3x faster), and small-medium transient (parity). All with zero dependencies — no WASM, no native binary, no process spawn. The only remaining gap is the largest ring oscillator (11-stage, 1.2x slower than WASM).
+> **Where spice-ts shines:** DC (up to 5x faster than WASM), AC (1.6-3x faster via native complex sparse solver), nonlinear CMOS (1.1-1.3x faster), and small-medium transient (parity). The default solver has no native binary, no WASM startup, and no process spawn. The optional ngspice-WASM backend is available when compatibility matters more than startup cost.
 
 ### Accuracy
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@spice-ts/core)](https://www.npmjs.com/package/@spice-ts/core)
 [![CI](https://github.com/mfiumara/spice-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/mfiumara/spice-ts/actions/workflows/ci.yml)
 
-Zero-dependency TypeScript SPICE circuit simulator. Parse netlists and run DC, transient, and AC analysis directly in Node.js or the browser — no native binaries, no WASM.
+TypeScript-native SPICE circuit simulator. Parse netlists and run DC, transient, and AC analysis directly in Node.js or the browser with the built-in solver, or swap to an optional ngspice WASM backend.
 
 ```ts
 import { simulate } from '@spice-ts/core';
@@ -34,6 +34,7 @@ Requires Node.js ≥ 20.
 - **Transient analysis** — backward Euler and trapezoidal integration with adaptive timestep
 - **AC small-signal** — frequency sweep (dec/oct/lin) via complex LU solve
 - **Device models** — R, C, L, V, I, Diode (Shockley), BJT (Ebers-Moll NPN/PNP), MOSFET (Level 1 Shichman-Hodges NMOS/PMOS), BSIM3v3 (LEVEL=49)
+- **Passive parasitics** — capacitor ESR/ESL/leakage and inductor DCR/core-loss/winding-capacitance expansion for AC and transient analysis
 - **Controlled sources** — VCVS (E), VCCS (G), CCVS (H), CCCS (F) with DC, AC, and subcircuit support
 - **Sparse solver** — Gilbert-Peierls LU with symbolic/numeric split, typed-array stamping, batch MOSFET evaluation. Competitive with ngspice-WASM on DC, AC, and nonlinear circuits
 - **Complex AC solver** — native complex sparse LU (no 2n×2n real expansion)
@@ -41,6 +42,7 @@ Requires Node.js ≥ 20.
 - **Library support** — `.include` file resolution, `.lib`/`.endl` section selection (process corners), `.param` expressions with SI suffixes
 - **Async parsing** — `parseAsync()` with platform-agnostic `IncludeResolver` callback for loading external files
 - **Streaming API** — `simulateStream()` yields results as an `AsyncIterableIterator`
+- **Swappable simulator backend** — use the default TypeScript solver or select optional `ngspice-wasm` via `simulate(..., { simulator })`
 - **Programmatic API** — build circuits in code with `Circuit`, or parse SPICE netlists with `parse()`
 - **Typed errors** — `ConvergenceError`, `SingularMatrixError`, `ParseError`, `CycleError`, and more
 
@@ -79,6 +81,35 @@ ckt.addAnalysis('op');
 const result = await simulate(ckt);
 console.log(result.dc?.voltage('out')); // 2.5
 ```
+
+### Passive parasitics
+
+Capacitor and inductor instances can carry model or instance parameters. The native solver expands these into equivalent primitive networks before AC and transient analysis.
+
+```spice
+.model CLOSS C(CAP=1u ESR=250m ESL=10n RLEAK=1meg)
+C1 in 0 CLOSS
+
+.model LLOSS L(IND=10u RSER=400m RPAR=2k CPAR=3p)
+L1 out 0 LLOSS
+```
+
+Capacitors support `CAP`, geometry/temperature parameters, `ESR`/`RSER`/`RS`, `ESL`/`LSER`/`LS`, `RLEAK`/`RPAR`, and loss-derived `DF` or `Q` with `FREQ`. Inductors support `IND`/`L`, geometry/temperature parameters, `RSER`/`DCR`/`RDC`, `RPAR`, `CPAR`, `Q` with `FREQ`, and `SRF`-derived parallel capacitance.
+
+### Swappable backend
+
+The TypeScript solver is used by default. To run through ngspice compiled to WASM, install `eecircuit-engine` and pass `simulator: 'ngspice-wasm'`:
+
+```ts
+const result = await simulate(`
+  V1 1 0 DC 5
+  R1 1 2 1k
+  R2 2 0 2k
+  .op
+`, { simulator: 'ngspice-wasm' });
+```
+
+Custom adapters can also be passed via `simulator` when they implement `simulate(input, options)`.
 
 ### Streaming
 
@@ -140,6 +171,7 @@ The resolver is platform-agnostic — use `fetch()` in the browser, `readFile()`
 | `maxIterations` | `100` | Max Newton-Raphson iterations (DC) |
 | `maxTransientIterations` | `50` | Max NR iterations per timestep |
 | `integrationMethod` | `'trapezoidal'` | `'euler'` or `'trapezoidal'` |
+| `simulator` | `'spice-ts'` | Built-in TypeScript solver, `'ngspice-wasm'`, or a custom simulator adapter |
 | `resolveInclude` | — | Async callback for `.include`/`.lib` |
 
 All public exports have TSDoc comments for IDE hover-docs.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,14 @@
   "files": [
     "dist"
   ],
+  "peerDependencies": {
+    "eecircuit-engine": "^1.7.0"
+  },
+  "peerDependenciesMeta": {
+    "eecircuit-engine": {
+      "optional": true
+    }
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/packages/core/src/analysis/ac.test.ts
+++ b/packages/core/src/analysis/ac.test.ts
@@ -50,4 +50,22 @@ describe('AC Small-Signal Analysis', () => {
     const f0 = 1 / (2 * Math.PI * Math.sqrt(10e-3 * 100e-9));
     expect(freqs[maxIdx]).toBeCloseTo(f0, -2);
   });
+
+  it('includes capacitor ESR and ESL in AC response', async () => {
+    const fLow = 1 / (2 * Math.PI * 1e3 * 1e-6);
+    const fRes = 1 / (2 * Math.PI * Math.sqrt(1e-6 * 1e-6));
+
+    const result = await simulate(`
+      V1 in 0 AC 1 0
+      C1 in 0 1u ESR=1 ESL=1u RLEAK=1e12
+      .ac lin 1 ${fLow} ${fRes}
+      .end
+    `);
+
+    expect(result.ac).toBeDefined();
+    const sourceCurrent = result.ac!.current('V1');
+
+    expect(sourceCurrent[0].magnitude).toBeCloseTo(1e-3, 2);
+    expect(sourceCurrent[1].magnitude).toBeCloseTo(1, 1);
+  });
 });

--- a/packages/core/src/circuit.test.ts
+++ b/packages/core/src/circuit.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { Circuit } from './circuit.js';
+import { Capacitor } from './devices/capacitor.js';
+import { Inductor } from './devices/inductor.js';
+import { Resistor } from './devices/resistor.js';
 
 describe('Circuit', () => {
   it('maps node names to indices, with ground at -1', () => {
@@ -50,6 +53,81 @@ describe('Circuit', () => {
     expect(compiled.branchCount).toBe(1);
     expect(compiled.nodeNames).toContain('1');
     expect(compiled.nodeNames).toContain('2');
+  });
+
+  it('resolves programmatic capacitor model cards', () => {
+    const ckt = new Circuit();
+    ckt.addModel({ name: 'CSTD', type: 'C', params: { CAP: 3e-9 } });
+    ckt.addCapacitor('C1', '1', '0', undefined, 'CSTD');
+    ckt.addAnalysis('op');
+
+    const compiled = ckt.compile();
+    const cap = compiled.devices.find(d => d.name === 'C1');
+    expect(cap).toBeInstanceOf(Capacitor);
+    expect((cap as Capacitor).capacitance).toBeCloseTo(3e-9);
+  });
+
+  it('resolves programmatic inductor model cards', () => {
+    const ckt = new Circuit();
+    ckt.addModel({ name: 'LSTD', type: 'L', params: { IND: 3e-9 } });
+    ckt.addInductor('L1', '1', '0', undefined, 'LSTD');
+    ckt.addAnalysis('op');
+
+    const compiled = ckt.compile();
+    const ind = compiled.devices.find(d => d.name === 'L1');
+    expect(ind).toBeInstanceOf(Inductor);
+    expect((ind as Inductor).inductance).toBeCloseTo(3e-9);
+  });
+
+  it('expands capacitor parasitics into an equivalent primitive network', () => {
+    const ckt = new Circuit();
+    ckt.addCapacitor('C1', 'in', '0', 1e-6, undefined, {
+      ESR: 0.25,
+      ESL: 10e-9,
+      RLEAK: 1e6,
+    });
+    ckt.addAnalysis('op');
+
+    const compiled = ckt.compile();
+    const names = compiled.devices.map(d => d.name);
+
+    expect(names).toContain('C1.RLEAK');
+    expect(names).toContain('C1.ESL');
+    expect(names).toContain('C1.ESR');
+    expect(names).toContain('C1');
+    expect(compiled.nodeNames).toContain('C1.esl');
+    expect(compiled.nodeNames).toContain('C1.esr');
+    expect(compiled.branchNames).toContain('C1.ESL');
+
+    expect(compiled.devices.find(d => d.name === 'C1.RLEAK')).toBeInstanceOf(Resistor);
+    expect(compiled.devices.find(d => d.name === 'C1.ESL')).toBeInstanceOf(Inductor);
+    expect(compiled.devices.find(d => d.name === 'C1.ESR')).toBeInstanceOf(Resistor);
+    expect(compiled.devices.find(d => d.name === 'C1')).toBeInstanceOf(Capacitor);
+  });
+
+  it('expands inductor parasitics into an equivalent primitive network', () => {
+    const ckt = new Circuit();
+    ckt.addInductor('L1', 'in', '0', 10e-6, undefined, {
+      RSER: 0.4,
+      RPAR: 2e3,
+      CPAR: 3e-12,
+    });
+    ckt.addAnalysis('op');
+
+    const compiled = ckt.compile();
+    const names = compiled.devices.map(d => d.name);
+
+    expect(names).toContain('L1.RPAR');
+    expect(names).toContain('L1.CPAR');
+    expect(names).toContain('L1.RSER');
+    expect(names).toContain('L1');
+    expect(compiled.nodeNames).toContain('L1.rser');
+    expect(compiled.branchNames).toContain('L1');
+
+    expect(compiled.devices.find(d => d.name === 'L1.RPAR')).toBeInstanceOf(Resistor);
+    expect(compiled.devices.find(d => d.name === 'L1.CPAR')).toBeInstanceOf(Capacitor);
+    expect(compiled.devices.find(d => d.name === 'L1.RSER')).toBeInstanceOf(Resistor);
+    expect(compiled.devices.find(d => d.name === 'L1')).toBeInstanceOf(Inductor);
   });
 
   it('provides node name to index mapping', () => {

--- a/packages/core/src/circuit.ts
+++ b/packages/core/src/circuit.ts
@@ -20,6 +20,15 @@ import { evaluateExpression } from './parser/expression.js';
 import { parseNumber, tokenizeNetlist } from './parser/tokenizer.js';
 import { parseModelCard } from './parser/model-parser.js';
 import { parseSourceWaveform, parseInstanceParams } from './parser/waveform-parser.js';
+import { parsePassiveElement } from './parser/passive-parser.js';
+import {
+  resolveCapacitance,
+  resolveCapacitorModel,
+  resolveInductance,
+  resolveInductorModel,
+  type ResolvedCapacitorModel,
+  type ResolvedInductorModel,
+} from './devices/passive-model.js';
 import { CycleError } from './errors.js';
 
 /**
@@ -60,6 +69,140 @@ interface DeviceDescriptor {
   modelName?: string;
   params?: Record<string, number>;
   controlSource?: string;
+}
+
+function formatNumber(value: number): string {
+  return Number.isFinite(value) ? value.toString() : String(value);
+}
+
+function formatParams(params?: Record<string, number>): string {
+  if (!params) return '';
+  return Object.entries(params)
+    .map(([key, value]) => `${key}=${formatNumber(value)}`)
+    .join(' ');
+}
+
+function formatModel(model: ModelParams): string {
+  const params = formatParams(model.params);
+  return params
+    ? `.model ${model.name} ${model.type} (${params})`
+    : `.model ${model.name} ${model.type}`;
+}
+
+function formatWaveform(wf?: Partial<SourceWaveform> & { dc?: number }): string {
+  if (!wf) return 'DC 0';
+  if (wf.dc !== undefined) return `DC ${formatNumber(wf.dc)}`;
+  if (!wf.type) return 'DC 0';
+
+  switch (wf.type) {
+    case 'dc':
+      return `DC ${formatNumber(wf.value ?? 0)}`;
+    case 'ac':
+      return `AC ${formatNumber(wf.magnitude ?? 1)} ${formatNumber(wf.phase ?? 0)}`;
+    case 'pulse':
+      return `PULSE(${[
+        wf.v1 ?? 0,
+        wf.v2 ?? 0,
+        wf.delay ?? 0,
+        wf.rise ?? 1e-12,
+        wf.fall ?? 1e-12,
+        wf.width ?? Infinity,
+        wf.period ?? Infinity,
+      ].map(formatNumber).join(' ')})`;
+    case 'sin':
+      return `SIN(${[
+        wf.offset ?? 0,
+        wf.amplitude ?? 0,
+        wf.frequency ?? 0,
+        wf.delay,
+        wf.damping,
+        wf.phase,
+      ].filter(v => v !== undefined).map(v => formatNumber(v as number)).join(' ')})`;
+    default:
+      return 'DC 0';
+  }
+}
+
+function formatDevice(desc: DeviceDescriptor): string {
+  const params = formatParams(desc.params);
+  const tail = params ? ` ${params}` : '';
+
+  switch (desc.type) {
+    case 'R':
+      return `${desc.name} ${desc.nodes[0]} ${desc.nodes[1]} ${formatNumber(desc.value ?? 0)}`;
+    case 'C':
+    case 'L': {
+      const value = desc.value !== undefined ? formatNumber(desc.value) : undefined;
+      const valueAndModel = [value, desc.modelName].filter(Boolean).join(' ');
+      return `${desc.name} ${desc.nodes[0]} ${desc.nodes[1]} ${valueAndModel || '0'}${tail}`;
+    }
+    case 'V':
+    case 'I':
+      return `${desc.name} ${desc.nodes[0]} ${desc.nodes[1]} ${formatWaveform(desc.waveform)}`;
+    case 'D':
+      return `${desc.name} ${desc.nodes[0]} ${desc.nodes[1]} ${desc.modelName ?? ''}`.trim();
+    case 'Q':
+      return `${desc.name} ${desc.nodes[0]} ${desc.nodes[1]} ${desc.nodes[2]} ${desc.modelName ?? ''}`.trim();
+    case 'M':
+      return `${desc.name} ${desc.nodes.join(' ')} ${desc.modelName ?? ''}${tail}`.trim();
+    case 'E':
+    case 'G':
+      return `${desc.name} ${desc.nodes.join(' ')} ${formatNumber(desc.value ?? 0)}`;
+    case 'F':
+    case 'H':
+      return `${desc.name} ${desc.nodes[0]} ${desc.nodes[1]} ${desc.controlSource ?? ''} ${formatNumber(desc.value ?? 0)}`.trim();
+    case 'X':
+      return `${desc.name} ${desc.nodes.join(' ')} ${desc.modelName ?? ''}${tail}`.trim();
+    default:
+      return `${desc.name} ${desc.nodes.join(' ')}`;
+  }
+}
+
+function formatAnalysis(analysis: AnalysisCommand): string {
+  switch (analysis.type) {
+    case 'op':
+      return '.op';
+    case 'dc':
+      return `.dc ${analysis.source} ${formatNumber(analysis.start)} ${formatNumber(analysis.stop)} ${formatNumber(analysis.step)}`;
+    case 'tran': {
+      const parts = ['.tran', formatNumber(analysis.timestep), formatNumber(analysis.stopTime)];
+      if (analysis.startTime !== undefined) parts.push(formatNumber(analysis.startTime));
+      if (analysis.maxTimestep !== undefined) parts.push(formatNumber(analysis.maxTimestep));
+      return parts.join(' ');
+    }
+    case 'ac':
+      return `.ac ${analysis.variation} ${analysis.points} ${formatNumber(analysis.startFreq)} ${formatNumber(analysis.stopFreq)}`;
+  }
+}
+
+function formatStep(step: StepAnalysis): string {
+  if (step.sweepMode === 'list') {
+    return `.step ${step.param} LIST ${(step.values ?? []).map(formatNumber).join(' ')}`;
+  }
+  if (step.sweepMode === 'lin') {
+    return `.step ${step.param} ${formatNumber(step.start ?? 0)} ${formatNumber(step.stop ?? 0)} ${formatNumber(step.increment ?? 0)}`;
+  }
+  return `.step ${step.sweepMode.toUpperCase()} ${step.param} ${formatNumber(step.start ?? 0)} ${formatNumber(step.stop ?? 0)} ${step.points ?? 0}`;
+}
+
+function isPositiveFinite(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function hasCapacitorParasitics(model: ResolvedCapacitorModel): boolean {
+  return isPositiveFinite(model.seriesResistance)
+    || isPositiveFinite(model.seriesInductance)
+    || isPositiveFinite(model.parallelResistance);
+}
+
+function hasInductorParasitics(model: ResolvedInductorModel): boolean {
+  return isPositiveFinite(model.seriesResistance)
+    || isPositiveFinite(model.parallelResistance)
+    || isPositiveFinite(model.parallelCapacitance);
+}
+
+function internalNodeName(deviceName: string, suffix: string): string {
+  return `${deviceName}.${suffix}`;
 }
 
 /**
@@ -128,12 +271,28 @@ export class Circuit {
    * @param name - Device name (e.g., `'C1'`)
    * @param nodePos - Positive terminal node
    * @param nodeNeg - Negative terminal node
-   * @param capacitance - Capacitance value in farads
+   * @param capacitance - Capacitance value in farads. Omit when using a `.model C` card value.
+   * @param modelName - Optional name of a `.model C` card
+   * @param instanceParams - Per-instance model parameters (e.g., `{ L: 10e-6, W: 1e-6, M: 2 }`)
    */
-  addCapacitor(name: string, nodePos: string, nodeNeg: string, capacitance: number): void {
+  addCapacitor(
+    name: string,
+    nodePos: string,
+    nodeNeg: string,
+    capacitance?: number,
+    modelName?: string,
+    instanceParams?: Record<string, number>,
+  ): void {
     this.nodeSet.add(nodePos);
     this.nodeSet.add(nodeNeg);
-    this.descriptors.push({ type: 'C', name, nodes: [nodePos, nodeNeg], value: capacitance });
+    this.descriptors.push({
+      type: 'C',
+      name,
+      nodes: [nodePos, nodeNeg],
+      value: capacitance,
+      modelName,
+      params: instanceParams,
+    });
   }
 
   /**
@@ -142,12 +301,28 @@ export class Circuit {
    * @param name - Device name (e.g., `'L1'`)
    * @param nodePos - Positive terminal node
    * @param nodeNeg - Negative terminal node
-   * @param inductance - Inductance value in henries
+   * @param inductance - Inductance value in henries. Omit when using a `.model L` card value.
+   * @param modelName - Optional name of a `.model L` card
+   * @param instanceParams - Per-instance model parameters (e.g., `{ NT: 10, SCALE: 2 }`)
    */
-  addInductor(name: string, nodePos: string, nodeNeg: string, inductance: number): void {
+  addInductor(
+    name: string,
+    nodePos: string,
+    nodeNeg: string,
+    inductance?: number,
+    modelName?: string,
+    instanceParams?: Record<string, number>,
+  ): void {
     this.nodeSet.add(nodePos);
     this.nodeSet.add(nodeNeg);
-    this.descriptors.push({ type: 'L', name, nodes: [nodePos, nodeNeg], value: inductance });
+    this.descriptors.push({
+      type: 'L',
+      name,
+      nodes: [nodePos, nodeNeg],
+      value: inductance,
+      modelName,
+      params: instanceParams,
+    });
   }
 
   /**
@@ -441,6 +616,43 @@ export class Circuit {
   }
 
   /**
+   * Serialize the programmatic circuit to a SPICE-like netlist.
+   *
+   * This is primarily used by external simulator backends that consume text
+   * netlists. Raw subcircuit bodies are preserved exactly as registered.
+   */
+  toNetlist(): string {
+    const lines: string[] = ['* spice-ts generated netlist'];
+
+    for (const model of this._models.values()) {
+      lines.push(formatModel(model));
+    }
+
+    for (const subckt of this._subcircuits.values()) {
+      const params = formatParams(subckt.params);
+      const header = `.subckt ${subckt.name} ${subckt.ports.join(' ')}${params ? ` ${params}` : ''}`;
+      lines.push(header.trim());
+      lines.push(...subckt.body);
+      lines.push(`.ends ${subckt.name}`);
+    }
+
+    for (const desc of this.descriptors) {
+      lines.push(formatDevice(desc));
+    }
+
+    for (const step of this._steps) {
+      lines.push(formatStep(step));
+    }
+
+    for (const analysis of this._analyses) {
+      lines.push(formatAnalysis(analysis));
+    }
+
+    lines.push('.end');
+    return lines.join('\n');
+  }
+
+  /**
    * Compile the circuit into a form ready for numerical simulation.
    *
    * Expands subcircuit instances, assigns node indices, instantiates device
@@ -452,7 +664,7 @@ export class Circuit {
    */
   compile(): CompiledCircuit {
     // Pre-expand subcircuit instances into flat device descriptors
-    const expandedDescriptors = this.expandAllSubcircuits();
+    const expandedDescriptors = this.expandPassiveParasitics(this.expandAllSubcircuits());
 
     // Collect all nodes from expanded descriptors
     for (const desc of expandedDescriptors) {
@@ -502,13 +714,24 @@ export class Circuit {
         case 'I':
           devices.push(new CurrentSource(desc.name, nodeIndices, resolveWaveform(desc.waveform)));
           break;
-        case 'C':
-          devices.push(new Capacitor(desc.name, nodeIndices, desc.value!));
+        case 'C': {
+          const model = desc.modelName ? this._models.get(desc.modelName) : undefined;
+          if (desc.modelName && !model) {
+            throw new Error(`Capacitor '${desc.name}' references unknown model '${desc.modelName}'`);
+          }
+          const { value } = resolveCapacitance(desc.value, model, desc.params);
+          devices.push(new Capacitor(desc.name, nodeIndices, value));
           break;
+        }
         case 'L': {
+          const model = desc.modelName ? this._models.get(desc.modelName) : undefined;
+          if (desc.modelName && !model) {
+            throw new Error(`Inductor '${desc.name}' references unknown model '${desc.modelName}'`);
+          }
+          const { value } = resolveInductance(desc.value, model, desc.params);
           const bi = branchIndex++;
           branchNames.push(desc.name);
-          devices.push(new Inductor(desc.name, nodeIndices, bi, desc.value!));
+          devices.push(new Inductor(desc.name, nodeIndices, bi, value));
           break;
         }
         case 'D': {
@@ -625,6 +848,140 @@ export class Circuit {
         result.push(desc);
       }
     }
+    return result;
+  }
+
+  private expandPassiveParasitics(descriptors: DeviceDescriptor[]): DeviceDescriptor[] {
+    const result: DeviceDescriptor[] = [];
+
+    for (const desc of descriptors) {
+      if (desc.type === 'C') {
+        const model = desc.modelName ? this._models.get(desc.modelName) : undefined;
+        if (desc.modelName && !model) {
+          throw new Error(`Capacitor '${desc.name}' references unknown model '${desc.modelName}'`);
+        }
+        const resolved = resolveCapacitorModel(desc.value, model, desc.params);
+        if (hasCapacitorParasitics(resolved)) {
+          result.push(...this.expandCapacitorDescriptor(desc, resolved));
+        } else {
+          result.push(desc);
+        }
+        continue;
+      }
+
+      if (desc.type === 'L') {
+        const model = desc.modelName ? this._models.get(desc.modelName) : undefined;
+        if (desc.modelName && !model) {
+          throw new Error(`Inductor '${desc.name}' references unknown model '${desc.modelName}'`);
+        }
+        const resolved = resolveInductorModel(desc.value, model, desc.params);
+        if (hasInductorParasitics(resolved)) {
+          result.push(...this.expandInductorDescriptor(desc, resolved));
+        } else {
+          result.push(desc);
+        }
+        continue;
+      }
+
+      result.push(desc);
+    }
+
+    return result;
+  }
+
+  private expandCapacitorDescriptor(
+    desc: DeviceDescriptor,
+    model: ResolvedCapacitorModel,
+  ): DeviceDescriptor[] {
+    const [p, n] = desc.nodes;
+    const result: DeviceDescriptor[] = [];
+
+    if (isPositiveFinite(model.parallelResistance)) {
+      result.push({
+        type: 'R',
+        name: `${desc.name}.RLEAK`,
+        nodes: [p, n],
+        value: model.parallelResistance,
+      });
+    }
+
+    let left = p;
+    if (isPositiveFinite(model.seriesInductance)) {
+      const right = internalNodeName(desc.name, 'esl');
+      result.push({
+        type: 'L',
+        name: `${desc.name}.ESL`,
+        nodes: [left, right],
+        value: model.seriesInductance,
+      });
+      left = right;
+    }
+
+    if (isPositiveFinite(model.seriesResistance)) {
+      const right = internalNodeName(desc.name, 'esr');
+      result.push({
+        type: 'R',
+        name: `${desc.name}.ESR`,
+        nodes: [left, right],
+        value: model.seriesResistance,
+      });
+      left = right;
+    }
+
+    result.push({
+      type: 'C',
+      name: desc.name,
+      nodes: [left, n],
+      value: model.capacitance,
+    });
+
+    return result;
+  }
+
+  private expandInductorDescriptor(
+    desc: DeviceDescriptor,
+    model: ResolvedInductorModel,
+  ): DeviceDescriptor[] {
+    const [p, n] = desc.nodes;
+    const result: DeviceDescriptor[] = [];
+
+    if (isPositiveFinite(model.parallelResistance)) {
+      result.push({
+        type: 'R',
+        name: `${desc.name}.RPAR`,
+        nodes: [p, n],
+        value: model.parallelResistance,
+      });
+    }
+
+    if (isPositiveFinite(model.parallelCapacitance)) {
+      result.push({
+        type: 'C',
+        name: `${desc.name}.CPAR`,
+        nodes: [p, n],
+        value: model.parallelCapacitance,
+      });
+    }
+
+    let left = p;
+    if (isPositiveFinite(model.seriesResistance)) {
+      const right = internalNodeName(desc.name, 'rser');
+      result.push({
+        type: 'R',
+        name: `${desc.name}.RSER`,
+        nodes: [left, right],
+        value: model.seriesResistance,
+      });
+      left = right;
+    }
+
+    result.push({
+      type: 'L',
+      name: desc.name,
+      nodes: [left, n],
+      value: model.inductance,
+    });
+
     return result;
   }
 
@@ -757,20 +1114,26 @@ export class Circuit {
           break;
         }
         case 'C': {
-          const valStr = evalToken(tokens[3]);
+          const evaluatedTokens = tokens.map(t => evalToken(t));
+          const parsed = parsePassiveElement(evaluatedTokens, 3, 'C');
           result.push({
             type: 'C', name: devName,
             nodes: [mapNode(tokens[1]), mapNode(tokens[2])],
-            value: parseNumber(valStr),
+            value: parsed.value,
+            modelName: parsed.modelName,
+            params: parsed.params,
           });
           break;
         }
         case 'L': {
-          const valStr = evalToken(tokens[3]);
+          const evaluatedTokens = tokens.map(t => evalToken(t));
+          const parsed = parsePassiveElement(evaluatedTokens, 3, 'L');
           result.push({
             type: 'L', name: devName,
             nodes: [mapNode(tokens[1]), mapNode(tokens[2])],
-            value: parseNumber(valStr),
+            value: parsed.value,
+            modelName: parsed.modelName,
+            params: parsed.params,
           });
           break;
         }

--- a/packages/core/src/devices/passive-model.test.ts
+++ b/packages/core/src/devices/passive-model.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCapacitorModel, resolveInductorModel } from './passive-model.js';
+
+describe('passive parasitic model resolution', () => {
+  it('resolves explicit capacitor ESR, ESL, and leakage aliases', () => {
+    const resolved = resolveCapacitorModel(1e-6, undefined, {
+      ESR: 0.2,
+      ESL: 10e-9,
+      RLEAK: 1e6,
+      M: 2,
+    });
+
+    expect(resolved.capacitance).toBeCloseTo(2e-6);
+    expect(resolved.seriesResistance).toBeCloseTo(0.1);
+    expect(resolved.seriesInductance).toBeCloseTo(5e-9);
+    expect(resolved.parallelResistance).toBeCloseTo(5e5);
+  });
+
+  it('derives capacitor ESR from dissipation factor or Q at a measurement frequency', () => {
+    const dfModel = resolveCapacitorModel(1e-6, undefined, {
+      DF: 0.1,
+      FREQ: 1e3,
+    });
+    expect(dfModel.seriesResistance).toBeCloseTo(0.1 / (2 * Math.PI * 1e3 * 1e-6));
+
+    const qModel = resolveCapacitorModel(1e-6, undefined, {
+      Q: 100,
+      FREQ: 1e3,
+    });
+    expect(qModel.seriesResistance).toBeCloseTo(1 / (2 * Math.PI * 1e3 * 1e-6 * 100));
+  });
+
+  it('resolves explicit and derived inductor parasitics', () => {
+    const explicit = resolveInductorModel(10e-6, undefined, {
+      RSER: 0.5,
+      RPAR: 2e3,
+      CPAR: 4e-12,
+      M: 2,
+    });
+
+    expect(explicit.inductance).toBeCloseTo(5e-6);
+    expect(explicit.seriesResistance).toBeCloseTo(0.25);
+    expect(explicit.parallelResistance).toBeCloseTo(1e3);
+    expect(explicit.parallelCapacitance).toBeCloseTo(8e-12);
+
+    const derived = resolveInductorModel(10e-6, undefined, {
+      Q: 50,
+      FREQ: 100e3,
+      SRF: 10e6,
+    });
+
+    expect(derived.seriesResistance).toBeCloseTo(2 * Math.PI * 100e3 * 10e-6 / 50);
+    expect(derived.parallelCapacitance).toBeCloseTo(
+      1 / ((2 * Math.PI * 10e6) ** 2 * 10e-6),
+    );
+  });
+});

--- a/packages/core/src/devices/passive-model.ts
+++ b/packages/core/src/devices/passive-model.ts
@@ -1,0 +1,287 @@
+import type { ModelParams } from '../types.js';
+
+const DEFAULT_TEMP_C = 27;
+const EPSILON_0 = 8.854214871e-12;
+const EPSILON_SIO2 = 3.4531479969e-11;
+const MU_0 = 1.25663706143592e-6;
+
+export interface ResolvedPassiveValue {
+  value: number;
+  params: Record<string, number>;
+}
+
+export interface ResolvedCapacitorModel extends ResolvedPassiveValue {
+  capacitance: number;
+  seriesResistance: number;
+  seriesInductance: number;
+  parallelResistance: number;
+}
+
+export interface ResolvedInductorModel extends ResolvedPassiveValue {
+  inductance: number;
+  seriesResistance: number;
+  parallelResistance: number;
+  parallelCapacitance: number;
+}
+
+function mergedParams(
+  model: ModelParams | undefined,
+  instanceParams: Record<string, number> | undefined,
+): Record<string, number> {
+  return { ...(model?.params ?? {}), ...(instanceParams ?? {}) };
+}
+
+function scale(params: Record<string, number>): number {
+  return params.SCALE ?? 1;
+}
+
+function multiplicity(params: Record<string, number>): number {
+  return params.M ?? 1;
+}
+
+function multiplicityDivisor(params: Record<string, number>): number {
+  const m = multiplicity(params);
+  return m === 0 ? 1 : m;
+}
+
+function parallelScale(params: Record<string, number>): number {
+  const value = scale(params) * multiplicity(params);
+  return value === 0 ? 1 : value;
+}
+
+function temperatureFactor(params: Record<string, number>): number {
+  const tnom = params.TNOM ?? DEFAULT_TEMP_C;
+  const temp = params.TEMP ?? (DEFAULT_TEMP_C + (params.DTEMP ?? 0));
+  const delta = temp - tnom;
+  const tc1 = params.TC1 ?? 0;
+  const tc2 = params.TC2 ?? 0;
+  return 1 + tc1 * delta + tc2 * delta * delta;
+}
+
+function modelTypeMatches(model: ModelParams | undefined, expected: string): boolean {
+  if (!model) return true;
+  return model.type.toUpperCase() === expected;
+}
+
+function finitePositive(value: number | undefined): value is number {
+  return value !== undefined && Number.isFinite(value) && value > 0;
+}
+
+function firstParam(params: Record<string, number>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = params[key];
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function scaledCapSeries(value: number | undefined, params: Record<string, number>): number {
+  if (!finitePositive(value)) return 0;
+  return value / parallelScale(params);
+}
+
+function scaledCapParallelResistance(value: number | undefined, params: Record<string, number>): number {
+  if (!finitePositive(value)) return Infinity;
+  return value / parallelScale(params);
+}
+
+function scaledInductorSeriesResistance(value: number | undefined, params: Record<string, number>): number {
+  if (!finitePositive(value)) return 0;
+  return value * scale(params) / multiplicityDivisor(params);
+}
+
+function scaledInductorParallelResistance(value: number | undefined, params: Record<string, number>): number {
+  if (!finitePositive(value)) return Infinity;
+  return value / multiplicityDivisor(params);
+}
+
+function scaledInductorParallelCapacitance(value: number | undefined, params: Record<string, number>): number {
+  if (!finitePositive(value)) return 0;
+  return value * scale(params) * multiplicityDivisor(params);
+}
+
+function conductanceToResistance(value: number | undefined): number | undefined {
+  return finitePositive(value) ? 1 / value : undefined;
+}
+
+function lossFrequency(params: Record<string, number>): number | undefined {
+  return firstParam(params, ['FREQ', 'F', 'QFREQ']);
+}
+
+function resolveCapacitorSeriesResistance(
+  capacitance: number,
+  params: Record<string, number>,
+): number {
+  const explicit = firstParam(params, ['ESR', 'RSER', 'RS']);
+  if (explicit !== undefined) return scaledCapSeries(explicit, params);
+
+  const freq = lossFrequency(params);
+  if (!finitePositive(freq) || !finitePositive(capacitance)) return 0;
+
+  const omega = 2 * Math.PI * freq;
+  const df = firstParam(params, ['DF', 'D', 'TAND', 'TANDELTA']);
+  if (finitePositive(df)) {
+    return df / (omega * capacitance);
+  }
+
+  const q = firstParam(params, ['Q']);
+  if (finitePositive(q)) {
+    return 1 / (omega * capacitance * q);
+  }
+
+  return 0;
+}
+
+function resolveInductorSeriesResistance(
+  inductance: number,
+  params: Record<string, number>,
+): number {
+  const explicit = firstParam(params, ['RSER', 'RS', 'R', 'DCR', 'RDC', 'ESR']);
+  if (explicit !== undefined) return scaledInductorSeriesResistance(explicit, params);
+
+  const freq = lossFrequency(params);
+  const q = firstParam(params, ['Q']);
+  if (!finitePositive(freq) || !finitePositive(q) || !finitePositive(inductance)) return 0;
+
+  return 2 * Math.PI * freq * inductance / q;
+}
+
+function resolveCapacitorParallelResistance(params: Record<string, number>): number {
+  const explicit = firstParam(params, ['RPAR', 'RP', 'RSHUNT', 'RLEAK', 'LEAKR', 'RLEAKAGE', 'LEAK']);
+  const fromConductance = conductanceToResistance(firstParam(params, ['GPAR', 'GLEAK']));
+  return scaledCapParallelResistance(explicit ?? fromConductance, params);
+}
+
+function resolveInductorParallelResistance(params: Record<string, number>): number {
+  const explicit = firstParam(params, ['RPAR', 'RP', 'RCORE', 'RLOSS']);
+  const fromConductance = conductanceToResistance(firstParam(params, ['GPAR', 'GCORE', 'GLOSS']));
+  return scaledInductorParallelResistance(explicit ?? fromConductance, params);
+}
+
+function resolveInductorParallelCapacitance(
+  inductance: number,
+  params: Record<string, number>,
+): number {
+  const explicit = firstParam(params, ['CPAR', 'CP', 'CAP', 'CSELF', 'CW', 'C']);
+  if (explicit !== undefined) return scaledInductorParallelCapacitance(explicit, params);
+
+  const srf = firstParam(params, ['SRF', 'FR', 'FSELF']);
+  if (!finitePositive(srf) || !finitePositive(inductance)) return 0;
+
+  const omega = 2 * Math.PI * srf;
+  return 1 / (omega * omega * inductance);
+}
+
+export function resolveCapacitorModel(
+  instanceValue: number | undefined,
+  model: ModelParams | undefined,
+  instanceParams?: Record<string, number>,
+): ResolvedCapacitorModel {
+  if (!modelTypeMatches(model, 'C')) {
+    throw new Error(`Model '${model!.name}' has type '${model!.type}', expected C for capacitor`);
+  }
+
+  const params = mergedParams(model, instanceParams);
+  const m = multiplicity(params);
+  const s = scale(params);
+
+  let cNom: number;
+  if (instanceValue !== undefined) {
+    cNom = instanceValue * s * m;
+  } else if (params.CAP !== undefined) {
+    cNom = params.CAP * s * m;
+  } else {
+    const length = params.L ?? params.DEFL ?? 0;
+    const width = params.W ?? params.DEFW ?? 1e-6;
+    const effectiveLength = length - (params.SHORT ?? 0);
+    const effectiveWidth = width - (params.NARROW ?? 0);
+    const thick = params.THICK ?? 0;
+    const cj = params.CJ ?? (thick !== 0
+      ? (params.DI !== undefined ? params.DI * EPSILON_0 : EPSILON_SIO2) / thick
+      : 0);
+    const cjsw = params.CJSW ?? 0;
+
+    cNom = (
+      cj * effectiveLength * effectiveWidth
+      + 2 * cjsw * (effectiveLength + effectiveWidth)
+    ) * s * m;
+  }
+
+  const capacitance = cNom * temperatureFactor(params);
+  return {
+    value: capacitance,
+    capacitance,
+    seriesResistance: resolveCapacitorSeriesResistance(capacitance, params),
+    seriesInductance: scaledCapSeries(firstParam(params, ['ESL', 'LSER', 'LS']), params),
+    parallelResistance: resolveCapacitorParallelResistance(params),
+    params,
+  };
+}
+
+export function resolveCapacitance(
+  instanceValue: number | undefined,
+  model: ModelParams | undefined,
+  instanceParams?: Record<string, number>,
+): ResolvedPassiveValue {
+  const resolved = resolveCapacitorModel(instanceValue, model, instanceParams);
+  return { value: resolved.capacitance, params: resolved.params };
+}
+
+export function resolveInductorModel(
+  instanceValue: number | undefined,
+  model: ModelParams | undefined,
+  instanceParams?: Record<string, number>,
+): ResolvedInductorModel {
+  if (!modelTypeMatches(model, 'L')) {
+    throw new Error(`Model '${model!.name}' has type '${model!.type}', expected L for inductor`);
+  }
+
+  const params = mergedParams(model, instanceParams);
+  const m = multiplicity(params);
+  const s = scale(params);
+  const divisor = multiplicityDivisor(params);
+
+  let lNom: number;
+  if (instanceValue !== undefined) {
+    lNom = instanceValue * s / divisor;
+  } else if (params.IND !== undefined) {
+    lNom = params.IND * s / divisor;
+  } else if (params.L !== undefined) {
+    lNom = params.L * s / divisor;
+  } else if (params.LENGTH !== undefined && params.LENGTH !== 0) {
+    const nt = params.NT ?? 0;
+    const mu = params.MU ?? 1;
+    if (params.DIA !== undefined) {
+      lNom = (
+        mu * MU_0 * nt * nt * Math.PI * params.DIA * params.DIA
+        / (4 * params.LENGTH)
+      ) * s / divisor;
+    } else {
+      lNom = (
+        mu * MU_0 * nt * nt * (params.CSECT ?? 0)
+        / params.LENGTH
+      ) * s / divisor;
+    }
+  } else {
+    lNom = 0;
+  }
+
+  const inductance = lNom * temperatureFactor(params);
+  return {
+    value: inductance,
+    inductance,
+    seriesResistance: resolveInductorSeriesResistance(inductance, params),
+    parallelResistance: resolveInductorParallelResistance(params),
+    parallelCapacitance: resolveInductorParallelCapacitance(inductance, params),
+    params,
+  };
+}
+
+export function resolveInductance(
+  instanceValue: number | undefined,
+  model: ModelParams | undefined,
+  instanceParams?: Record<string, number>,
+): ResolvedPassiveValue {
+  const resolved = resolveInductorModel(instanceValue, model, instanceParams);
+  return { value: resolved.inductance, params: resolved.params };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
-export { simulate, simulateStream, simulateStepStream } from './simulate.js';
+export { simulate, simulateStream, simulateStepStream, createSimulator } from './simulate.js';
 export { createTransientSim } from './analysis/transient-driver.js';
 export type { TransientSim, TransientSimOptions } from './analysis/transient-driver.js';
+export { WasmNgspiceSimulator } from './simulators/ngspice-wasm.js';
+export type { WasmNgspiceSimulatorOptions } from './simulators/ngspice-wasm.js';
 export { parse, parseAsync } from './parser/index.js';
 export { preprocess } from './parser/preprocessor.js';
 export { Circuit } from './circuit.js';
@@ -20,6 +22,9 @@ export type {
   StepAnalysis,
   StepSweepMode,
   StepStreamEvent,
+  SimulatorBackend,
+  SimulatorBackendName,
+  SimulatorAdapter,
 } from './types.js';
 export type { DeviceModel, StampContext } from './devices/device.js';
 export type { CircuitIR, IRComponent, IRPort, ComponentType } from './ir/types.js';

--- a/packages/core/src/ir/builder.ts
+++ b/packages/core/src/ir/builder.ts
@@ -1,6 +1,7 @@
 import type { CircuitIR, IRComponent, IRPort, ComponentType } from './types.js';
 import type { SourceWaveform, ModelParams } from '../types.js';
 import { GROUND_NODE } from '../types.js';
+import { resolveCapacitorModel, resolveInductorModel } from '../devices/passive-model.js';
 
 /**
  * Device descriptor — mirrors the private interface in circuit.ts.
@@ -159,9 +160,9 @@ function buildDisplayValue(
     case 'R':
       return formatSI(desc.value ?? 0);
     case 'C':
-      return formatSI(desc.value ?? 0, 'F');
+      return formatSI((componentParams.capacitance as number) ?? 0, 'F');
     case 'L':
-      return formatSI(desc.value ?? 0, 'H');
+      return formatSI((componentParams.inductance as number) ?? 0, 'H');
     case 'V':
     case 'I':
       return waveformDisplayValue(componentParams);
@@ -239,9 +240,41 @@ function buildParams(
     case 'R':
       return { resistance: desc.value ?? 0 };
     case 'C':
-      return { capacitance: desc.value ?? 0 };
+      {
+        const model = desc.modelName ? models.get(desc.modelName) : undefined;
+        const resolved = resolveCapacitorModel(desc.value, model, desc.params);
+        const result: Record<string, number | string | boolean> = {
+          capacitance: resolved.capacitance,
+        };
+        if (desc.modelName) result.modelName = desc.modelName;
+        if (resolved.seriesResistance > 0) result.seriesResistance = resolved.seriesResistance;
+        if (resolved.seriesInductance > 0) result.seriesInductance = resolved.seriesInductance;
+        if (Number.isFinite(resolved.parallelResistance)) result.parallelResistance = resolved.parallelResistance;
+        if (desc.params) {
+          for (const [k, v] of Object.entries(desc.params)) {
+            result[k] = v;
+          }
+        }
+        return result;
+      }
     case 'L':
-      return { inductance: desc.value ?? 0 };
+      {
+        const model = desc.modelName ? models.get(desc.modelName) : undefined;
+        const resolved = resolveInductorModel(desc.value, model, desc.params);
+        const result: Record<string, number | string | boolean> = {
+          inductance: resolved.inductance,
+        };
+        if (desc.modelName) result.modelName = desc.modelName;
+        if (resolved.seriesResistance > 0) result.seriesResistance = resolved.seriesResistance;
+        if (Number.isFinite(resolved.parallelResistance)) result.parallelResistance = resolved.parallelResistance;
+        if (resolved.parallelCapacitance > 0) result.parallelCapacitance = resolved.parallelCapacitance;
+        if (desc.params) {
+          for (const [k, v] of Object.entries(desc.params)) {
+            result[k] = v;
+          }
+        }
+        return result;
+      }
     case 'V':
     case 'I':
       return flattenWaveform(desc.waveform);

--- a/packages/core/src/ir/ir.test.ts
+++ b/packages/core/src/ir/ir.test.ts
@@ -349,6 +349,55 @@ describe('Circuit.toIR()', () => {
     expect(l1.displayValue).toBe('10mH');
   });
 
+  it('should resolve passive model values in IR params and display', () => {
+    const ckt = new Circuit();
+    ckt.addModel({ name: 'CSTD', type: 'C', params: { CAP: 3e-9 } });
+    ckt.addModel({ name: 'LSTD', type: 'L', params: { IND: 4e-6 } });
+    ckt.addCapacitor('C1', 'a', 'b', undefined, 'CSTD');
+    ckt.addInductor('L1', 'c', 'd', undefined, 'LSTD', { M: 2 });
+
+    const ir = ckt.toIR();
+
+    const c1 = ir.components.find(c => c.id === 'C1')!;
+    expect(c1.params.capacitance).toBeCloseTo(3e-9);
+    expect(c1.params.modelName).toBe('CSTD');
+    expect(c1.displayValue).toBe('3nF');
+
+    const l1 = ir.components.find(c => c.id === 'L1')!;
+    expect(l1.params.inductance).toBeCloseTo(2e-6);
+    expect(l1.params.modelName).toBe('LSTD');
+    expect(l1.params.M).toBe(2);
+    expect(l1.displayValue).toBe('2uH');
+  });
+
+  it('should include passive parasitic metadata in IR params', () => {
+    const ckt = new Circuit();
+    ckt.addCapacitor('C1', 'a', 'b', 1e-6, undefined, {
+      ESR: 0.2,
+      ESL: 10e-9,
+      RLEAK: 1e6,
+    });
+    ckt.addInductor('L1', 'c', 'd', 10e-6, undefined, {
+      RSER: 0.5,
+      RPAR: 2e3,
+      CPAR: 4e-12,
+    });
+
+    const ir = ckt.toIR();
+
+    const c1 = ir.components.find(c => c.id === 'C1')!;
+    expect(c1.params.capacitance).toBeCloseTo(1e-6);
+    expect(c1.params.seriesResistance).toBeCloseTo(0.2);
+    expect(c1.params.seriesInductance).toBeCloseTo(10e-9);
+    expect(c1.params.parallelResistance).toBeCloseTo(1e6);
+
+    const l1 = ir.components.find(c => c.id === 'L1')!;
+    expect(l1.params.inductance).toBeCloseTo(10e-6);
+    expect(l1.params.seriesResistance).toBeCloseTo(0.5);
+    expect(l1.params.parallelResistance).toBeCloseTo(2e3);
+    expect(l1.params.parallelCapacitance).toBeCloseTo(4e-12);
+  });
+
   it('should convert subcircuit instance to IR', () => {
     const ckt = new Circuit();
     ckt.addSubcircuitInstance('X1', ['in', 'out', '0'], 'OPAMP', { GAIN: 1e5 });

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -3,6 +3,7 @@ import { ParseError } from '../errors.js';
 import { tokenizeNetlist, parseNumber } from './tokenizer.js';
 import { parseModelCard } from './model-parser.js';
 import { parseSourceWaveform, parseInstanceParams } from './waveform-parser.js';
+import { parsePassiveElement } from './passive-parser.js';
 import { preprocess } from './preprocessor.js';
 import type { IncludeResolver } from '../types.js';
 
@@ -212,13 +213,13 @@ function parseDevice(circuit: Circuit, tokens: string[], lineNumber: number): vo
       break;
     }
     case 'C': {
-      const value = parseNumber(tokens[3]);
-      circuit.addCapacitor(name, tokens[1], tokens[2], value);
+      const parsed = parsePassiveElement(tokens, 3, 'C');
+      circuit.addCapacitor(name, tokens[1], tokens[2], parsed.value, parsed.modelName, parsed.params);
       break;
     }
     case 'L': {
-      const value = parseNumber(tokens[3]);
-      circuit.addInductor(name, tokens[1], tokens[2], value);
+      const parsed = parsePassiveElement(tokens, 3, 'L');
+      circuit.addInductor(name, tokens[1], tokens[2], parsed.value, parsed.modelName, parsed.params);
       break;
     }
     case 'V': {

--- a/packages/core/src/parser/parser.test.ts
+++ b/packages/core/src/parser/parser.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { parse, parseAsync } from './index.js';
+import { Capacitor } from '../devices/capacitor.js';
+import { Inductor } from '../devices/inductor.js';
 
 describe('SPICE netlist parser', () => {
   it('parses a simple voltage divider', () => {
@@ -113,6 +115,111 @@ describe('SPICE netlist parser', () => {
     const compiled = ckt.compile();
     expect(compiled.models.has('DMOD')).toBe(true);
     expect(compiled.models.get('DMOD')!.params.IS).toBeCloseTo(1e-14);
+  });
+
+  it('parses capacitor .model values and instance parameters', () => {
+    const ckt = parse(`
+      .model CSTD C(CAP=1n TC1=0.001 TC2=0.0001)
+      C1 1 0 CSTD M=2 SCALE=0.5 TEMP=37
+      .op
+      .end
+    `);
+    const compiled = ckt.compile();
+    const cap = compiled.devices.find(d => d.name === 'C1');
+
+    expect(cap).toBeInstanceOf(Capacitor);
+    expect((cap as Capacitor).capacitance).toBeCloseTo(1.02e-9);
+  });
+
+  it('parses semiconductor capacitor geometry from model and instance dimensions', () => {
+    const ckt = parse(`
+      .model CMOD C(CJ=5e-5 CJSW=2e-11 DEFW=2u)
+      C1 1 0 CMOD L=10u W=1u
+      .op
+      .end
+    `);
+    const compiled = ckt.compile();
+    const cap = compiled.devices.find(d => d.name === 'C1');
+
+    expect(cap).toBeInstanceOf(Capacitor);
+    expect((cap as Capacitor).capacitance).toBeCloseTo(9.4e-16);
+  });
+
+  it('parses capacitor values with separated physical units', () => {
+    const ckt = parse(`
+      C1 1 0 1 uF
+      .op
+      .end
+    `);
+    const compiled = ckt.compile();
+    const cap = compiled.devices.find(d => d.name === 'C1');
+
+    expect(cap).toBeInstanceOf(Capacitor);
+    expect((cap as Capacitor).capacitance).toBeCloseTo(1e-6);
+  });
+
+  it('parses capacitor parasitic model parameters', () => {
+    const ckt = parse(`
+      .model CLOSS C(CAP=1u ESR=250m ESL=10n RLEAK=1meg)
+      C1 1 0 CLOSS
+      .op
+      .end
+    `);
+    const compiled = ckt.compile();
+
+    expect(compiled.devices.map(d => d.name)).toEqual([
+      'C1.RLEAK',
+      'C1.ESL',
+      'C1.ESR',
+      'C1',
+    ]);
+    expect(compiled.branchNames).toEqual(['C1.ESL']);
+  });
+
+  it('parses inductor .model values and multiplicity', () => {
+    const ckt = parse(`
+      .model LSTD L(IND=10u TC1=0.001)
+      L1 1 0 LSTD M=2 SCALE=0.5 TEMP=37
+      .op
+      .end
+    `);
+    const compiled = ckt.compile();
+    const ind = compiled.devices.find(d => d.name === 'L1');
+
+    expect(ind).toBeInstanceOf(Inductor);
+    expect((ind as Inductor).inductance).toBeCloseTo(2.525e-6);
+  });
+
+  it('parses geometric inductor models', () => {
+    const ckt = parse(`
+      .model LGEOM L(LENGTH=10u CSECT=4p NT=20 MU=2)
+      L1 1 0 LGEOM
+      .op
+      .end
+    `);
+    const compiled = ckt.compile();
+    const ind = compiled.devices.find(d => d.name === 'L1');
+
+    expect(ind).toBeInstanceOf(Inductor);
+    expect((ind as Inductor).inductance).toBeCloseTo(4.021238596594944e-10);
+  });
+
+  it('parses inductor parasitic model parameters', () => {
+    const ckt = parse(`
+      .model LLOSS L(IND=10u RSER=400m RPAR=2k CPAR=3p)
+      L1 1 0 LLOSS
+      .op
+      .end
+    `);
+    const compiled = ckt.compile();
+
+    expect(compiled.devices.map(d => d.name)).toEqual([
+      'L1.RPAR',
+      'L1.CPAR',
+      'L1.RSER',
+      'L1',
+    ]);
+    expect(compiled.branchNames).toEqual(['L1']);
   });
 
   it('parses DC sweep', () => {

--- a/packages/core/src/parser/passive-parser.ts
+++ b/packages/core/src/parser/passive-parser.ts
@@ -1,0 +1,111 @@
+import { parseNumber } from './tokenizer.js';
+import { parseInstanceParams } from './waveform-parser.js';
+
+export interface ParsedPassiveElement {
+  value?: number;
+  modelName?: string;
+  params: Record<string, number>;
+}
+
+const PREFIX_FACTORS: Record<string, number> = {
+  T: 1e12, t: 1e12,
+  G: 1e9, g: 1e9,
+  K: 1e3, k: 1e3,
+  M: 1e6,
+  m: 1e-3,
+  U: 1e-6, u: 1e-6,
+  N: 1e-9, n: 1e-9,
+  P: 1e-12, p: 1e-12,
+  F: 1e-15, f: 1e-15,
+};
+
+function unitFactor(token: string, kind: 'C' | 'L'): number | undefined {
+  const expectedUnit = kind === 'C' ? 'F' : 'H';
+  const match = token.match(/^([TtGgKkMmUuNnPpFf]?)([FfHh])$/);
+  if (!match || match[2].toUpperCase() !== expectedUnit) return undefined;
+  const prefix = match[1];
+  return prefix ? PREFIX_FACTORS[prefix] : 1;
+}
+
+function parsePassiveNumber(token: string, kind: 'C' | 'L'): number | undefined {
+  try {
+    return parseNumber(token);
+  } catch {
+    // Accept engineering unit suffixes that include the physical unit, e.g. 1uF or 10nH.
+    const expectedUnit = kind === 'C' ? 'F' : 'H';
+    const match = token.match(/^([+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?)([TtGgKkMmUuNnPpFf]?)([FfHh])$/);
+    if (!match || match[5].toUpperCase() !== expectedUnit) return undefined;
+    const prefix = match[4];
+    const factor = prefix ? PREFIX_FACTORS[prefix] : 1;
+    return Number(match[1]) * factor;
+  }
+}
+
+function parsePassiveNumberWithUnit(
+  tokens: string[],
+  index: number,
+  kind: 'C' | 'L',
+): { value: number; consumed: number } | undefined {
+  const value = parsePassiveNumber(tokens[index], kind);
+  if (value === undefined) return undefined;
+
+  const separatedUnitFactor = tokens[index + 1] ? unitFactor(tokens[index + 1], kind) : undefined;
+  if (separatedUnitFactor !== undefined) {
+    return { value: value * separatedUnitFactor, consumed: 2 };
+  }
+
+  return { value, consumed: 1 };
+}
+
+function parsePassiveValueAssignment(token: string, kind: 'C' | 'L'): number | undefined {
+  const eqIdx = token.indexOf('=');
+  if (eqIdx <= 0) return undefined;
+
+  const key = token.slice(0, eqIdx).toUpperCase();
+  const valueToken = token.slice(eqIdx + 1);
+  const isValueKey = kind === 'C'
+    ? key === 'C' || key === 'CAP'
+    : key === 'L' || key === 'IND';
+  if (!isValueKey) return undefined;
+
+  return parsePassiveNumber(valueToken, kind);
+}
+
+export function parsePassiveElement(
+  tokens: string[],
+  startIdx: number,
+  kind: 'C' | 'L',
+): ParsedPassiveElement {
+  let idx = startIdx;
+  let value: number | undefined;
+  let modelName: string | undefined;
+
+  const first = tokens[idx];
+  if (first === undefined) {
+    return { params: {} };
+  }
+
+  const assignmentValue = parsePassiveValueAssignment(first, kind);
+  if (assignmentValue !== undefined) {
+    value = assignmentValue;
+    idx++;
+  } else {
+    const numeric = parsePassiveNumberWithUnit(tokens, idx, kind);
+    if (numeric) {
+      value = numeric.value;
+      idx += numeric.consumed;
+      if (tokens[idx] && !tokens[idx].includes('=')) {
+        modelName = tokens[idx++];
+      }
+    } else if (!first.includes('=')) {
+      modelName = first;
+      idx++;
+    }
+  }
+
+  return {
+    value,
+    modelName,
+    params: parseInstanceParams(tokens, idx),
+  };
+}

--- a/packages/core/src/results.ts
+++ b/packages/core/src/results.ts
@@ -86,6 +86,16 @@ export class TransientResult {
     if (i === undefined) throw new Error(`Unknown branch: ${source}`);
     return i;
   }
+
+  /** Copy of all node voltage waveforms as a Map. */
+  get voltages(): Map<string, number[]> {
+    return new Map(this.voltageArrays);
+  }
+
+  /** Copy of all branch current waveforms as a Map. */
+  get currents(): Map<string, number[]> {
+    return new Map(this.currentArrays);
+  }
 }
 
 /**
@@ -125,6 +135,16 @@ export class ACResult {
     const i = this.currentArrays.get(source);
     if (i === undefined) throw new Error(`Unknown branch: ${source}`);
     return i;
+  }
+
+  /** Copy of all node voltage phasors as a Map. */
+  get voltages(): Map<string, { magnitude: number; phase: number }[]> {
+    return new Map(this.voltageArrays);
+  }
+
+  /** Copy of all branch current phasors as a Map. */
+  get currents(): Map<string, { magnitude: number; phase: number }[]> {
+    return new Map(this.currentArrays);
   }
 }
 

--- a/packages/core/src/simulate.ts
+++ b/packages/core/src/simulate.ts
@@ -2,7 +2,7 @@ import { Circuit } from './circuit.js';
 import type { CompiledCircuit } from './circuit.js';
 import { parse, parseAsync } from './parser/index.js';
 import type { SimulationOptions, SimulationWarning, TransientStep, ACPoint } from './types.js';
-import type { TransientAnalysis, ACAnalysis, ResolvedOptions } from './types.js';
+import type { TransientAnalysis, ACAnalysis, ResolvedOptions, SimulatorAdapter, SimulatorBackend } from './types.js';
 import { resolveOptions } from './types.js';
 import { solveDCOperatingPoint } from './analysis/dc.js';
 import { solveTransient } from './analysis/transient.js';
@@ -10,12 +10,46 @@ import { solveAC } from './analysis/ac.js';
 import { solveDCSweep } from './analysis/dc-sweep.js';
 import { solveStep, generateStepValues } from './analysis/step.js';
 import type { StepStreamEvent, StepAnalysis } from './types.js';
-import type { SimulationResult } from './results.js';
+import type { SimulationResult, StepResult } from './results.js';
 import { InvalidCircuitError } from './errors.js';
 import { MNAAssembler } from './mna/assembler.js';
 import { toCsc } from './solver/csc-matrix.js';
 import { ComplexSparseSolver } from './solver/complex-sparse-solver.js';
 import { createDriverFromCompiled } from './analysis/transient-driver.js';
+import { WasmNgspiceSimulator } from './simulators/ngspice-wasm.js';
+
+class SpiceTsSimulator implements SimulatorAdapter {
+  readonly name = 'spice-ts';
+
+  async simulate(input: string | Circuit, options?: SimulationOptions): Promise<SimulationResult> {
+    return simulate(input, { ...options, simulator: 'spice-ts' });
+  }
+}
+
+export function createSimulator(simulator: SimulatorBackend = 'spice-ts'): SimulatorAdapter {
+  if (typeof simulator !== 'string') return simulator;
+
+  switch (simulator) {
+    case 'spice-ts':
+      return new SpiceTsSimulator();
+    case 'ngspice-wasm':
+      return new WasmNgspiceSimulator();
+    default:
+      throw new InvalidCircuitError(`Unknown simulator backend '${simulator}'`);
+  }
+}
+
+function withoutSimulator(options?: SimulationOptions): SimulationOptions | undefined {
+  if (!options) return undefined;
+  const { simulator: _simulator, ...rest } = options;
+  return rest;
+}
+
+function selectedExternalSimulator(options?: SimulationOptions): SimulatorAdapter | null {
+  const simulator = options?.simulator;
+  if (!simulator || simulator === 'spice-ts') return null;
+  return createSimulator(simulator);
+}
 
 /**
  * Run all analyses declared in a SPICE netlist or {@link Circuit} object.
@@ -44,6 +78,11 @@ export async function simulate(
   input: string | Circuit,
   options?: SimulationOptions,
 ): Promise<SimulationResult> {
+  const simulator = selectedExternalSimulator(options);
+  if (simulator) {
+    return simulator.simulate(input, withoutSimulator(options));
+  }
+
   let circuit: Circuit;
   if (typeof input === 'string') {
     if (options?.resolveInclude) {
@@ -128,6 +167,12 @@ export async function* simulateStream(
   input: string | Circuit,
   options?: SimulationOptions,
 ): AsyncIterableIterator<TransientStep | ACPoint> {
+  if (selectedExternalSimulator(options)) {
+    const result = await simulate(input, options);
+    yield* streamFromSimulationResult(result);
+    return;
+  }
+
   let circuit: Circuit;
   if (typeof input === 'string') {
     if (options?.resolveInclude) {
@@ -183,6 +228,19 @@ export async function* simulateStepStream(
   input: string | Circuit,
   options?: SimulationOptions,
 ): AsyncIterableIterator<StepStreamEvent> {
+  if (selectedExternalSimulator(options)) {
+    const result = await simulate(input, options);
+    if (result.steps) {
+      for (let stepIndex = 0; stepIndex < result.steps.length; stepIndex++) {
+        const step = result.steps[stepIndex];
+        yield* streamEventsFromStepResult(step, stepIndex, step.paramName, step.paramValue);
+      }
+    } else {
+      yield* streamEventsFromStepResult(result, 0, '', 0);
+    }
+    return;
+  }
+
   let circuit: Circuit;
   if (typeof input === 'string') {
     if (options?.resolveInclude) {
@@ -286,6 +344,63 @@ function validateCircuit(compiled: CompiledCircuit, warnings: SimulationWarning[
   if (compiled.analyses.length === 0) {
     throw new InvalidCircuitError('No analysis command specified');
   }
+}
+
+function* streamFromSimulationResult(result: SimulationResult): Generator<TransientStep | ACPoint> {
+  if (result.steps) {
+    for (const step of result.steps) {
+      yield* streamPointsFromStepResult(step);
+    }
+    return;
+  }
+  yield* streamPointsFromStepResult(result);
+}
+
+function* streamPointsFromStepResult(
+  result: StepResult | SimulationResult,
+): Generator<TransientStep | ACPoint> {
+  if (result.transient) {
+    const voltages = result.transient.voltages;
+    const currents = result.transient.currents;
+    for (let i = 0; i < result.transient.time.length; i++) {
+      yield {
+        time: result.transient.time[i],
+        voltages: mapAtIndex(voltages, i),
+        currents: mapAtIndex(currents, i),
+      };
+    }
+  }
+
+  if (result.ac) {
+    const voltages = result.ac.voltages;
+    const currents = result.ac.currents;
+    for (let i = 0; i < result.ac.frequencies.length; i++) {
+      yield {
+        frequency: result.ac.frequencies[i],
+        voltages: mapAtIndex(voltages, i),
+        currents: mapAtIndex(currents, i),
+      };
+    }
+  }
+}
+
+function* streamEventsFromStepResult(
+  result: StepResult | SimulationResult,
+  stepIndex: number,
+  paramName: string,
+  paramValue: number,
+): Generator<StepStreamEvent> {
+  for (const point of streamPointsFromStepResult(result)) {
+    yield { stepIndex, paramName, paramValue, point };
+  }
+}
+
+function mapAtIndex<T>(arrays: Map<string, T[]>, index: number): Map<string, T> {
+  const result = new Map<string, T>();
+  for (const [name, values] of arrays) {
+    result.set(name, values[index]);
+  }
+  return result;
 }
 
 function* streamTransient(
@@ -425,4 +540,3 @@ function generateStreamFreqs(analysis: ACAnalysis): number[] {
   }
   return frequencies;
 }
-

--- a/packages/core/src/simulators/ngspice-wasm.ts
+++ b/packages/core/src/simulators/ngspice-wasm.ts
@@ -1,0 +1,464 @@
+import { Circuit, type CompiledCircuit } from '../circuit.js';
+import { InvalidCircuitError } from '../errors.js';
+import { generateStepValues } from '../analysis/step.js';
+import { parse } from '../parser/index.js';
+import { preprocess } from '../parser/preprocessor.js';
+import { ACResult, DCResult, DCSweepResult, TransientResult, type SimulationResult, type StepResult } from '../results.js';
+import type {
+  AnalysisCommand,
+  DCSweepAnalysis,
+  SimulationOptions,
+  SimulationWarning,
+  SimulatorAdapter,
+  StepAnalysis,
+  TransientAnalysis,
+} from '../types.js';
+
+type NgspiceComplex = { real: number; img: number };
+type NgspiceData = {
+  name: string;
+  type: string;
+  values: number[] | NgspiceComplex[];
+};
+type NgspiceResult = {
+  numVariables: number;
+  numPoints: number;
+  dataType: 'real' | 'complex';
+  data: NgspiceData[];
+};
+type NgspiceSimulation = {
+  start(): Promise<void>;
+  setNetList(input: string): void;
+  runSim(): Promise<NgspiceResult>;
+  getError(): string[];
+};
+type NgspiceSimulationClass = new () => NgspiceSimulation;
+
+export interface WasmNgspiceSimulatorOptions {
+  /** Optional injected Simulation class, useful for tests or custom bundlers. */
+  Simulation?: NgspiceSimulationClass;
+}
+
+interface PreparedInput {
+  netlist: string;
+  compiled: CompiledCircuit;
+}
+
+interface VariableName {
+  kind: 'voltage' | 'current' | 'time' | 'frequency' | 'other';
+  name: string;
+}
+
+/**
+ * Optional ngspice WASM simulator backend powered by `eecircuit-engine`.
+ *
+ * The package is loaded lazily so the default TypeScript simulator remains
+ * dependency-light unless this backend is selected.
+ */
+export class WasmNgspiceSimulator implements SimulatorAdapter {
+  readonly name = 'ngspice-wasm';
+
+  constructor(private readonly options: WasmNgspiceSimulatorOptions = {}) {}
+
+  async simulate(
+    input: string | Circuit,
+    options?: SimulationOptions,
+  ): Promise<SimulationResult> {
+    const prepared = await prepareInput(input, options);
+
+    const warnings: SimulationWarning[] = [];
+    const result: SimulationResult = { warnings };
+    const baseNetlist = stripAnalysisCommands(prepared.netlist);
+
+    if (prepared.compiled.steps.length > 0) {
+      if (prepared.compiled.steps.length > 1) {
+        warnings.push({
+          type: 'unsupported',
+          message: 'Multiple .step directives found; only the first is used. Nested sweeps are not yet supported.',
+        });
+      }
+      result.steps = await this.runStepAnalyses(baseNetlist, prepared.compiled, prepared.compiled.steps[0], warnings);
+      return result;
+    }
+
+    Object.assign(result, await this.runAnalyses(baseNetlist, prepared.compiled, warnings));
+    return result;
+  }
+
+  private async runStepAnalyses(
+    baseNetlist: string,
+    compiled: CompiledCircuit,
+    step: StepAnalysis,
+    warnings: SimulationWarning[],
+  ): Promise<StepResult[]> {
+    const values = generateStepValues(step);
+    const device = compiled.devices.find(d => d.name === step.param);
+    if (!device) {
+      throw new InvalidCircuitError(`Step parameter device '${step.param}' not found`);
+    }
+    if (!device.setParameter || !device.getParameter) {
+      throw new InvalidCircuitError(`Device '${step.param}' does not support parametric sweep`);
+    }
+
+    const results: StepResult[] = [];
+    for (const value of values) {
+      const stepNetlist = setSteppedDeviceValue(baseNetlist, step.param, value);
+      results.push({
+        paramName: step.param,
+        paramValue: value,
+        ...(await this.runAnalyses(stepNetlist, compiled, warnings)),
+      });
+    }
+
+    return results;
+  }
+
+  private async runAnalyses(
+    baseNetlist: string,
+    compiled: CompiledCircuit,
+    warnings: SimulationWarning[],
+  ): Promise<Omit<SimulationResult, 'warnings' | 'steps'>> {
+    const result: Omit<SimulationResult, 'warnings' | 'steps'> = {};
+
+    for (const analysis of compiled.analyses) {
+      const raw = await this.runRaw(`${baseNetlist}\n${formatAnalysis(analysis)}\n.end`, warnings);
+      switch (analysis.type) {
+        case 'op':
+          result.dc = mapDCResult(raw, compiled);
+          break;
+        case 'dc':
+          result.dcSweep = mapDCSweepResult(raw, compiled, analysis);
+          break;
+        case 'tran':
+          result.transient = mapTransientResult(raw, compiled, analysis);
+          break;
+        case 'ac':
+          result.ac = mapACResult(raw, compiled);
+          break;
+      }
+    }
+
+    return result;
+  }
+
+  private async runRaw(netlist: string, warnings: SimulationWarning[]): Promise<NgspiceResult> {
+    const Sim = await this.loadSimulationClass();
+    const sim = new Sim();
+    await sim.start();
+    sim.setNetList(adaptNetlistForNgspice(netlist));
+    const raw = await sim.runSim();
+    const messages = sim.getError().filter(line => line.trim().length > 0);
+
+    for (const message of messages) {
+      warnings.push({ type: 'ngspice-wasm', message });
+    }
+
+    const fatal = messages.find(message => /^error:/i.test(message.trim()));
+    if (fatal) {
+      throw new InvalidCircuitError(`ngspice-wasm simulation failed: ${fatal}`);
+    }
+    if (raw.numVariables === 0 || raw.numPoints === 0) {
+      throw new InvalidCircuitError('ngspice-wasm simulation produced no data');
+    }
+
+    return raw;
+  }
+
+  private async loadSimulationClass(): Promise<NgspiceSimulationClass> {
+    if (this.options.Simulation) return this.options.Simulation;
+
+    try {
+      const mod = await import('eecircuit-engine');
+      return (mod as { Simulation: NgspiceSimulationClass }).Simulation;
+    } catch (err) {
+      throw new InvalidCircuitError(
+        `ngspice-wasm simulator requires optional package 'eecircuit-engine': ${(err as Error).message}`,
+      );
+    }
+  }
+}
+
+async function prepareInput(
+  input: string | Circuit,
+  options?: SimulationOptions,
+): Promise<PreparedInput> {
+  if (typeof input !== 'string') {
+    const compiled = input.compile();
+    return { netlist: input.toNetlist(), compiled };
+  }
+
+  const netlist = options?.resolveInclude
+    ? await preprocess(input, options.resolveInclude)
+    : input;
+  const circuit = parse(netlist);
+  return { netlist, compiled: circuit.compile() };
+}
+
+function stripAnalysisCommands(netlist: string): string {
+  const lines: string[] = [];
+  for (const line of netlist.split('\n')) {
+    const trimmed = line.trim();
+    const lower = trimmed.toLowerCase();
+    if (
+      lower === '.end'
+      || lower === '.op'
+      || lower.startsWith('.dc ')
+      || lower.startsWith('.tran ')
+      || lower.startsWith('.ac ')
+      || lower.startsWith('.step ')
+    ) {
+      continue;
+    }
+    lines.push(line);
+  }
+  return lines.join('\n').trim();
+}
+
+function setSteppedDeviceValue(netlist: string, deviceName: string, value: number): string {
+  let found = false;
+  const valueText = formatNumber(value);
+  const lines = netlist.split('\n').map(line => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('*') || trimmed.startsWith(';')) return line;
+
+    const tokens = trimmed.split(/\s+/);
+    if (tokens[0]?.toLowerCase() !== deviceName.toLowerCase()) return line;
+
+    found = true;
+    const type = tokens[0][0].toUpperCase();
+    switch (type) {
+      case 'R':
+        if (tokens.length < 4) {
+          throw new InvalidCircuitError(`Cannot step malformed resistor '${deviceName}'`);
+        }
+        tokens[3] = valueText;
+        break;
+      case 'C':
+      case 'L':
+        replacePassiveValue(tokens, type as 'C' | 'L', valueText);
+        break;
+      default:
+        throw new InvalidCircuitError(
+          `Device '${deviceName}' does not support parametric sweep with ngspice-wasm`,
+        );
+    }
+
+    const leading = line.match(/^\s*/)?.[0] ?? '';
+    return `${leading}${tokens.join(' ')}`;
+  });
+
+  if (!found) {
+    throw new InvalidCircuitError(`Step parameter device '${deviceName}' not found in netlist`);
+  }
+
+  return lines.join('\n');
+}
+
+function replacePassiveValue(tokens: string[], kind: 'C' | 'L', valueText: string): void {
+  const valueKeys = kind === 'C' ? ['C', 'CAP'] : ['L', 'IND'];
+  if (tokens.length <= 3) {
+    tokens.push(valueText);
+    return;
+  }
+
+  const candidate = tokens[3];
+  const eqIdx = candidate.indexOf('=');
+  if (eqIdx > 0) {
+    const key = candidate.slice(0, eqIdx).toUpperCase();
+    if (valueKeys.includes(key)) {
+      tokens[3] = `${candidate.slice(0, eqIdx + 1)}${valueText}`;
+    } else {
+      tokens.splice(3, 0, valueText);
+    }
+    return;
+  }
+
+  if (tokens[4] && isSeparatedPhysicalUnit(tokens[4], kind)) {
+    tokens.splice(3, 2, valueText);
+    return;
+  }
+
+  if (looksLikePassiveValue(candidate, kind)) {
+    tokens[3] = valueText;
+    return;
+  }
+
+  tokens.splice(3, 0, valueText);
+}
+
+function isSeparatedPhysicalUnit(token: string, kind: 'C' | 'L'): boolean {
+  const unit = kind === 'C' ? '[Ff]' : '[Hh]';
+  return new RegExp(`^[TtGgKkMmUuNnPpFf]?${unit}$`).test(token);
+}
+
+function looksLikePassiveValue(token: string, kind: 'C' | 'L'): boolean {
+  const unit = kind === 'C' ? '[Ff]' : '[Hh]';
+  const suffix = `[Mm][Ee][Gg]|[TtGgKkMmUuNnPpFf]|[TtGgKkMmUuNnPpFf]?${unit}`;
+  return new RegExp(`^[+-]?(?:\\d+\\.?\\d*|\\.\\d+)(?:[eE][+-]?\\d+)?(?:${suffix})?$`).test(token);
+}
+
+function formatNumber(value: number): string {
+  return Number.isFinite(value) ? value.toString() : String(value);
+}
+
+function adaptNetlistForNgspice(netlist: string): string {
+  const adapted: string[] = ['* spice-ts ngspice-wasm'];
+  for (const line of netlist.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.toLowerCase() === '.end') continue;
+
+    const mosfetMatch = line.match(/^(M\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(NMOD|PMOD|NMOS\S*|PMOS\S*)\s*(.*)$/i);
+    if (mosfetMatch) {
+      const [, name, drain, gate, source, model, rest] = mosfetMatch;
+      adapted.push(`${name} ${drain} ${gate} ${source} ${source} ${model}${rest ? ` ${rest}` : ''}`);
+      continue;
+    }
+
+    adapted.push(line.replace(/[^\x00-\x7F]/g, '-'));
+  }
+  adapted.push('.end');
+  return adapted.join('\n');
+}
+
+function formatAnalysis(analysis: AnalysisCommand): string {
+  switch (analysis.type) {
+    case 'op':
+      return '.op';
+    case 'dc':
+      return `.dc ${analysis.source} ${analysis.start} ${analysis.stop} ${analysis.step}`;
+    case 'tran': {
+      const parts = ['.tran', analysis.timestep.toString(), analysis.stopTime.toString()];
+      if (analysis.startTime !== undefined) parts.push(analysis.startTime.toString());
+      if (analysis.maxTimestep !== undefined) parts.push(analysis.maxTimestep.toString());
+      return parts.join(' ');
+    }
+    case 'ac':
+      return `.ac ${analysis.variation} ${analysis.points} ${analysis.startFreq} ${analysis.stopFreq}`;
+  }
+}
+
+function variableName(name: string): VariableName {
+  const lower = name.toLowerCase();
+  if (lower === 'time') return { kind: 'time', name: 'time' };
+  if (lower === 'frequency') return { kind: 'frequency', name: 'frequency' };
+
+  const voltage = name.match(/^v\((.+)\)$/i);
+  if (voltage) return { kind: 'voltage', name: voltage[1] };
+
+  const current = name.match(/^i\((.+)\)$/i);
+  if (current) return { kind: 'current', name: current[1] };
+
+  return { kind: 'other', name };
+}
+
+function canonical(name: string, candidates: string[]): string {
+  return candidates.find(candidate => candidate.toLowerCase() === name.toLowerCase()) ?? name;
+}
+
+function asRealArray(data: NgspiceData): number[] {
+  return data.values as number[];
+}
+
+function asComplexArray(data: NgspiceData): NgspiceComplex[] {
+  return data.values as NgspiceComplex[];
+}
+
+function mapDCResult(raw: NgspiceResult, compiled: CompiledCircuit): DCResult {
+  if (raw.dataType !== 'real') {
+    throw new InvalidCircuitError('ngspice-wasm .op produced non-real data');
+  }
+
+  const voltages = new Map<string, number>();
+  const currents = new Map<string, number>();
+  for (const data of raw.data) {
+    const parsed = variableName(data.name);
+    if (parsed.kind === 'voltage') {
+      voltages.set(canonical(parsed.name, compiled.nodeNames), asRealArray(data)[0]);
+    } else if (parsed.kind === 'current') {
+      currents.set(canonical(parsed.name, compiled.branchNames), asRealArray(data)[0]);
+    }
+  }
+  return new DCResult(voltages, currents);
+}
+
+function mapDCSweepResult(
+  raw: NgspiceResult,
+  compiled: CompiledCircuit,
+  _analysis: DCSweepAnalysis,
+): DCSweepResult {
+  if (raw.dataType !== 'real') {
+    throw new InvalidCircuitError('ngspice-wasm .dc produced non-real data');
+  }
+
+  const sweepValues = Float64Array.from(asRealArray(raw.data[0]));
+  const voltages = new Map<string, Float64Array>();
+  const currents = new Map<string, Float64Array>();
+
+  for (const data of raw.data.slice(1)) {
+    const parsed = variableName(data.name);
+    if (parsed.kind === 'voltage') {
+      voltages.set(canonical(parsed.name, compiled.nodeNames), Float64Array.from(asRealArray(data)));
+    } else if (parsed.kind === 'current') {
+      currents.set(canonical(parsed.name, compiled.branchNames), Float64Array.from(asRealArray(data)));
+    }
+  }
+
+  return new DCSweepResult(sweepValues, voltages, currents);
+}
+
+function mapTransientResult(
+  raw: NgspiceResult,
+  compiled: CompiledCircuit,
+  _analysis: TransientAnalysis,
+): TransientResult {
+  if (raw.dataType !== 'real') {
+    throw new InvalidCircuitError('ngspice-wasm .tran produced non-real data');
+  }
+
+  const timeVar = raw.data.find(data => variableName(data.name).kind === 'time');
+  if (!timeVar) throw new InvalidCircuitError('ngspice-wasm .tran result has no time vector');
+
+  const voltages = new Map<string, number[]>();
+  const currents = new Map<string, number[]>();
+  for (const data of raw.data) {
+    const parsed = variableName(data.name);
+    if (parsed.kind === 'voltage') {
+      voltages.set(canonical(parsed.name, compiled.nodeNames), [...asRealArray(data)]);
+    } else if (parsed.kind === 'current') {
+      currents.set(canonical(parsed.name, compiled.branchNames), [...asRealArray(data)]);
+    }
+  }
+
+  return new TransientResult([...asRealArray(timeVar)], voltages, currents);
+}
+
+function mapACResult(raw: NgspiceResult, compiled: CompiledCircuit): ACResult {
+  if (raw.dataType !== 'complex') {
+    throw new InvalidCircuitError('ngspice-wasm .ac produced non-complex data');
+  }
+
+  const freqVar = raw.data.find(data => variableName(data.name).kind === 'frequency');
+  if (!freqVar) throw new InvalidCircuitError('ngspice-wasm .ac result has no frequency vector');
+
+  const frequencies = asComplexArray(freqVar).map(value => value.real);
+  const voltages = new Map<string, { magnitude: number; phase: number }[]>();
+  const currents = new Map<string, { magnitude: number; phase: number }[]>();
+
+  for (const data of raw.data) {
+    const parsed = variableName(data.name);
+    if (parsed.kind !== 'voltage' && parsed.kind !== 'current') continue;
+
+    const mapped = asComplexArray(data).map(value => ({
+      magnitude: Math.hypot(value.real, value.img),
+      phase: Math.atan2(value.img, value.real) * 180 / Math.PI,
+    }));
+
+    if (parsed.kind === 'voltage') {
+      voltages.set(canonical(parsed.name, compiled.nodeNames), mapped);
+    } else {
+      currents.set(canonical(parsed.name, compiled.branchNames), mapped);
+    }
+  }
+
+  return new ACResult(frequencies, voltages, currents);
+}

--- a/packages/core/src/simulators/simulator-backends.test.ts
+++ b/packages/core/src/simulators/simulator-backends.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { Circuit } from '../circuit.js';
+import { DCResult } from '../results.js';
+import { createSimulator, simulate, simulateStepStream, simulateStream } from '../simulate.js';
+import type { SimulatorAdapter } from '../types.js';
+
+describe('swappable simulator backends', () => {
+  it('routes simulate() through a custom adapter', async () => {
+    const adapter: SimulatorAdapter = {
+      name: 'test-adapter',
+      async simulate() {
+        return {
+          dc: new DCResult(new Map([['out', 1.25]]), new Map()),
+          warnings: [{ type: 'test', message: 'adapter used' }],
+        };
+      },
+    };
+
+    const result = await simulate('V1 out 0 DC 1\n.op', { simulator: adapter });
+
+    expect(result.dc!.voltage('out')).toBe(1.25);
+    expect(result.warnings[0]).toEqual({ type: 'test', message: 'adapter used' });
+  });
+
+  it('keeps the TypeScript simulator as the default backend', async () => {
+    const simulator = createSimulator('spice-ts');
+    const result = await simulator.simulate(`
+      V1 1 0 DC 5
+      R1 1 2 1k
+      R2 2 0 2k
+      .op
+      .end
+    `);
+
+    expect(result.dc!.voltage('2')).toBeCloseTo(10 / 3, 6);
+  });
+
+  it('runs a DC operating point through ngspice WASM', async () => {
+    const result = await simulate(`
+      V1 1 0 DC 5
+      R1 1 2 1k
+      R2 2 0 2k
+      .op
+      .end
+    `, { simulator: 'ngspice-wasm' });
+
+    expect(result.dc!.voltage('1')).toBeCloseTo(5, 6);
+    expect(result.dc!.voltage('2')).toBeCloseTo(10 / 3, 6);
+    expect(result.dc!.current('V1')).toBeCloseTo(-1 / 600, 6);
+  });
+
+  it('runs a programmatic Circuit through ngspice WASM', async () => {
+    const ckt = new Circuit();
+    ckt.addVoltageSource('V1', 'in', '0', { dc: 3 });
+    ckt.addResistor('R1', 'in', 'out', 1000);
+    ckt.addResistor('R2', 'out', '0', 2000);
+    ckt.addAnalysis('op');
+
+    const result = await simulate(ckt, { simulator: 'ngspice-wasm' });
+
+    expect(result.dc!.voltage('out')).toBeCloseTo(2, 6);
+  });
+
+  it('preprocesses includes before running ngspice WASM', async () => {
+    const result = await simulate(`
+      .include 'divider.inc'
+      V1 1 0 DC 6
+      .op
+      .end
+    `, {
+      simulator: 'ngspice-wasm',
+      resolveInclude: async (path) => {
+        expect(path).toBe('divider.inc');
+        return 'R1 1 2 1k\nR2 2 0 2k';
+      },
+    });
+
+    expect(result.dc!.voltage('2')).toBeCloseTo(4, 6);
+  });
+
+  it('maps ngspice WASM DC sweep, transient, and AC result shapes', async () => {
+    const dc = await simulate(`
+      V1 in 0 DC 0
+      R1 in 0 1k
+      .dc V1 0 2 1
+      .end
+    `, { simulator: 'ngspice-wasm' });
+
+    expect([...dc.dcSweep!.sweepValues]).toEqual([0, 1, 2]);
+    expect([...dc.dcSweep!.voltage('in')]).toEqual([0, 1, 2]);
+
+    const tran = await simulate(`
+      V1 in 0 PULSE(0 5 0 1n 1n 5u 10u)
+      R1 in out 1k
+      C1 out 0 1u
+      .tran 1u 2u
+      .end
+    `, { simulator: 'ngspice-wasm' });
+
+    expect(tran.transient!.time.length).toBeGreaterThan(2);
+    expect(tran.transient!.voltage('out').length).toBe(tran.transient!.time.length);
+
+    const ac = await simulate(`
+      V1 in 0 AC 1
+      R1 in out 1k
+      C1 out 0 1u
+      .ac dec 2 1 100
+      .end
+    `, { simulator: 'ngspice-wasm' });
+
+    expect(ac.ac!.frequencies).toHaveLength(5);
+    expect(ac.ac!.voltage('in')[0].magnitude).toBeCloseTo(1, 6);
+  });
+
+  it('streams result points from external backends', async () => {
+    const points = [];
+    for await (const point of simulateStream(`
+      V1 in 0 PULSE(0 1 0 1n 1n 5u 10u)
+      R1 in out 1k
+      C1 out 0 1u
+      .tran 1u 1u
+      .end
+    `, { simulator: 'ngspice-wasm' })) {
+      points.push(point);
+    }
+
+    expect(points.length).toBeGreaterThan(1);
+    expect('time' in points[0]).toBe(true);
+  });
+
+  it('maps ngspice WASM .step result sets', async () => {
+    const result = await simulate(`
+      V1 1 0 DC 10
+      R1 1 2 1k
+      R2 2 0 1k
+      .op
+      .step param R2 list 1k 4k
+      .end
+    `, { simulator: 'ngspice-wasm' });
+
+    expect(result.steps).toHaveLength(2);
+    expect(result.dc).toBeUndefined();
+    expect(result.steps![0].paramName).toBe('R2');
+    expect(result.steps![0].paramValue).toBeCloseTo(1000);
+    expect(result.steps![0].dc!.voltage('2')).toBeCloseTo(5, 6);
+    expect(result.steps![1].paramValue).toBeCloseTo(4000);
+    expect(result.steps![1].dc!.voltage('2')).toBeCloseTo(8, 6);
+  });
+
+  it('streams ngspice WASM .step points with metadata', async () => {
+    const events = [];
+    for await (const event of simulateStepStream(`
+      V1 in 0 AC 1
+      R1 in out 1k
+      C1 out 0 1u
+      .ac lin 1 1 2
+      .step param R1 list 1k 2k
+      .end
+    `, { simulator: 'ngspice-wasm' })) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(2);
+    expect(events[0].stepIndex).toBe(0);
+    expect(events[0].paramName).toBe('R1');
+    expect(events[0].paramValue).toBeCloseTo(1000);
+    expect('frequency' in events[0].point).toBe(true);
+    expect(events[1].stepIndex).toBe(1);
+    expect(events[1].paramValue).toBeCloseTo(2000);
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,7 +83,30 @@ export interface SimulationOptions {
   gmin?: number;
   /** Resolver for .include and .lib file directives */
   resolveInclude?: IncludeResolver;
+  /**
+   * Simulation backend to use. Defaults to `'spice-ts'`, the TypeScript-native
+   * solver. Use `'ngspice-wasm'` to run through the optional ngspice WASM
+   * adapter, or pass a custom simulator adapter.
+   */
+  simulator?: SimulatorBackend;
 }
+
+/** Built-in simulator backend names. */
+export type SimulatorBackendName = 'spice-ts' | 'ngspice-wasm';
+
+/** Pluggable simulator adapter compatible with {@link simulate}. */
+export interface SimulatorAdapter {
+  /** Human-readable backend name for diagnostics. */
+  readonly name?: string;
+  /** Run a simulation and return the standard spice-ts result shape. */
+  simulate(
+    input: string | import('./circuit.js').Circuit,
+    options?: SimulationOptions,
+  ): Promise<import('./results.js').SimulationResult>;
+}
+
+/** Simulation backend selector accepted by {@link SimulationOptions}. */
+export type SimulatorBackend = SimulatorBackendName | SimulatorAdapter;
 
 /** Resolved options with all defaults filled in */
 export interface ResolvedOptions {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
+  external: ['eecircuit-engine'],
   dts: {
     compilerOptions: {
       composite: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,10 @@ importers:
         version: 8.0.8(@types/node@25.5.2)(esbuild@0.27.7)(tsx@4.21.0)
 
   packages/core:
+    dependencies:
+      eecircuit-engine:
+        specifier: ^1.7.0
+        version: 1.7.0
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.4


### PR DESCRIPTION
## Summary

Adds a swappable core simulator backend API with an optional ngspice WASM adapter powered by `eecircuit-engine`.

Also completes passive capacitor and inductor modeling by resolving model/instance parameters and expanding parasitic equivalent networks for AC/transient analysis.

## What changed

- Added `SimulationOptions.simulator`, simulator adapter types, and `createSimulator()` routing.
- Added `WasmNgspiceSimulator` with lazy `eecircuit-engine` import, programmatic `Circuit` serialization, include preprocessing, `.op/.dc/.tran/.ac/.step` result mapping, and stream expansion support.
- Added optional peer dependency metadata and tsup external config for `eecircuit-engine`.
- Added capacitor/inductor model parsing and resolution for model cards, geometry/temperature values, ESR/ESL/leakage, DCR/core loss, winding capacitance, Q/DF/SRF derived parameters.
- Expanded passive parasitic models into primitive R/C/L networks during compile while exposing resolved metadata through IR.
- Updated README docs and focused tests.

## Validation

- `pnpm --dir packages/core exec vitest run src/simulators/simulator-backends.test.ts` — 9 passed
- `pnpm --dir packages/core run lint`
- `pnpm --dir packages/core test` — 427 passed, 1 skipped
- `pnpm --dir packages/core run build`
- `git diff --check`

## Notes

Unrelated untracked local files were intentionally not included: `output.gif`, `packages/ui/.codex/`.